### PR TITLE
Add error message when database is not ready for connection yet

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -115,6 +116,10 @@ second argument:
 			})
 			if err != nil {
 				return err
+			}
+
+			if status.User == "" {
+				return errors.New("database branch is not ready yet")
 			}
 
 			tmpFile, err := createLoginFile(status.User, status.Password)


### PR DESCRIPTION
If the user is blank, our database is not yet ready for connecting. Let's return an error for this.