### PR TITLE
cmd: add globally applied -json mode

### DIFF
--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -65,13 +65,8 @@ func BranchCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
 			end()
-			if isJSON {
+			if cfg.OutputJSON {
 				err := printer.PrintJSON(dbBranch)
 				if err != nil {
 					return err
@@ -87,7 +82,6 @@ func BranchCmd(cfg *config.Config) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.Branch.Notes, "notes", "", "notes for the database branch")
 	cmd.Flags().StringVar(&createReq.Branch.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
-	cmd.PersistentFlags().Bool("json", false, "Show output as JSON")
 
 	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization, "The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck

--- a/internal/cmd/branch/get.go
+++ b/internal/cmd/branch/get.go
@@ -54,13 +54,8 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
 			end()
-			err = printer.PrintOutput(isJSON, printer.NewDatabaseBranchPrinter(b))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDatabaseBranchPrinter(b))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/branch/list.go
+++ b/internal/cmd/branch/list.go
@@ -55,17 +55,12 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			if len(branches) == 0 && !isJSON {
+			if len(branches) == 0 && !cfg.OutputJSON {
 				fmt.Printf("No branches exist in %s.\n", cmdutil.BoldBlue(database))
 				return nil
 			}
 
-			err = printer.PrintOutput(isJSON, printer.NewDatabaseBranchSlicePrinter(branches))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDatabaseBranchSlicePrinter(branches))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/branch/request_deploy.go
+++ b/internal/cmd/branch/request_deploy.go
@@ -41,11 +41,7 @@ func RequestDeployCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-			if isJSON {
+			if cfg.OutputJSON {
 				err := printer.PrintJSON(deployRequest)
 				if err != nil {
 					return err

--- a/internal/cmd/branch/status.go
+++ b/internal/cmd/branch/status.go
@@ -40,13 +40,8 @@ func StatusCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
 			end()
-			err = printer.PrintOutput(isJSON, printer.NewDatabaseBranchStatusPrinter(status))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDatabaseBranchStatusPrinter(status))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -54,13 +54,8 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
 			end()
-			if isJSON {
+			if cfg.OutputJSON {
 				err := printer.PrintJSON(database)
 				if err != nil {
 					return err

--- a/internal/cmd/database/database.go
+++ b/internal/cmd/database/database.go
@@ -12,10 +12,8 @@ func DatabaseCmd(cfg *config.Config) *cobra.Command {
 		Use:     "database <command>",
 		Short:   "Create, read, destroy, and update databases",
 		Aliases: []string{"db"},
-		Long:    "TODO",
 	}
 
-	cmd.PersistentFlags().Bool("json", false, "Show output as JSON")
 	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization, "The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 

--- a/internal/cmd/database/get.go
+++ b/internal/cmd/database/get.go
@@ -52,13 +52,8 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
 			end()
-			err = printer.PrintOutput(isJSON, printer.NewDatabasePrinter(database))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDatabasePrinter(database))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/database/list.go
+++ b/internal/cmd/database/list.go
@@ -53,17 +53,12 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			if len(databases) == 0 && !isJSON {
+			if len(databases) == 0 && !cfg.OutputJSON {
 				fmt.Println("No databases have been created yet.")
 				return nil
 			}
 
-			err = printer.PrintOutput(isJSON, printer.NewDatabaseSlicePrinter(databases))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDatabaseSlicePrinter(databases))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/deploy/deploy.go
+++ b/internal/cmd/deploy/deploy.go
@@ -38,12 +38,7 @@ func DeployCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			if isJSON {
+			if cfg.OutputJSON {
 				err := printer.PrintJSON(deployRequest)
 				if err != nil {
 					return err
@@ -56,7 +51,6 @@ func DeployCmd(cfg *config.Config) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().Bool("json", false, "Show output as JSON")
 	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization, "The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 

--- a/internal/cmd/deploy/get.go
+++ b/internal/cmd/deploy/get.go
@@ -38,12 +38,7 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewDeployRequestPrinter(dr))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDeployRequestPrinter(dr))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/deploy/list.go
+++ b/internal/cmd/deploy/list.go
@@ -40,12 +40,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewDeployRequestSlicePrinter(deployRequests))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewDeployRequestSlicePrinter(deployRequests))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -75,8 +75,10 @@ func Execute(ver, commit, buildDate string) error {
 
 	cfg := config.New()
 
-	rootCmd.PersistentFlags().StringVar(&cfg.BaseURL, "api-url", ps.DefaultBaseURL, "The base URL for the PlanetScale API.")
-	rootCmd.PersistentFlags().StringVar(&cfg.AccessToken, "api-token", cfg.AccessToken, "The API token to use for authenticating against the PlanetScale API.")
+	rootCmd.PersistentFlags().StringVar(&cfg.BaseURL,
+		"api-url", ps.DefaultBaseURL, "The base URL for the PlanetScale API.")
+	rootCmd.PersistentFlags().StringVar(&cfg.AccessToken,
+		"api-token", cfg.AccessToken, "The API token to use for authenticating against the PlanetScale API.")
 
 	if err := viper.BindPFlag("org", rootCmd.PersistentFlags().Lookup("org")); err != nil {
 		return err
@@ -90,9 +92,16 @@ func Execute(ver, commit, buildDate string) error {
 		return err
 	}
 
+	rootCmd.PersistentFlags().BoolVar(&cfg.OutputJSON, "json", false, "Show output as JSON")
+	if err := viper.BindPFlag("json", rootCmd.PersistentFlags().Lookup("json")); err != nil {
+		return err
+	}
+
 	// service token flags. they are hidden for now.
-	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenName, "service-token-name", "", "The Service Token name for authenticating.")
-	rootCmd.PersistentFlags().StringVar(&cfg.ServiceToken, "service-token", "", "Service Token for authenticating.")
+	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenName,
+		"service-token-name", "", "The Service Token name for authenticating.")
+	rootCmd.PersistentFlags().StringVar(&cfg.ServiceToken,
+		"service-token", "", "Service Token for authenticating.")
 	_ = rootCmd.PersistentFlags().MarkHidden("service-token-name")
 	_ = rootCmd.PersistentFlags().MarkHidden("service-token")
 

--- a/internal/cmd/snapshot/create.go
+++ b/internal/cmd/snapshot/create.go
@@ -39,12 +39,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewSchemaSnapshotPrinter(snapshot))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewSchemaSnapshotPrinter(snapshot))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/snapshot/get.go
+++ b/internal/cmd/snapshot/get.go
@@ -38,12 +38,7 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewSchemaSnapshotPrinter(snapshot))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewSchemaSnapshotPrinter(snapshot))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/snapshot/list.go
+++ b/internal/cmd/snapshot/list.go
@@ -40,17 +40,12 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			if len(snapshots) == 0 && !isJSON {
+			if len(snapshots) == 0 && !cfg.OutputJSON {
 				fmt.Printf("No schema snapshots exist for %s in %s.\n", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
 				return nil
 			}
 
-			err = printer.PrintOutput(isJSON, printer.NewSchemaSnapshotSlicePrinter(snapshots))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewSchemaSnapshotSlicePrinter(snapshots))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/snapshot/request_deploy.go
+++ b/internal/cmd/snapshot/request_deploy.go
@@ -36,11 +36,7 @@ func RequestDeployCmd(cfg *config.Config) *cobra.Command {
 			}
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-			if isJSON {
+			if cfg.OutputJSON {
 				err := printer.PrintJSON(deployRequest)
 				if err != nil {
 					return err

--- a/internal/cmd/snapshot/snapshot.go
+++ b/internal/cmd/snapshot/snapshot.go
@@ -13,7 +13,6 @@ func SnapshotCmd(cfg *config.Config) *cobra.Command {
 		Short: "Create, get, and list schema snapshots",
 	}
 
-	cmd.PersistentFlags().Bool("json", false, "Show output as JSON")
 	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization, "The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 

--- a/internal/cmd/token/add-access.go
+++ b/internal/cmd/token/add-access.go
@@ -53,12 +53,7 @@ For a complete list of the access permissions that can be granted to a token, se
 
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewServiceTokenAccessPrinter(access))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewServiceTokenAccessPrinter(access))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/token/create.go
+++ b/internal/cmd/token/create.go
@@ -36,12 +36,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewServiceTokenPrinter(token))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewServiceTokenPrinter(token))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/token/get-access.go
+++ b/internal/cmd/token/get-access.go
@@ -41,12 +41,7 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewServiceTokenAccessPrinter(accesses))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewServiceTokenAccessPrinter(accesses))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/token/list.go
+++ b/internal/cmd/token/list.go
@@ -36,12 +36,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 
 			end()
 
