### PR TITLE
proxy: try to bind to :3306, fallback to random port afterwards

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -2,7 +2,10 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -61,8 +64,7 @@ argument:
 				}
 			}
 
-			const localProxyAddr = "127.0.0.1"
-			localAddr := localProxyAddr + ":0"
+			localAddr := "127.0.0.1:3306"
 			if flags.localAddr != "" {
 				localAddr = flags.localAddr
 			}
@@ -78,31 +80,17 @@ argument:
 				proxyOpts.Logger = zap.NewNop()
 			}
 
-			p, err := proxy.NewClient(proxyOpts)
+			err = runProxy(proxyOpts, database, branch)
 			if err != nil {
-				return fmt.Errorf("couldn't create proxy client: %s", err)
+				if isAddrInUse(err) {
+					fmt.Println("Tried address 127.0.0.1:3306, but it's already in use. Picking up a random port ...")
+					proxyOpts.LocalAddr = "127.0.0.1:0"
+					return runProxy(proxyOpts, database, branch)
+				}
+				return err
 			}
 
-			go func() {
-				// this is blocking and will only return once p.Run() below is
-				// invoked
-				addr, err := p.LocalAddr()
-				if err != nil {
-					fmt.Printf("failed getting local addr: %s\n", err)
-					return
-				}
-
-				fmt.Printf("Secure connection to databases %s and branch %s is established!.\n\nLocal address to connect your application: %s (press ctrl-c to quit)",
-					cmdutil.BoldBlue(database),
-					cmdutil.BoldBlue(branch),
-					cmdutil.BoldBlue(addr.String()),
-				)
-			}()
-
-			// TODO(fatih): replace with signal.NotifyContext once Go 1.16 is released
-			// https://go-review.googlesource.com/c/go/+/219640
-			ctx = sigutil.WithSignal(ctx, syscall.SIGINT, syscall.SIGTERM)
-			return p.Run(ctx)
+			return nil
 		},
 	}
 
@@ -115,4 +103,57 @@ argument:
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 
 	return cmd
+}
+
+func runProxy(proxyOpts proxy.Options, database, branch string) error {
+	ctx := context.Background()
+	p, err := proxy.NewClient(proxyOpts)
+	if err != nil {
+		return fmt.Errorf("couldn't create proxy client: %s", err)
+	}
+
+	go func() {
+		// this is blocking and will only return once p.Run() below is
+		// invoked
+		addr, err := p.LocalAddr()
+		if err != nil {
+			fmt.Printf("failed getting local addr: %s\n", err)
+			return
+		}
+
+		fmt.Printf("Secure connection to databases %s and branch %s is established!.\n\nLocal address to connect your application: %s (press ctrl-c to quit)",
+			cmdutil.BoldBlue(database),
+			cmdutil.BoldBlue(branch),
+			cmdutil.BoldBlue(addr.String()),
+		)
+	}()
+
+	// TODO(fatih): replace with signal.NotifyContext once Go 1.16 is released
+	// https://go-review.googlesource.com/c/go/+/219640
+	ctx = sigutil.WithSignal(ctx, syscall.SIGINT, syscall.SIGTERM)
+	return p.Run(ctx)
+}
+
+// isAddrInUse returns an error if the error indicates that the given address
+// is already in use. Becaue different OS return different error messages, we
+// try to get the underlying error.
+// see: https://stackoverflow.com/a/65865898
+func isAddrInUse(err error) bool {
+	var syserr *os.SyscallError
+	if !errors.As(err, &syserr) {
+		return false
+	}
+	var errErrno syscall.Errno // doesn't need a "*" (ptr) because it's already a ptr (uintptr)
+	if !errors.As(syserr, &errErrno) {
+		return false
+	}
+	if errErrno == syscall.EADDRINUSE {
+		return true
+	}
+
+	const WSAEADDRINUSE = 10048
+	if runtime.GOOS == "windows" && errErrno == WSAEADDRINUSE {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
closes: https://github.com/planetscale/project-big-bang/issues/169

This tries to make `pscale connect` more user-friendly. It first tries to bind to the port `3306`. If fallbacks to a random port only if the address is already in use.

before:

```
pscale connect prod development --local-addr "127.0.0.1:3306"
Error: error net.Listen: listen tcp 127.0.0.1:3306: bind: address already in use
```

after:

```
$ pscale connect prod development
Secure connection to databases prod and branch development is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)

# run MySQL on port 3306
$ brew services start mysql
==> Successfully started `mysql` (label: homebrew.mxcl.mysql)

$ pscale connect prod development
Tried address 127.0.0.1:3306, but it's already in use. Picking up a random port ...
Secure connection to databases prod and branch development is established!.

Local address to connect your application: 127.0.0.1:63727 (press ctrl-c to quit)
```
