### PR TITLE
proxy: pick up a random port and bind to the correct port

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/planetscale-go v0.9.0
-	github.com/planetscale/sql-proxy v0.1.3
+	github.com/planetscale/sql-proxy v0.1.4
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ github.com/planetscale/planetscale-go v0.9.0 h1:EY2BQNyBAWx8rjk5ecqcmulKyT8zheWa
 github.com/planetscale/planetscale-go v0.9.0/go.mod h1:R+07GStW2oGSfeTwWoplnimSEFzxIzEofOHgPFxArg0=
 github.com/planetscale/sql-proxy v0.1.3 h1:u0HA78rkasas2JOHEyA21LAtIx+HVU6W7yPeS1XJRow=
 github.com/planetscale/sql-proxy v0.1.3/go.mod h1:Z1F1p5YmoBV0mkbfApaFA0zYv0Ngxm4GT4VnvtCgoro=
+github.com/planetscale/sql-proxy v0.1.4 h1:RBTxrEXiF08W8GHTuHQ1Hn9aM79ibLSFZ3yX/dwsF/c=
+github.com/planetscale/sql-proxy v0.1.4/go.mod h1:lTxdxxilj2oOgVsZ5c1Eyjo/3XTEv0GZ8E2A33y6We8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,7 +75,7 @@ github.com/pkg/errors
 # github.com/planetscale/planetscale-go v0.9.0
 ## explicit
 github.com/planetscale/planetscale-go/planetscale
-# github.com/planetscale/sql-proxy v0.1.3
+# github.com/planetscale/sql-proxy v0.1.4
 ## explicit
 github.com/planetscale/sql-proxy/proxy
 github.com/planetscale/sql-proxy/sigutil


### PR DESCRIPTION
This PR changes the address to bind locally. Instead of binding to a hardcoded port, we now let the OS pick up a random port for us. We had to introduce a new method to the `sql-proxy` repo (https://github.com/planetscale/sql-proxy/pull/52) to make this work.

Both `pscale shell` and `pscale connect` now automatically bind to a random port.

closes https://github.com/planetscale/project-big-bang/issues/111