-			isJSON, err := cmd.Flags().GetBool("json")
-			if err != nil {
-				return err
-			}
-
-			err = printer.PrintOutput(isJSON, printer.NewServiceTokenSlicePrinter(tokens))
+			err = printer.PrintOutput(cfg.OutputJSON, printer.NewServiceTokenSlicePrinter(tokens))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/token/token.go
+++ b/internal/cmd/token/token.go
@@ -13,7 +13,6 @@ func TokenCmd(cfg *config.Config) *cobra.Command {
 		Short: "Create, get, and list service tokens",
 	}
 
-	cmd.PersistentFlags().Bool("json", false, "Show output as JSON")
 	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization, "The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	// Project Configuration
 	Database string
 	Branch   string
+
+	OutputJSON bool
 }
 
 // GlobalConfig is sourced from the global config path and contains globaly


### PR DESCRIPTION
This removes the local `--json` flags from all subcommands and uses a
**global** `--json` flag. It simplifies the code quite a bit as we don't
have to look up the local flag anymore and don't have to set up a local
JSON flag for subcommands.

We will create follow-up PR to improve the JSON mode even further
and display anything printed to stdout/stderr in JSON format
(including user errors). The goal is to make sure `pscale` can be used
in scripts and automation software in a compatible and easy way.
