### PR TITLE
Fix API token authentication

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -64,12 +64,15 @@ func Execute() error {
 	cfg := config.New()
 
 	rootCmd.PersistentFlags().StringVar(&cfg.BaseURL, "api-url", ps.DefaultBaseURL, "The base URL for the PlanetScale API.")
-	rootCmd.PersistentFlags().StringVar(&cfg.AccessToken, "api-token", "", "The API token to use for authenticating against the PlanetScale API.")
+	rootCmd.PersistentFlags().StringVar(&cfg.AccessToken, "api-token", cfg.AccessToken, "The API token to use for authenticating against the PlanetScale API.")
 
 	err := viper.BindPFlag("org", rootCmd.PersistentFlags().Lookup("org"))
 	if err != nil {
 		return err
 	}
+
+	// We don't want to show the default value
+	rootCmd.PersistentFlags().Lookup("api-token").DefValue = ""
 
 	rootCmd.AddCommand(auth.AuthCmd(cfg))
 	rootCmd.AddCommand(database.DatabaseCmd(cfg))


### PR DESCRIPTION
This pull request fixes the CLI authentication to provide a default value from the `config` object without printing the API token itself within the help message. Otherwise, the value of `config.AccessToken` will always be set to blank.