### PR TITLE
Add confirmation to deletion commands

### DIFF
--- a/pkg/cmd/branch/delete.go
+++ b/pkg/cmd/branch/delete.go
@@ -33,13 +33,14 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			blue := color.New(color.FgBlue).SprintFunc()
+			boldBlue := color.New(color.FgBlue).Add(color.Bold).SprintFunc()
 			bold := color.New(color.Bold).SprintFunc()
+
 			if !force {
 				confirmationName := fmt.Sprintf("%s/%s", source, branch)
 				userInput := ""
 
-				confirmationMessage := fmt.Sprintf("%s %s %s", bold("Please type"), bold(blue(confirmationName)), bold("to confirm:"))
+				confirmationMessage := fmt.Sprintf("%s %s %s", bold("Please type"), boldBlue(confirmationName), bold("to confirm:"))
 
 				prompt := &survey.Input{
 					Message: confirmationMessage,
@@ -65,7 +66,7 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			fmt.Printf("Successfully deleted branch `%s` from `%s`\n", bold(blue(branch)), bold(blue(source)))
+			fmt.Printf("Successfully deleted branch %s from %s\n", boldBlue(branch), boldBlue(source))
 
 			return nil
 		},

--- a/pkg/cmd/database/delete.go
+++ b/pkg/cmd/database/delete.go
@@ -34,11 +34,12 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 
 			name := args[0]
 
-			blue := color.New(color.FgBlue).SprintFunc()
+			boldBlue := color.New(color.FgBlue).Add(color.Bold).SprintFunc()
 			bold := color.New(color.Bold).SprintfFunc()
+
 			if !force {
 				userInput := ""
-				confirmationMessage := fmt.Sprintf("%s %s %s", bold("Please type"), bold(blue(name)), bold("to confirm:"))
+				confirmationMessage := fmt.Sprintf("%s %s %s", bold("Please type"), boldBlue(name), bold("to confirm:"))
 
 				prompt := &survey.Input{
 					Message: confirmationMessage,
@@ -64,7 +65,7 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 			}
 
 			if deleted {
-				fmt.Printf("Successfully deleted database %s\n", bold(blue(name)))
+				fmt.Printf("Successfully deleted database %s\n", boldBlue(name))
 			}
 
 			return nil


### PR DESCRIPTION
This pull request adds confirmation to the database and branch deletion commands. This is because we want to add a little friction for deleting these resources, since these actions have huge consequences.

![image](https://user-images.githubusercontent.com/956631/105215980-f952d080-5b1f-11eb-826d-c27f47ab6dcb.png)
