### PR TITLE
cmd: add `pscale branch create` subcommand

### DIFF
--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -1,91 +1,23 @@
 package branch
 
 import (
-	"context"
-	"fmt"
-	"net/url"
-
-	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
-	"github.com/planetscale/cli/internal/printer"
-	ps "github.com/planetscale/planetscale-go/planetscale"
 
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
 // BranchCmd handles the branching of a database.
 func BranchCmd(cfg *config.Config) *cobra.Command {
-	createReq := &ps.CreateDatabaseBranchRequest{
-		Branch: new(ps.DatabaseBranch),
-	}
-
 	cmd := &cobra.Command{
-		Use:     "branch <source-database> <branch> [options]",
-		Short:   "Branch a production database",
-		Args:    cmdutil.RequiredArgs("source-database", "branch"),
-		Aliases: []string{"b"},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-			source := args[0]
-			branch := args[1]
-
-			// Simplest case, the names are equivalent
-			if source == branch {
-				return fmt.Errorf("A branch named '%s' already exists", branch)
-			}
-
-			createReq.Database = source
-			createReq.Branch.Name = branch
-			createReq.Organization = cfg.Organization
-
-			web, err := cmd.Flags().GetBool("web")
-			if err != nil {
-				return err
-			}
-
-			if web {
-				fmt.Println("🌐  Redirecting you to branch a database in your web browser.")
-				err := browser.OpenURL(fmt.Sprintf("%s/%s/%s/branches?name=%s&notes=%s&showDialog=true", cmdutil.ApplicationURL, cfg.Organization, source, url.QueryEscape(createReq.Branch.Name), url.QueryEscape(createReq.Branch.Notes)))
-				if err != nil {
-					return err
-				}
-				return nil
-			}
-
-			client, err := cfg.NewClientFromConfig()
-			if err != nil {
-				return err
-			}
-
-			end := cmdutil.PrintProgress(fmt.Sprintf("Creating branch from %s...", cmdutil.BoldBlue(source)))
-			defer end()
-			dbBranch, err := client.DatabaseBranches.Create(ctx, createReq)
-			if err != nil {
-				return err
-			}
-
-			end()
-			if cfg.OutputJSON {
-				err := printer.PrintJSON(dbBranch)
-				if err != nil {
-					return err
-				}
-			} else {
-				fmt.Printf("Branch %s was successfully created!\n", cmdutil.BoldBlue(dbBranch.Name))
-			}
-
-			return nil
-		},
+		Use:   "branch <command>",
+		Short: "Create, delete, and manage branches",
 	}
 
-	cmd.Flags().StringVar(&createReq.Branch.Notes, "notes", "", "notes for the database branch")
-	cmd.Flags().StringVar(&createReq.Branch.ParentBranch, "from", "", "branch to be created from")
-	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
-
-	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization, "The organization for the current user")
+	cmd.PersistentFlags().StringVar(&cfg.Organization, "org", cfg.Organization,
+		"The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 
+	cmd.AddCommand(CreateCmd(cfg))
 	cmd.AddCommand(ListCmd(cfg))
 	cmd.AddCommand(StatusCmd(cfg))
 	cmd.AddCommand(DeleteCmd(cfg))

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -1,0 +1,88 @@
+package branch
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/browser"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func CreateCmd(cfg *config.Config) *cobra.Command {
+	createReq := &ps.CreateDatabaseBranchRequest{
+		Branch: new(ps.DatabaseBranch),
+	}
+
+	cmd := &cobra.Command{
+		Use:     "create <source-database> <branch> [options]",
+		Short:   "Create a new branch from a database",
+		Args:    cmdutil.RequiredArgs("source-database", "branch"),
+		Aliases: []string{"b"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			source := args[0]
+			branch := args[1]
+
+			// Simplest case, the names are equivalent
+			if source == branch {
+				return fmt.Errorf("A branch named '%s' already exists", branch)
+			}
+
+			createReq.Database = source
+			createReq.Branch.Name = branch
+			createReq.Organization = cfg.Organization
+
+			web, err := cmd.Flags().GetBool("web")
+			if err != nil {
+				return err
+			}
+
+			if web {
+				fmt.Println("🌐  Redirecting you to branch a database in your web browser.")
+				err := browser.OpenURL(fmt.Sprintf(
+					"%s/%s/%s/branches?name=%s&notes=%s&showDialog=true",
+					cmdutil.ApplicationURL, cfg.Organization, source, url.QueryEscape(createReq.Branch.Name), url.QueryEscape(createReq.Branch.Notes),
+				))
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+
+			client, err := cfg.NewClientFromConfig()
+			if err != nil {
+				return err
+			}
+
+			end := cmdutil.PrintProgress(fmt.Sprintf("Creating branch from %s...", cmdutil.BoldBlue(source)))
+			defer end()
+			dbBranch, err := client.DatabaseBranches.Create(ctx, createReq)
+			if err != nil {
+				return err
+			}
+
+			end()
+			if cfg.OutputJSON {
+				err := printer.PrintJSON(dbBranch)
+				if err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("Branch %s was successfully created!\n", cmdutil.BoldBlue(dbBranch.Name))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&createReq.Branch.Notes, "notes", "", "notes for the database branch")
+	cmd.Flags().StringVar(&createReq.Branch.ParentBranch, "from", "", "branch to be created from")
+	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
+
+	return cmd
+}


### PR DESCRIPTION
closes: https://github.com/planetscale/project-big-bang/issues/170

To make things standardized across all commands, let's make `pscale branch` be `pscale branch create` instead.

```
$ pscale branch --help
Create, delete, and manage branches

Usage:
  pscale branch [command]

Available Commands:
  create         Create a new branch from a database
  delete         Delete a branch from a database
  get            Get a specific branch of a database
  list           List all branches of a database
  request-deploy Requests a deploy for a specific schema snapshot ID
  status         Check the status of a branch of a database
  switch         Switches the current project to use the specified branch
```

```
$ pscale branch create --help
Create a new branch from a database

Usage:
  pscale branch create <source-database> <branch> [options] [flags]

Aliases:
  create, b
```