### PR TITLE
cmd: show user friendly error messages

### DIFF
--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -21,17 +21,12 @@ func BranchCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:     "branch <source-database> <branch-name> [options]",
+		Use:     "branch <source-database> <branch> [options]",
 		Short:   "Branch a production database",
+		Args:    cmdutil.RequiredArgs("source-database", "branch"),
 		Aliases: []string{"b"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			// If the user does not provide a source database and a branch name,
-			// show the usage.
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
 			source := args[0]
 			branch := args[1]
 

--- a/internal/cmd/branch/delete.go
+++ b/internal/cmd/branch/delete.go
@@ -20,15 +20,12 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:     "delete <db_name> <branch_name>",
+		Use:     "delete <database> <branch>",
 		Short:   "Delete a branch from a database",
+		Args:    cmdutil.RequiredArgs("database", "branch"),
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
 			source := args[0]
 			branch := args[1]
 

--- a/internal/cmd/branch/get.go
+++ b/internal/cmd/branch/get.go
@@ -16,14 +16,11 @@ import (
 
 func GetCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <source_name> <branch_name>",
+		Use:   "get <source-database> <branch>",
 		Short: "Get a specific branch of a database",
+		Args:  cmdutil.RequiredArgs("source-database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
 			source := args[0]
 			branch := args[1]
 

--- a/internal/cmd/branch/list.go
+++ b/internal/cmd/branch/list.go
@@ -19,14 +19,10 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list <database>",
 		Short:   "List all branches of a database",
+		Args:    cmdutil.RequiredArgs("database"),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-
-			if len(args) == 0 {
-				return errors.New("<db_name> is missing")
-			}
-
 			database := args[0]
 
 			web, err := cmd.Flags().GetBool("web")

--- a/internal/cmd/branch/request_deploy.go
+++ b/internal/cmd/branch/request_deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/printer"
 	"github.com/planetscale/planetscale-go/planetscale"
+
 	"github.com/spf13/cobra"
 )
 
@@ -17,13 +18,11 @@ func RequestDeployCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "request-deploy <database> <branch>",
 		Short: "Requests a deploy for a specific schema snapshot ID",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
 			database, branch := args[0], args[1]
+
 			deployReq.Database = database
 			deployReq.Branch = branch
 			deployReq.Organization = cfg.Organization

--- a/internal/cmd/branch/status.go
+++ b/internal/cmd/branch/status.go
@@ -16,21 +16,18 @@ import (
 // StatusCmd gets the status of a database branch using the PlanetScale API.
 func StatusCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "status <db_name> <branch_name>",
+		Use:   "status <database> <branch>",
 		Short: "Check the status of a branch of a database",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
+			source := args[0]
+			branch := args[1]
 
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
 			}
-
-			source := args[0]
-			branch := args[1]
 
 			end := cmdutil.PrintProgress(fmt.Sprintf("Getting status for branch %s in %s...", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(source)))
 			defer end()

--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -20,12 +20,9 @@ func SwitchCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "switch <branch>",
 		Short: "Switches the current project to use the specified branch",
+		Args:  cmdutil.RequiredArgs("branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) != 1 {
-				return cmd.Usage()
-			}
-
 			branch := args[0]
 
 			client, err := cfg.NewClientFromConfig()

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -24,7 +24,9 @@ func ConnectCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "connect [database] [branch]",
+		Use: "connect [database] [branch]",
+		// we only require database, because we deduct branch automatically
+		Args:  cmdutil.RequiredArgs("database"),
 		Short: "Create a secure connection to the given database and branch",
 		Example: `The connect subcommand establish a secure connection between your host and remote psdb. 
 
@@ -40,10 +42,6 @@ argument:
   pscale connect mydatabase mybranch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) < 1 {
-				return cmd.Usage()
-			}
-
 			database := args[0]
 
 			client, err := cfg.NewClientFromConfig()

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -20,8 +20,9 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 	createReq := &ps.CreateDatabaseRequest{}
 
 	cmd := &cobra.Command{
-		Use:   "create <name>",
+		Use:   "create <database>",
 		Short: "Create a database instance",
+		Args:  cmdutil.RequiredArgs("database"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 			web, err := cmd.Flags().GetBool("web")
@@ -30,9 +31,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			}
 
 			createReq.Organization = cfg.Organization
-			if len(args) == 1 {
-				createReq.Name = args[0]
-			}
+			createReq.Name = args[0]
 
 			if web {
 				fmt.Println("🌐  Redirecting you to create a database in your web browser.")
@@ -41,10 +40,6 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 					return err
 				}
 				return nil
-			}
-
-			if len(args) != 1 {
-				return cmd.Usage()
 			}
 
 			client, err := cfg.NewClientFromConfig()

--- a/internal/cmd/database/delete.go
+++ b/internal/cmd/database/delete.go
@@ -22,21 +22,18 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:     "delete <database_name>",
+		Use:     "delete <database>",
 		Short:   "Delete a database instance",
+		Args:    cmdutil.RequiredArgs("database"),
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			name := args[0]
+
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
 			}
-
-			if len(args) == 0 {
-				return errors.New("<database_name> is missing")
-			}
-
-			name := args[0]
 
 			if !force {
 				if !cmdutil.IsTTY {

--- a/internal/cmd/database/get.go
+++ b/internal/cmd/database/get.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -17,21 +16,17 @@ import (
 
 func GetCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <database_name>",
+		Use:   "get <database>",
 		Short: "Retrieve information about a database",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.RequiredArgs("database"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			name := args[0]
+
 			web, err := cmd.Flags().GetBool("web")
 			if err != nil {
 				return err
 			}
-
-			if len(args) == 0 {
-				return errors.New("<database_name> is missing")
-			}
-
-			name := args[0]
 
 			if web {
 				fmt.Println("🌐  Redirecting you to your database in your web browser.")

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -17,13 +17,9 @@ func DeployCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "deploy <id>",
 		Short: "Approve and deploy a specific deploy request",
+		Args:  cmdutil.RequiredArgs("id"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-
-			if len(args) != 1 {
-				return cmd.Usage()
-			}
-
 			id := args[0]
 
 			performReq.ID = id

--- a/internal/cmd/deploy/get.go
+++ b/internal/cmd/deploy/get.go
@@ -17,18 +17,16 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get [id]",
 		Short: "Get a deploy request",
+		Args:  cmdutil.RequiredArgs("id"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			id := args[0]
+
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
 			}
 
-			if len(args) != 1 {
-				return cmd.Usage()
-			}
-
-			id := args[0]
 			getReq.ID = id
 
 			end := cmdutil.PrintProgress(fmt.Sprintf("Fetching deploy %s...", cmdutil.BoldBlue(id)))

--- a/internal/cmd/deploy/list.go
+++ b/internal/cmd/deploy/list.go
@@ -15,16 +15,11 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 	listReq := &planetscale.ListDeployRequestsRequest{}
 
 	cmd := &cobra.Command{
-		Use:   "list [database] [branch]",
+		Use:   "list <database> <branch>",
 		Short: "List the deploy requests for a database branch",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-
-			if len(args) != 2 {
-				fmt.Println(args)
-				return cmd.Usage()
-			}
-
 			database, branch := args[0], args[1]
 
 			listReq.Organization = cfg.Organization

--- a/internal/cmd/merge/merge.go
+++ b/internal/cmd/merge/merge.go
@@ -18,15 +18,11 @@ func MergeCmd(cfg *config.Config) *cobra.Command {
 	mergeInto := ""
 
 	cmd := &cobra.Command{
-		Use:   "merge [database] [from_branch]",
+		Use:   "merge <database> <from-branch>",
 		Short: "Merge the branch from the database",
+		Args:  cmdutil.RequiredArgs("database", "from-branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
 			database := args[0]
 			fromBranch := args[1]
 

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/promptutil"
 	"github.com/planetscale/cli/internal/proxyutil"
@@ -31,7 +32,9 @@ func ShellCmd(cfg *config.Config) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "shell [database] [branch]",
+		Use: "shell [database] [branch]",
+		// we only require database, because we deduct branch automatically
+		Args:  cmdutil.RequiredArgs("database"),
 		Short: "Open a shell instance to the given database and branch",
 		Example: `The shell subcommand opens a secure MySQL shell instance to your database.
 
@@ -48,10 +51,6 @@ second argument:
   pscale shell mydatabase mybranch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) < 1 {
-				return cmd.Usage()
-			}
-
 			database := args[0]
 
 			_, err := exec.LookPath("mysql")

--- a/internal/cmd/snapshot/create.go
+++ b/internal/cmd/snapshot/create.go
@@ -16,18 +16,15 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <database> <branch>",
 		Short: "Create a new schema snapshot for a database branch",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			database, branch := args[0], args[1]
+
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
 			}
