### PR TITLE
goreleaser: improve archive links and publish immediately

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
+project_name: pscale
 release:
   prerelease: auto # don't publish release with -rc1,-pre, etc suffixes
-  draft: true 
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
* This will produce links in the form of "pscale_" instead of "cli_".
* I also discovered that we should publish immediately so brew can
  access the download links during installation.
