### PR TITLE
Use api.planetscaledb.io as the base URL for the API

### DIFF
--- a/psapi/client.go
+++ b/psapi/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultBaseURL = "https://ps-api-bb-rails-prod.herokuapp.com/"
+	DefaultBaseURL = "https://api.planetscaledb.io/"
 	jsonMediaType  = "application/json"
 )
 


### PR DESCRIPTION
This changes the base API url to be the proper api.planetscaledb.io URL rather than the Heroku one.