-
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
-			database, branch := args[0], args[1]
 
 			end := cmdutil.PrintProgress(fmt.Sprintf("Creating schema snapshot for %s in %s...", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database)))
 			defer end()

--- a/internal/cmd/snapshot/get.go
+++ b/internal/cmd/snapshot/get.go
@@ -15,21 +15,18 @@ import (
 // GetCmd makes a command for fetching a single snapshot by its ID.
 func GetCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <snapshot_id>",
+		Use:   "get <snapshot-id>",
 		Short: "Get a specific schema snapshot",
+		Args:  cmdutil.RequiredArgs("snapshot-id"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			id := args[0]
 
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
 			}
 
-			if len(args) != 1 {
-				return cmd.Usage()
-			}
-
-			id := args[0]
 			end := cmdutil.PrintProgress(fmt.Sprintf("Fetching schema snapshot %s", cmdutil.BoldBlue(id)))
 			defer end()
 

--- a/internal/cmd/snapshot/list.go
+++ b/internal/cmd/snapshot/list.go
@@ -16,19 +16,16 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list <database> <branch>",
 		Short:   "List all of the schema snapshots for a database branch",
+		Args:    cmdutil.RequiredArgs("database", "branch"),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
+			database, branch := args[0], args[1]
+
 			client, err := cfg.NewClientFromConfig()
 			if err != nil {
 				return err
 			}
-
-			if len(args) != 2 {
-				return cmd.Usage()
-			}
-
-			database, branch := args[0], args[1]
 
 			end := cmdutil.PrintProgress(fmt.Sprintf("Fetching schema snapshots for %s in %s...", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database)))
 			defer end()

