### PR TITLE
Update file permissions for access token files

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -146,7 +146,7 @@ func writeAccessToken(ctx context.Context, accessToken string) error {
 	}
 
 	tokenBytes := []byte(accessToken)
-	err = ioutil.WriteFile(tokenPath, tokenBytes, 0666)
+	err = ioutil.WriteFile(tokenPath, tokenBytes, 0600)
 	if err != nil {
 		return errors.Wrap(err, "error writing token")
 	}


### PR DESCRIPTION
Changes the permission for files that we write to be `0600` instead of `0666`. 