### PR TITLE
Add ls alias to list databases.

### DIFF
--- a/pkg/cmd/database/list.go
+++ b/pkg/cmd/database/list.go
@@ -15,8 +15,9 @@ import (
 // ListCmd is the command for listing all databases for an authenticated user.
 func ListCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List databases",
+		Use:     "list",
+		Short:   "List databases",
+		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			web, err := cmd.Flags().GetBool("web")


### PR DESCRIPTION
Quick pull request to add an `ls` alias for listing databases