### PR TITLE
Fix client ID that's being passed in to be the configurable one

### DIFF
--- a/pkg/cmd/auth/login.go
+++ b/pkg/cmd/auth/login.go
@@ -66,7 +66,7 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 
 			s.Start()
 			defer s.Stop()
-			accessToken, err := authenticator.GetAccessTokenForDevice(ctx, deviceVerification, auth.DefaultOAuthClientID)
+			accessToken, err := authenticator.GetAccessTokenForDevice(ctx, deviceVerification, clientID)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes a bug that wasn't using a configured client ID when authorizing a device and polling for the token.