### PR TITLE
client: dump API error if API returns a different JSON blob

### DIFF
--- a/psapi/client.go
+++ b/psapi/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -100,10 +101,25 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 	defer res.Body.Close()
 
 	if res.StatusCode >= 400 {
-		errorRes := &ErrorResponse{}
-		err = json.NewDecoder(res.Body).Decode(errorRes)
+		out, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return nil, err
+		}
+
+		errorRes := &ErrorResponse{}
+		err = json.Unmarshal(out, errorRes)
+		if err != nil {
+			return nil, err
+		}
+
+		// json.Unmarshal doesn't return an error if the response
+		// body has a different protocol then "ErrorResponse". We
+		// check here to make sure that errorRes is populated. If
+		// not, we return the full response back to the user, so
+		// they can debug the issue.
+		// TODO(arslan): fix the behavior on the API side
+		if *errorRes == (ErrorResponse{}) {
+			return nil, errors.New(string(out))
 		}
 
 		return nil, errorRes


### PR DESCRIPTION
Previously we would silently drop any API error if it wouldn't match our
`ErrorResponse` type. To prevent that, we're now reading the body first
and then printing the whole error to the user. This makes it easier to
debug and see what the problem is:

Before:

```
$ psctl db list
Error: error listing databases:
exit status 1
```

After:

```
$ psctl db list
Error: error listing databases: {"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
exit status 1
```