### PR TITLE
cmd/database: add short usage msg's and improve error for delete

### DIFF
--- a/pkg/cmd/database/create.go
+++ b/pkg/cmd/database/create.go
@@ -17,7 +17,8 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 		Database: new(psapi.Database),
 	}
 	cmd := &cobra.Command{
-		Use: "create",
+		Use:   "create",
+		Short: "Create a database instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			web, err := cmd.Flags().GetBool("web")

--- a/pkg/cmd/database/delete.go
+++ b/pkg/cmd/database/delete.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -15,12 +16,15 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete <database_id>",
 		Short: "Delete a database instance",
-		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
+			}
+
+			if len(args) == 0 {
+				return errors.New("<database_id> is missing")
 			}
 
 			id, err := strconv.Atoi(args[0])

--- a/pkg/cmd/database/list.go
+++ b/pkg/cmd/database/list.go
@@ -15,7 +15,8 @@ import (
 // ListCmd is the command for listing all databases for an authenticated user.
 func ListCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "list",
+		Use:   "list",
+		Short: "List databases",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			web, err := cmd.Flags().GetBool("web")


### PR DESCRIPTION
* Add the missing `short` descriptions for some commands
* Remove `cobra.ExactArgs` for a better error message

Before:

```
$ psctl db delete
Error: accepts 1 arg(s), received 0
exit status 1
```

After:

```
$ psctl db delete
Error: <database_id> is missing
exit status 1
```