### PR TITLE
Use user-provided auth URL when getting default org

### DIFF
--- a/pkg/cmd/auth/login.go
+++ b/pkg/cmd/auth/login.go
@@ -84,7 +84,7 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 			s.Stop()
 			fmt.Println("Successfully logged in!")
 
-			err = writeDefaultOrganization(ctx, accessToken)
+			err = writeDefaultOrganization(ctx, accessToken, authURL)
 			if err != nil {
 				return err
 			}
@@ -100,9 +100,9 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 	return cmd
 }
 
-func writeDefaultOrganization(ctx context.Context, accessToken string) error {
+func writeDefaultOrganization(ctx context.Context, accessToken, authURL string) error {
 	// After successfully logging in, attempt to set the org by default.
-	client, err := planetscale.NewClient(planetscale.WithAccessToken(accessToken))
+	client, err := planetscale.NewClient(planetscale.WithAccessToken(accessToken), planetscale.WithBaseURL(authURL))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Quick follow-on to https://github.com/planetscale/cli/pull/43.

If you're trying to use this locally (e.g. with a user-provided URL for the API), you'll get a successful auth followed by 

```
Error: {"error":"invalid_token","error_description":"The access token is invalid","state":"unauthorized"}
```

This is because this method doesn't use the `baseURL` from earlier, so it will always go to prod PS.