### PR TITLE
Use label for name after successful database creation

### DIFF
--- a/pkg/cmd/database/create.go
+++ b/pkg/cmd/database/create.go
@@ -28,7 +28,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Successfully created database: %s\n", database.Name)
+			fmt.Printf("Successfully created database: %s\n", database.Label)
 
 			return nil
 		},

--- a/psapi/databases.go
+++ b/psapi/databases.go
@@ -27,7 +27,6 @@ type DatabasesService interface {
 type Database struct {
 	ID          int64  `json:"id,omitempty" header:"id"`
 	Label       string `json:"label" header:"label"`
-	Name        string `json:"name" header:"name"`
 	Slug        string `json:"slug" header:"slug"`
 	Description string `json:"description" header:"description"`
 }


### PR DESCRIPTION
This pull request removes the name from the database model in the CLI and also uses the `label` for the name after a successful creation.