### PR TITLE
goreleaser: produce deb and rpm packages, improvements

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,6 @@
+release:
+  prerelease: auto # don't publish release with -rc1,-pre, etc suffixes
+  draft: true 
 builds:
   - env:
       - CGO_ENABLED=0
@@ -8,15 +11,22 @@ builds:
     main: ./cmd/pscale/main.go
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+nfpms:
+  - maintainer: PlanetScale
+    description: The PlanetScale CLI
+    homepage: https://github.com/planetscale/cli
+    license: Apache 2.0
+    formats:
+    - deb
+    - rpm
+    replacements:
+      darwin: macOS
 archives:
   - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-checksum:
-  name_template: 'checksums.txt'
+      darwin: macOS
+    format_overrides:
+      - goos: windows
+        format: zip
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:


### PR DESCRIPTION
* By default, releases are now marked as `draft` until we publish. This will come in handy because it will allow us to review it before we make it public.
* Produce `deb` and `rpm` packages.
* Tag releases as `pre-release` when the version contains a suffix in the form of `rc1` or `pre1`.
* Rename archives into a more readable format.
* Produce `windows` archives as `.zip`.
