### PR TITLE
ci: improve Go test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,16 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.15
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test ./...
 
   lint:
     name: lint


### PR DESCRIPTION
The following improvements have been made:

* Updated the Go version from 1.13 to 1.15. This is done for two reasons. First, we should always aim to use the latest version, this is a common theme in Go projects, and each version provides more performance or overall UX improvements we need. Second, starting with Go 1.14, the `go` command line CLI now automatically detects the `vendor/` folder and uses that during `go build` and `go test`. This is needed, so the CI detects any inconsistencies during a pull request and that the source code is 100% buildable.

* I removed the `Get dependencies` part because we're vendoring the source code, and `go get` makes a network call to fetch dependencies.  We don't need to fetch the dependencies again because our "source of truth" is the `vendor/` folder. This particular step also breaks our CI if we start using private dependencies (i.e., https://github.com/planetscale/cli/pull/27). We could configure our CI to make `go get` work easily, but I think we don't need it for now due to the usage of the `vendor/` folder. (nit: we might need a private key in the future to verify the vendor folder + go.mod changes, but the ability to verify it is not yet implemented by the Go team https://github.com/golang/go/issues/27348) 

* I removed the `-v` flag from `go test -v`. The main reason is that `-v` outputs too much information. It's not needed. The best outcome is to output only the issues we see. The benefit is, it's easier to parse the CI output for humans, and we don't have to scroll hundreds of lines.

Before:

```
go test -v ./...
=== RUN   TestVerifyDevice
=== RUN   TestVerifyDevice/returns_device_verification_when_authentication_is_successful
=== RUN   TestVerifyDevice/returns_device_verification_with_check_interval_of_5_seconds_when_interval_is_0
--- PASS: TestVerifyDevice (0.00s)
    --- PASS: TestVerifyDevice/returns_device_verification_when_authentication_is_successful (0.00s)
    --- PASS: TestVerifyDevice/returns_device_verification_with_check_interval_of_5_seconds_when_interval_is_0 (0.00s)
PASS
ok      github.com/planetscale/cli/auth (cached)
?       github.com/planetscale/cli/cmd/psctl    [no test files]
?       github.com/planetscale/cli/cmdutil      [no test files]
?       github.com/planetscale/cli/config       [no test files]
?       github.com/planetscale/cli/pkg/cmd      [no test files]
?       github.com/planetscale/cli/pkg/cmd/auth [no test files]
?       github.com/planetscale/cli/pkg/cmd/database     [no test files]
=== RUN   TestDo
=== RUN   TestDo/returns_an_HTTP_response_and_no_error_for_2xx_responses
=== RUN   TestDo/returns_ErrorResponse_for_4xx_errors
=== RUN   TestDo/returns_an_HTTP_response_200_when_posting_a_request
--- PASS: TestDo (0.00s)
    --- PASS: TestDo/returns_an_HTTP_response_and_no_error_for_2xx_responses (0.00s)
    --- PASS: TestDo/returns_ErrorResponse_for_4xx_errors (0.00s)
    --- PASS: TestDo/returns_an_HTTP_response_200_when_posting_a_request (0.00s)
PASS
ok      github.com/planetscale/cli/psapi        (cached)
?       github.com/planetscale/cli/testutil     [no test files]
```

After:

```
go test ./...
ok      github.com/planetscale/cli/auth (cached)
?       github.com/planetscale/cli/cmd/psctl    [no test files]
?       github.com/planetscale/cli/cmdutil      [no test files]
?       github.com/planetscale/cli/config       [no test files]
?       github.com/planetscale/cli/pkg/cmd      [no test files]
?       github.com/planetscale/cli/pkg/cmd/auth [no test files]
?       github.com/planetscale/cli/pkg/cmd/database     [no test files]
ok      github.com/planetscale/cli/psapi        (cached)
?       github.com/planetscale/cli/testutil     [no test files]
```