### PR TITLE
cmdutil: the color package handles TTY gracefully

### DIFF
--- a/internal/cmdutil/terminal.go
+++ b/internal/cmdutil/terminal.go
@@ -40,18 +40,12 @@ func PrintProgress(message string) func() {
 
 // BoldBlue returns a string formatted with blue and bold.
 func BoldBlue(msg string) string {
-	if !IsTTY {
-		return msg
-	}
 	// the 'color' package already handles IsTTY gracefully
 	return color.New(color.FgBlue).Add(color.Bold).Sprint(msg)
 }
 
 // Bold returns a string formatted with bold.
 func Bold(msg string) string {
-	if !IsTTY {
-		return msg
-	}
 	// the 'color' package already handles IsTTY gracefully
 	return color.New(color.Bold).Sprint(msg)
 }


### PR DESCRIPTION
We don't have to check for TTY because the `color` package handles it
already behind the scenes.

/cc @iheanyi 