### PR TITLE
Add `db` alias for `database`

### DIFF
--- a/pkg/cmd/database/database.go
+++ b/pkg/cmd/database/database.go
@@ -8,9 +8,10 @@ import (
 // DatabaseCmd encapsulates the commands for creating a database
 func DatabaseCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "database <command>",
-		Short: "Create, read, destroy, and update databases",
-		Long:  "TODO",
+		Use:     "database <command>",
+		Short:   "Create, read, destroy, and update databases",
+		Aliases: []string{"db"},
+		Long:    "TODO",
 	}
 
 	// TODO(iheanyi): Add `api-url` and `access-token` persistent flags here.


### PR DESCRIPTION
This pull request adds an alias so we can do things like `psctl db list` and not have to type out `database`. Shout out to @PixelJanitor for the idea. 