### PR TITLE
Begin using `ObjectPrinter` for outputting PlanetScale objects

### DIFF
--- a/internal/cmd/org/list.go
+++ b/internal/cmd/org/list.go
@@ -36,7 +36,10 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			err = printer.PrintOutput(cfg.OutputJSON, newOrganizationSlicePrinter(orgs))
+			err = printer.PrintOutput(cfg.OutputJSON, &printer.ObjectPrinter{
+				Source:  orgs,
+				Printer: newOrganizationSlicePrinter(orgs),
+			})
 			if err != nil {
 				return err
 			}

--- a/internal/printer/backup.go
+++ b/internal/printer/backup.go
@@ -17,8 +17,15 @@ type Backup struct {
 	CompletedAt int64  `header:"completed_at,timestamp(ms|utc|human)" json:"completed_at"`
 }
 
-// Returns a struct that prints out the various fields of a branch model.
-func NewBackupPrinter(backup *ps.Backup) *Backup {
+func NewBackupPrinter(backup *ps.Backup) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  backup,
+		Printer: newBackupPrinter(backup),
+	}
+}
+
+// newBackupPrinter Returns a struct that prints out the various fields of a branch model.
+func newBackupPrinter(backup *ps.Backup) *Backup {
 	return &Backup{
 		Name:        backup.Name,
 		State:       backup.State,
@@ -31,10 +38,17 @@ func NewBackupPrinter(backup *ps.Backup) *Backup {
 	}
 }
 
-func NewBackupSlicePrinter(backups []*ps.Backup) []*Backup {
+func NewBackupSlicePrinter(backups []*ps.Backup) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  backups,
+		Printer: newBackupSlicePrinter(backups),
+	}
+}
+
+func newBackupSlicePrinter(backups []*ps.Backup) []*Backup {
 	bs := make([]*Backup, 0, len(backups))
 	for _, backup := range backups {
-		bs = append(bs, NewBackupPrinter(backup))
+		bs = append(bs, newBackupPrinter(backup))
 	}
 	return bs
 }

--- a/internal/printer/database.go
+++ b/internal/printer/database.go
@@ -14,9 +14,9 @@ type Database struct {
 	Notes     string `header:"notes" json:"notes"`
 }
 
-// NewDatabasePrinter returns a struct that prints out the various fields of a
+// newDatabasePrinter returns a struct that prints out the various fields of a
 // database model.
-func NewDatabasePrinter(db *ps.Database) *Database {
+func newDatabasePrinter(db *ps.Database) *Database {
 	return &Database{
 		Name:      db.Name,
 		Notes:     db.Notes,
@@ -25,12 +25,26 @@ func NewDatabasePrinter(db *ps.Database) *Database {
 	}
 }
 
-// NewDatabaseSlicePrinter returns a slice of printable databases.
-func NewDatabaseSlicePrinter(databases []*ps.Database) []*Database {
+func NewDatabasePrinter(db *ps.Database) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  db,
+		Printer: newDatabasePrinter(db),
+	}
+}
+
+func NewDatabaseSlicePrinter(dbs []*ps.Database) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  dbs,
+		Printer: newDatabaseSlicePrinter(dbs),
+	}
+}
+
+// newDatabaseSlicePrinter returns a slice of printable databases.
+func newDatabaseSlicePrinter(databases []*ps.Database) []*Database {
 	dbs := make([]*Database, 0, len(databases))
 
 	for _, db := range databases {
-		dbs = append(dbs, NewDatabasePrinter(db))
+		dbs = append(dbs, newDatabasePrinter(db))
 	}
 
 	return dbs

--- a/internal/printer/database_branch.go
+++ b/internal/printer/database_branch.go
@@ -15,9 +15,16 @@ type DatabaseBranch struct {
 	Notes        string `header:"notes" json:"notes"`
 }
 
+func NewDatabaseBranchPrinter(db *ps.DatabaseBranch) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  db,
+		Printer: newDatabaseBranchPrinter(db),
+	}
+}
+
 // NewDatabaseBranchPrinter returns a struct that prints out the various fields of a
 // database model.