--- a/internal/cmd/snapshot/request_deploy.go
+++ b/internal/cmd/snapshot/request_deploy.go
@@ -17,12 +17,9 @@ func RequestDeployCmd(cfg *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "request-deploy <id>",
 		Short: "Requests a deploy for a specific schema snapshot ID",
+		Args:  cmdutil.RequiredArgs("id"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			if len(args) != 1 {
-				return cmd.Usage()
-			}
-
 			id := args[0]
 			deployReq.SchemaSnapshotID = id
 

--- a/internal/cmdutil/args.go
+++ b/internal/cmdutil/args.go
@@ -1,0 +1,36 @@
+package cmdutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// RequiredArgs returns a short and actionable error message if the given
+// required arguments are not available.
+func RequiredArgs(reqArgs ...string) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		// show just the usage line and any examples if they exist
+		var usageTemplate = `Usage:{{if .Runnable}} {{.UseLine}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}
+`
+		cmd.SetUsageTemplate(usageTemplate)
+
+		n := len(reqArgs)
+		if len(args) >= n {
+			return nil
+		}
+
+		missing := reqArgs[len(args):]
+
+		a := fmt.Sprintf("arguments <%s>", strings.Join(missing, ", "))
+		if len(missing) == 1 {
+			a = fmt.Sprintf("argument <%s>", missing[0])
+		}
+
+		return fmt.Errorf("missing %s \n\n%s", a, cmd.UsageString())
+	}
+}


### PR DESCRIPTION
Most of the time, we print the output of `cmd.Usage()` if an argument is missing. However, that's not very useful. It's like dumping out the content of a book. Instead, we should tell the user what exactly went wrong. Even better, we can aid/help them (such as let them pick up a branch name), but that's an improvement for another PR.

This PR removes all `cmd.Usage()` calls and replaces them with explicit and actionable error messages. We use a custom `RequiredArgs` function that checks whether the given arguments exist for the given subcommand. As a bonus, we don't have to check for arguments anymore, simplifying our CLI quite a bit. We also print the same error message for all commands.  The `RequiredArgs` function also lets us format and improve the error message in a single place.

Before:

```
$ pscale deploy list planetscale
Usage:
  pscale deploy list [database] [branch] [flags]

Flags:
  -h, --help   help for list

Global Flags:
      --api-token string   The API token to use for authenticating against the PlanetScale API.
      --api-url string     The base URL for the PlanetScale API. (default "https://api.planetscaledb.io/")
      --config string      config file (default is $HOME/.config/planetscale/config.yaml)
      --json               Show output as JSON
      --org string         The organization for the current user
```

After:

```
$ pscale deploy list
Error: missing arguments <database, branch>

Usage: pscale deploy list <database> <branch> [flags]
```

If an argument exists, but we require multiple, it only shows the ones that are missing:

```
$ pscale deploy list planetscale
Error: missing argument <branch>

Usage: pscale deploy list <database> <branch> [flags]
```
