### PR TITLE
Fix web flags for database commands, add web flags for branch commands

### DIFF
--- a/cmdutil/browser.go
+++ b/cmdutil/browser.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cli/safeexec"
 )
 
+const ApplicationURL = "https://app.planetscaledb.io"
+
 // OpenBrowser opens a web browser at the specified url.
 func OpenBrowser(goos, url string) *exec.Cmd {
 	exe := "open"

--- a/pkg/cmd/branch/branch.go
+++ b/pkg/cmd/branch/branch.go
@@ -3,7 +3,10 @@ package branch
 import (
 	"context"
 	"fmt"
+	"net/url"
 
+	"github.com/pkg/browser"
+	"github.com/planetscale/cli/cmdutil"
 	"github.com/planetscale/cli/config"
 	ps "github.com/planetscale/planetscale-go"
 	"github.com/spf13/cobra"
@@ -37,6 +40,20 @@ func BranchCmd(cfg *config.Config) *cobra.Command {
 
 			createReq.Branch.Name = branch
 
+			web, err := cmd.Flags().GetBool("web")
+			if err != nil {
+				return err
+			}
+
+			if web {
+				fmt.Println("🌐  Redirecting you to branch a database in your web browser.")
+				err := browser.OpenURL(fmt.Sprintf("%s/%s/%s/branches?name=%s&notes=%s&showDialog=true", cmdutil.ApplicationURL, cfg.Organization, source, url.QueryEscape(createReq.Branch.Name), url.QueryEscape(createReq.Branch.Notes)))
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
@@ -54,6 +71,7 @@ func BranchCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&createReq.Branch.Notes, "notes", "", "notes for the database branch")
+	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
 	cmd.AddCommand(ListCmd(cfg))
 	cmd.AddCommand(StatusCmd(cfg))
 	cmd.AddCommand(DeleteCmd(cfg))

--- a/pkg/cmd/branch/get.go
+++ b/pkg/cmd/branch/get.go
@@ -2,9 +2,12 @@ package branch
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/lensesio/tableprinter"
+	"github.com/pkg/browser"
+	"github.com/planetscale/cli/cmdutil"
 	"github.com/planetscale/cli/config"
 	"github.com/planetscale/cli/printer"
 	"github.com/spf13/cobra"
@@ -23,6 +26,20 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			source := args[0]
 			branch := args[1]
 
+			web, err := cmd.Flags().GetBool("web")
+			if err != nil {
+				return err
+			}
+
+			if web {
+				fmt.Println("🌐  Redirecting you to your database branch in your web browser.")
+				err := browser.OpenURL(fmt.Sprintf("%s/%s/%s/branches/%s", cmdutil.ApplicationURL, cfg.Organization, source, branch))
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
@@ -39,5 +56,6 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolP("web", "w", false, "Show a database branch in your web browser.")
 	return cmd
 }

--- a/pkg/cmd/database/create.go
+++ b/pkg/cmd/database/create.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/pkg/browser"
+	"github.com/planetscale/cli/cmdutil"
 	"github.com/planetscale/cli/config"
 	ps "github.com/planetscale/planetscale-go"
 
@@ -29,7 +30,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 
 			if web {
 				fmt.Println("🌐  Redirecting you to create a database in your web browser.")
-				err := browser.OpenURL(fmt.Sprintf("https://app.planetscaledb.io/databases?name=%s&notes=%s&showDialog=true", url.QueryEscape(createReq.Database.Name), url.QueryEscape(createReq.Database.Notes)))
+				err := browser.OpenURL(fmt.Sprintf("%s/%s?name=%s&notes=%s&showDialog=true", cmdutil.ApplicationURL, cfg.Organization, url.QueryEscape(createReq.Database.Name), url.QueryEscape(createReq.Database.Notes)))
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/database/get.go
+++ b/pkg/cmd/database/get.go
@@ -3,9 +3,12 @@ package database
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/lensesio/tableprinter"
+	"github.com/pkg/browser"
+	"github.com/planetscale/cli/cmdutil"
 	"github.com/planetscale/cli/config"
 	"github.com/planetscale/cli/printer"
 	"github.com/spf13/cobra"
@@ -13,12 +16,12 @@ import (
 
 func GetCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <databases_name>",
+		Use:   "get <database_name>",
 		Short: "Retrieve information about a database",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			client, err := cfg.NewClientFromConfig()
+			web, err := cmd.Flags().GetBool("web")
 			if err != nil {
 				return err
 			}
@@ -26,8 +29,22 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			if len(args) == 0 {
 				return errors.New("<database_name> is missing")
 			}
+
 			name := args[0]
 
+			if web {
+				fmt.Println("🌐  Redirecting you to your database in your web browser.")
+				err := browser.OpenURL(fmt.Sprintf("%s/%s/%s", cmdutil.ApplicationURL, cfg.Organization, name))
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+
+			client, err := cfg.NewClientFromConfig()
+			if err != nil {
+				return err
+			}
 			database, err := client.Databases.Get(ctx, cfg.Organization, name)
 			if err != nil {
 				return err
@@ -37,6 +54,8 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolP("web", "w", false, "Open in your web browser")
 
 	return cmd
 }

--- a/pkg/cmd/database/list.go
+++ b/pkg/cmd/database/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lensesio/tableprinter"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
+	"github.com/planetscale/cli/cmdutil"
 	"github.com/planetscale/cli/config"
 	"github.com/planetscale/cli/printer"
 	"github.com/spf13/cobra"
@@ -28,7 +29,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 
 			if web {
 				fmt.Println("🌐  Redirecting you to your databases list in your web browser.")
-				err := browser.OpenURL("https://app.planetscaledb.io/databases")
+				err := browser.OpenURL(fmt.Sprintf("%s/%s", cmdutil.ApplicationURL, cfg.Organization))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This pull request adds the `--web` flag to every single `branch` command, in addition to fixing the URLs for the `db` commands as well.