### PR TITLE
Make Notes column last for database

### DIFF
--- a/printer/database.go
+++ b/printer/database.go
@@ -9,9 +9,9 @@ import (
 // Database returns a table-serializable database model.
 type Database struct {
 	Name      string `header:"name" json:"name"`
-	Notes     string `header:"notes" json:"notes"`
 	CreatedAt int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
 	UpdatedAt int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+	Notes     string `header:"notes" json:"notes"`
 }
 
 // NewDatabasePrinter returns a struct that prints out the various fields of a


### PR DESCRIPTION
This pull request changes up the output of the database so that the `NOTES` column is last. 

### Before

```shell
❯ psctl db list
  NAME              NOTES   CREATED AT      UPDATED AT
 ----------------- ------- --------------- ---------------
  iheanyi-test-db           4 minutes ago   4 minutes ago
```

### After
```shell
❯ psctl db list
  NAME              CREATED AT      UPDATED AT      NOTES
 ----------------- --------------- --------------- -------
  iheanyi-test-db   4 minutes ago   4 minutes ago
```