### PR TITLE
Humanize timestamps in output 

### DIFF
--- a/printer/database.go
+++ b/printer/database.go
@@ -7,10 +7,10 @@ import (
 )
 
 type Database struct {
-	Name      string     `header:"name"`
-	Notes     string     `header:"notes"`
-	CreatedAt *time.Time `header:"created_at,timestamp"`
-	UpdatedAt *time.Time `header:"updated_at,timestamp"`
+	Name      string `header:"name"`
+	Notes     string `header:"notes"`
+	CreatedAt int64  `header:"created_at,timestamp(ms|utc|human)"`
+	UpdatedAt int64  `header:"updated_at,timestamp(ms|utc|human)"`
 }
 
 // DatabasePrinter returns a struct that prints out the various fields of a
@@ -19,7 +19,7 @@ func NewDatabasePrinter(db *planetscale.Database) *Database {
 	return &Database{
 		Name:      db.Name,
 		Notes:     db.Notes,
-		CreatedAt: &db.CreatedAt,
-		UpdatedAt: &db.UpdatedAt,
+		CreatedAt: db.CreatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
+		UpdatedAt: db.UpdatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
 	}
 }


### PR DESCRIPTION
This pull request humanizes the timestamps within the output.

### Before

```
  NAME              NOTES       CREATED AT                          UPDATED AT                         
 ----------------- ----------- ----------------------------------- ----------------------------------- 
  iheanyi-test-db   something   2021-01-13 22:05:24.396 +0000 UTC   2021-01-13 22:05:24.396 +0000 UTC  
```

### After

```
  NAME              NOTES       CREATED AT     UPDATED AT    
 ----------------- ----------- -------------- -------------- 
  iheanyi-test-db   something   19 hours ago   19 hours ago  

```