### PR TITLE
Improve DB create command

### DIFF
--- a/pkg/cmd/database/create.go
+++ b/pkg/cmd/database/create.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/fatih/color"
 	"github.com/pkg/browser"
 	"github.com/planetscale/cli/cmdutil"
 	"github.com/planetscale/cli/config"
@@ -60,13 +61,14 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
+			boldBlue := color.New(color.FgBlue).Add(color.Bold).SprintfFunc()
 			if isJSON {
 				err := printer.PrintJSON(database)
 				if err != nil {
 					return err
 				}
 			} else {
-				fmt.Printf("Database `%s` was successfully created\n", database.Name)
+				fmt.Printf("Successfully created database %s\n", boldBlue(database.Name))
 			}
 
 			return nil


### PR DESCRIPTION
This pull request changes the syntax of the `db create` command from `db create --name --notes` to `db create [name] --notes [notes]`. This leads to less typing for the user. Also, made some small changes and tweaks to the styling of the success message as well.

![image](https://user-images.githubusercontent.com/956631/105219578-9d3e7b00-5b24-11eb-9125-460d9c26dfc8.png)
