### PR TITLE
Update CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-@iheanyi
-@planetscale-big-bang
+*     @planetscale/big-bang


### PR DESCRIPTION
This updates the CODEOWNERS to point to the Big Bang team and not a single individual.