### PR TITLE
cmd: support non-interactive shells

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -32,6 +32,9 @@ func LoginCmd(cfg *config.Config) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		Short: "Authenticate with PlanetScale",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmdutil.IsTTY {
+				return errors.New("The 'login' command requires an interactive shell")
+			}
 			authenticator, err := auth.New(cleanhttp.DefaultClient(), clientID, clientSecret, auth.SetBaseURL(authURL))
 			if err != nil {
 				return err

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -31,8 +31,11 @@ func LogoutCmd(cfg *config.Config) *cobra.Command {
 				fmt.Println("Already logged out. Exiting...")
 				return nil
 			}
-			fmt.Println("Press Enter to log out of the PlanetScale API.")
-			_ = waitForEnter(cmd.InOrStdin())
+
+			if cmdutil.IsTTY {
+				fmt.Println("Press Enter to log out of the PlanetScale API.")
+				_ = waitForEnter(cmd.InOrStdin())
+			}
 
 			authenticator, err := auth.New(cleanhttp.DefaultClient(), clientID, clientSecret, auth.SetBaseURL(apiURL))
 			if err != nil {

--- a/internal/cmd/branch/delete.go
+++ b/internal/cmd/branch/delete.go
@@ -39,7 +39,9 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 
 			if !force {
 				confirmationName := fmt.Sprintf("%s/%s", source, branch)
-				userInput := ""
+				if !cmdutil.IsTTY {
+					return fmt.Errorf("Cannot confirm deletion of branch %q (run with -force to override)", confirmationName)
+				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", cmdutil.Bold("Please type"), cmdutil.BoldBlue(confirmationName), cmdutil.Bold("to confirm:"))
 
@@ -47,6 +49,7 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 					Message: confirmationMessage,
 				}
 
+				var userInput string
 				err := survey.AskOne(prompt, &userInput)
 				if err != nil {
 					if err == terminal.InterruptErr {

--- a/internal/cmd/database/delete.go
+++ b/internal/cmd/database/delete.go
@@ -39,13 +39,16 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 			name := args[0]
 
 			if !force {
-				userInput := ""
+				if !cmdutil.IsTTY {
+					return fmt.Errorf("Cannot confirm deletion of database %q (run with -force to override)", name)
+				}
 				confirmationMessage := fmt.Sprintf("%s %s %s", cmdutil.Bold("Please type"), cmdutil.BoldBlue(name), cmdutil.Bold("to confirm:"))
 
 				prompt := &survey.Input{
 					Message: confirmationMessage,
 				}
 
+				var userInput string
 				err := survey.AskOne(prompt, &userInput)
 				if err != nil {
 					if err == terminal.InterruptErr {

--- a/internal/cmd/merge/merge.go
+++ b/internal/cmd/merge/merge.go
@@ -38,6 +38,10 @@ func MergeCmd(cfg *config.Config) *cobra.Command {
 			// If mergeInto is blank, then we need to prompt the user to select a
 			// branch.
 			if mergeInto == "" {
+				if !cmdutil.IsTTY {
+					return fmt.Errorf("no '-into' branch given")
+				}
+
 				err := selectBranch(ctx, client, fromBranch, &mergeInto, database, cfg.Organization)
 				if err != nil {
 					return err

--- a/internal/cmd/org/switch.go
+++ b/internal/cmd/org/switch.go
@@ -44,7 +44,7 @@ func SwitchCmd(cfg *config.Config) *cobra.Command {
 				}
 				end()
 				organization = org.Name
-			} else if len(args) == 0 {
+			} else if len(args) == 0 && cmdutil.IsTTY {
 				// Get organization names to show the user
 				end := cmdutil.PrintProgress("Fetching organizations...")
 				defer end()

--- a/internal/cmdutil/browser.go
+++ b/internal/cmdutil/browser.go
@@ -12,6 +12,9 @@ const ApplicationURL = "https://app.planetscaledb.io"
 
 // OpenBrowser opens a web browser at the specified url.
 func OpenBrowser(goos, url string) *exec.Cmd {
+	if !IsTTY {
+		panic("OpenBrowser called without a TTY")
+	}
 	exe := "open"
 	var args []string
 	switch goos {

--- a/internal/cmdutil/terminal.go
+++ b/internal/cmdutil/terminal.go
@@ -7,10 +7,25 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
 )
+
+var IsTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+
+func Emoji(emoji string) string {
+	if IsTTY {
+		return emoji
+	}
+	return ""
+}
 
 // PrintProgress starts a spinner with the relevant message.
 func PrintProgress(message string) func() {
+	if !IsTTY {
+		fmt.Println(message)
+		return func() {}
+	}
+
 	// Output to STDERR so we don't polluate STDOUT.
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
 	s.Suffix = fmt.Sprintf(" %s", message)
@@ -24,10 +39,12 @@ func PrintProgress(message string) func() {
 
 // BoldBlue returns a string formatted with blue and bold.
 func BoldBlue(msg string) string {
+	// the 'color' package already handles IsTTY gracefully
 	return color.New(color.FgBlue).Add(color.Bold).Sprint(msg)
 }
 
 // Bold returns a string formatted with bold.
 func Bold(msg string) string {
+	// the 'color' package already handles IsTTY gracefully
 	return color.New(color.Bold).Sprint(msg)
 }


### PR DESCRIPTION
Hi @fatih! Just a small fix here, since I saw your `TODO` in `branch.go`. It seems like the message output of the CLI tool is not TTY-aware (meaning that it many cases, it can block forever waiting for user input when we're not running in an interactive terminal, or it can print "animations" which don't look quite right when the output of a program is a file instead of a terminal).

This is simple enough to fix, and we don't need timeouts to do it, we simply need to add a few checks for all the "interactive" functionality of the CLI and ensure it only runs when we're in a terminal.