### PR TITLE
goreleaser: add homebrew support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     main: ./cmd/pscale/main.go
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    binary: "pscale"   
 nfpms:
   - maintainer: PlanetScale
     description: The PlanetScale CLI
@@ -21,6 +22,25 @@ nfpms:
     - rpm
     replacements:
       darwin: macOS
+brews:
+  - homepage: "https://planetscale.com/"
+    description: "The PlanetScale CLI"
+    name: "pscale"
+    license: Apache 2.0
+    tap: 
+      owner: planetscale
+      name: homebrew-tap
+    dependencies:
+      - name: mysql # needed for 'pscale shell'
+        type: optional
+    # TODO: remove this once we make the repo public      
+    download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
+    custom_require: "../custom_download_strategy"
+    folder: Formula
+    test: |
+         system "#{bin}/pscale --version"
+    install: |
+      bin.install "pscale"
 archives:
   - replacements:
       darwin: macOS

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # PlanetScale CLI
 
+## Installation
+
+**homebrew tap** (only on macOS for now):
+
+```
+brew install planetscale/tap/pscale
+```
+
+**deb/rpm**:
+
+Download the .deb or .rpm from the [releases](https://github.com/planetscale/cli/releases/latest) page and install with dpkg -i and rpm -i respectively.
+
+**manually**:
+
+Download the pre-compiled binaries from the [releases](https://github.com/planetscale/cli/releases/latest) page and copy to the desired location.
+
 ### Local Dev Setup
 
 In order to get setup and running with this project, you can run `script/setup` which will install all of the necessary dependencies. If `script/setup` installs Go, you should ensure that your `$GOPATH` is set properly and that you have added `$GOPATH/bin` to your `$PATH`.


### PR DESCRIPTION
This PR adds support for releasing the CLI as a homebrew package for macOS users.

To install the package, the command is:

```
brew install planetscale/tap/pscale
```

The homebrew formulas are automatically published to repo https://github.com/planetscale/homebrew-tap. The repo will also allow us to publish other homebrew packages in the future (`brew install planetscale/tap/pscale-proxy`)

We also update the Readme with the new instructions.

/xref https://github.com/planetscale/project-big-bang/issues/82
