### PR TITLE
Fix `db list` and `branch list` output when there are no databases or branches

### DIFF
--- a/pkg/cmd/branch/list.go
+++ b/pkg/cmd/branch/list.go
@@ -53,6 +53,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return errs.Wrap(err, "error listing branches")
 			}
 
+			end()
 			// Technically, this should never actually happen.
 			if len(branches) == 0 {
 				fmt.Println("No branches exist for this database.")
@@ -64,7 +65,6 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			end()
 			err = printer.PrintOutput(isJSON, printer.NewDatabaseBranchSlicePrinter(branches))
 			if err != nil {
 				return err

--- a/pkg/cmd/database/list.go
+++ b/pkg/cmd/database/list.go
@@ -46,6 +46,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return errors.Wrap(err, "error listing databases")
 			}
 
+			end()
 			if len(databases) == 0 {
 				fmt.Println("No databases have been created yet.")
 				return nil
@@ -56,7 +57,6 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			end()
 			err = printer.PrintOutput(isJSON, printer.NewDatabaseSlicePrinter(databases))
 			if err != nil {
 				return err


### PR DESCRIPTION
This pull request fixes a bug with database and branch listing when there's nothing. It's because we don't stop the spinner in time for these commands, so this will fix that.

### Before
```shell
❯ psctl db list
⠙ Fetching databases... No databases have been created yet.
```

### After
```shell
❯ psctl db list
No databases have been created yet.
```