### PR TITLE
Rename `--parent` flag to `--from` for branch creation

### DIFF
--- a/pkg/cmd/branch/branch.go
+++ b/pkg/cmd/branch/branch.go
@@ -89,7 +89,7 @@ func BranchCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&createReq.Branch.Notes, "notes", "", "notes for the database branch")
-	cmd.Flags().StringVar(&createReq.Branch.ParentBranch, "from", "", "parent branch for the branch to be created from")
+	cmd.Flags().StringVar(&createReq.Branch.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
 	cmd.PersistentFlags().Bool("json", false, "Show output as JSON")
 


### PR DESCRIPTION
This pull request changes the flag for creating a branch from another branch to `from` rather than `parent`. This is because `--from` is way less confusing than `parent` and users will know they will be creating a branch _from_ another branch.