### PR TITLE
Fix goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       # only release on tags
       if: success() && startsWith(github.ref, 'refs/tags/')
       with:
-        version: latest
+        version: v0.156.1
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
Goreleaser is broken with the latest release if we don't use the
latest Go version. To fix it:

* We fixed the gorelease tag to specific version
* We also update the Go version of the CI to v1.16