-func NewDatabaseBranchPrinter(db *ps.DatabaseBranch) *DatabaseBranch {
+func newDatabaseBranchPrinter(db *ps.DatabaseBranch) *DatabaseBranch {
 	return &DatabaseBranch{
 		Name:         db.Name,
 		Notes:        db.Notes,
@@ -28,11 +35,18 @@ func NewDatabaseBranchPrinter(db *ps.DatabaseBranch) *DatabaseBranch {
 	}
 }
 
-func NewDatabaseBranchSlicePrinter(branches []*ps.DatabaseBranch) []*DatabaseBranch {
+func NewDatabaseBranchSlicePrinter(branches []*ps.DatabaseBranch) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  branches,
+		Printer: newDatabaseBranchSlicePrinter(branches),
+	}
+}
+
+func newDatabaseBranchSlicePrinter(branches []*ps.DatabaseBranch) []*DatabaseBranch {
 	bs := make([]*DatabaseBranch, 0, len(branches))
 
 	for _, db := range branches {
-		bs = append(bs, NewDatabaseBranchPrinter(db))
+		bs = append(bs, newDatabaseBranchPrinter(db))
 	}
 
 	return bs

--- a/internal/printer/database_branch_status.go
+++ b/internal/printer/database_branch_status.go
@@ -10,7 +10,14 @@ type DatabaseBranchStatus struct {
 	Password    string `header:"password" json:"password"`
 }
 
-func NewDatabaseBranchStatusPrinter(status *ps.DatabaseBranchStatus) *DatabaseBranchStatus {
+func NewDatabaseBranchStatusPrinter(status *ps.DatabaseBranchStatus) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  status,
+		Printer: newDatabaseBranchStatusPrinter(status),
+	}
+}
+
+func newDatabaseBranchStatusPrinter(status *ps.DatabaseBranchStatus) *DatabaseBranchStatus {
 	var ready = "ready"
 	if !status.Ready {
 		ready = "not ready"

--- a/internal/printer/deploy_request.go
+++ b/internal/printer/deploy_request.go
@@ -21,7 +21,14 @@ type DeployRequest struct {
 	ClosedAt  *int64 `header:"closed_at,timestamp(ms|utc|human),-" json:"closed_at"`
 }
 
-func NewDeployRequestPrinter(dr *planetscale.DeployRequest) *DeployRequest {
+func NewDeployRequestPrinter(dr *planetscale.DeployRequest) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  dr,
+		Printer: newDeployRequestPrinter(dr),
+	}
+}
+
+func newDeployRequestPrinter(dr *planetscale.DeployRequest) *DeployRequest {
 	return &DeployRequest{
 		ID:                  dr.ID,
 		Branch:              dr.Branch,
@@ -37,11 +44,18 @@ func NewDeployRequestPrinter(dr *planetscale.DeployRequest) *DeployRequest {
 	}
 }
 
-func NewDeployRequestSlicePrinter(deployRequests []*planetscale.DeployRequest) []*DeployRequest {
+func NewDeployRequestSlicePrinter(deployRequests []*planetscale.DeployRequest) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  deployRequests,
+		Printer: newDeployRequestSlicePrinter(deployRequests),
+	}
+}
+
+func newDeployRequestSlicePrinter(deployRequests []*planetscale.DeployRequest) []*DeployRequest {
 	requests := make([]*DeployRequest, 0, len(deployRequests))
 
 	for _, dr := range deployRequests {
-		requests = append(requests, NewDeployRequestPrinter(dr))
+		requests = append(requests, newDeployRequestPrinter(dr))
 	}
 
 	return requests

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -9,13 +9,20 @@ import (
 	"github.com/lensesio/tableprinter"
 )
 
+// ObjectPrinter is responsible for encapsulating the source object and also
+// a special printer for outputting it in a tabular format.
+type ObjectPrinter struct {
+	Source  interface{}
+	Printer interface{}
+}
+
 // PrintOutput prints the output as JSON or in a table format.
-func PrintOutput(isJSON bool, obj interface{}) error {
+func PrintOutput(isJSON bool, obj *ObjectPrinter) error {
 	if isJSON {
-		return PrintJSON(obj)
+		return PrintJSON(obj.Source)
 	}
 
-	tableprinter.Print(os.Stdout, obj)
+	tableprinter.Print(os.Stdout, obj.Printer)
 	return nil
 }
 

--- a/internal/printer/schema_snapshot.go
+++ b/internal/printer/schema_snapshot.go
@@ -13,9 +13,16 @@ type SchemaSnapshot struct {
 	UpdatedAt int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
 }
 
-// NewSchemaSnapshotPrinter returns a struct that prints out the various fields
+func NewSchemaSnapshotPrinter(ss *planetscale.SchemaSnapshot) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  ss,
+		Printer: newSchemaSnapshotPrinter(ss),
+	}
+}
+
+// newSchemaSnapshotPrinter returns a struct that prints out the various fields
 // of a schema snapshot model.
-func NewSchemaSnapshotPrinter(ss *planetscale.SchemaSnapshot) *SchemaSnapshot {
+func newSchemaSnapshotPrinter(ss *planetscale.SchemaSnapshot) *SchemaSnapshot {
 	return &SchemaSnapshot{
 		ID:        ss.ID,
 		Name:      ss.Name,
@@ -24,11 +31,18 @@ func NewSchemaSnapshotPrinter(ss *planetscale.SchemaSnapshot) *SchemaSnapshot {
 	}
 }
 
-func NewSchemaSnapshotSlicePrinter(schemaSnapshots []*ps.SchemaSnapshot) []*SchemaSnapshot {
+func NewSchemaSnapshotSlicePrinter(schemaSnapshots []*ps.SchemaSnapshot) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  schemaSnapshots,
+		Printer: newSchemaSnapshotSlicePrinter(schemaSnapshots),
+	}
+}
+
+func newSchemaSnapshotSlicePrinter(schemaSnapshots []*ps.SchemaSnapshot) []*SchemaSnapshot {
 	snapshots := make([]*SchemaSnapshot, 0, len(schemaSnapshots))
 
 	for _, ss := range schemaSnapshots {
-		snapshots = append(snapshots, NewSchemaSnapshotPrinter(ss))
+		snapshots = append(snapshots, newSchemaSnapshotPrinter(ss))
 	}
 
 	return snapshots

--- a/internal/printer/service_token.go
+++ b/internal/printer/service_token.go
@@ -11,20 +11,34 @@ type ServiceToken struct {
 	Token string `header:"token" json:"token"`
 }
 
-// NewServiceTokenPrinter returns a struct that prints out the various fields
+func NewServiceTokenPrinter(st *planetscale.ServiceToken) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  st,
+		Printer: newServiceTokenPrinter(st),
+	}
+}
+
+// newServiceTokenPrinter returns a struct that prints out the various fields
 // of a schema snapshot model.
-func NewServiceTokenPrinter(st *planetscale.ServiceToken) *ServiceToken {
+func newServiceTokenPrinter(st *planetscale.ServiceToken) *ServiceToken {
 	return &ServiceToken{
 		Name:  st.ID,
 		Token: st.Token,
 	}
 }
 
-func NewServiceTokenSlicePrinter(serviceTokens []*ps.ServiceToken) []*ServiceToken {
+func NewServiceTokenSlicePrinter(serviceTokens []*ps.ServiceToken) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  serviceTokens,
+		Printer: newServiceTokenSlicePrinter(serviceTokens),
+	}
+}
+
+func newServiceTokenSlicePrinter(serviceTokens []*ps.ServiceToken) []*ServiceToken {
 	snapshots := make([]*ServiceToken, 0, len(serviceTokens))
 
 	for _, st := range serviceTokens {
-		snapshots = append(snapshots, NewServiceTokenPrinter(st))
+		snapshots = append(snapshots, newServiceTokenPrinter(st))
 	}
 
 	return snapshots

--- a/internal/printer/service_token_access.go
+++ b/internal/printer/service_token_access.go
@@ -10,9 +10,16 @@ type ServiceTokenAccess struct {
 	Accesses []string `header:"accesses" json:"accesses"`
 }
 
-// NewServiceTokenPrinter returns a struct that prints out the various fields
+func NewServiceTokenAccessPrinter(st []*planetscale.ServiceTokenAccess) *ObjectPrinter {
+	return &ObjectPrinter{
+		Source:  st,
+		Printer: newServiceTokenAccessPrinter(st),
+	}
+}
+
+// newServiceTokenPrinter returns a struct that prints out the various fields
 // of a schema snapshot model.
-func NewServiceTokenAccessPrinter(st []*planetscale.ServiceTokenAccess) []*ServiceTokenAccess {
+func newServiceTokenAccessPrinter(st []*planetscale.ServiceTokenAccess) []*ServiceTokenAccess {
 	data := map[string]*ServiceTokenAccess{}
 	for _, v := range st {
 		if db, ok := data[v.Resource.Name]; ok {


### PR DESCRIPTION
This pull request begins wrapping our PlanetScale models using `ObjectPrinter`. We will begin outputting the `Source` using JSON, so we will be able to keep our JSON payloads in their full-size, but we can selectively choose which fields we output to the tables that we show to the end-user. Next step will be to flesh out the API payloads in `planetscale-go` a lot more. 