### PR TITLE
cmd: improve "Error: Not Found" messages

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -106,7 +106,12 @@ func writeDefaultOrganization(ctx context.Context, accessToken, authURL string) 
 
 	orgs, err := client.Organizations.List(ctx)
 	if err != nil {
-		return err
+		switch cmdutil.ErrCode(err) {
+		case planetscale.ErrResponseMalformed:
+			return cmdutil.MalformedError(err)
+		default:
+			return errors.Wrap(err, "error listing organizations")
+		}
 	}
 
 	if len(orgs) > 0 {

--- a/internal/cmd/backup/create.go
+++ b/internal/cmd/backup/create.go
@@ -40,8 +40,10 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
+
 					return cmdutil.MalformedError(err)
 				default:
 					return err

--- a/internal/cmd/backup/delete.go
+++ b/internal/cmd/backup/delete.go
@@ -74,7 +74,8 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in branch %s of %s\n", cmdutil.BoldBlue(backup), cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)\n",
+						cmdutil.BoldBlue(backup), cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/backup/get.go
+++ b/internal/cmd/backup/get.go
@@ -61,7 +61,8 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in branch %s of %s\n", cmdutil.BoldBlue(backup), cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)\n",
+						cmdutil.BoldBlue(backup), cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/backup/list.go
+++ b/internal/cmd/backup/list.go
@@ -55,7 +55,8 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)\n",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -66,7 +66,8 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n", cmdutil.BoldBlue(source), cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("source database %s does not exist in organization %s\n",
+						cmdutil.BoldBlue(source), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/branch/delete.go
+++ b/internal/cmd/branch/delete.go
@@ -72,7 +72,8 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n", cmdutil.BoldBlue(source), cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("source database %s does not exist in organization %s\n",
+						cmdutil.BoldBlue(source), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/branch/get.go
+++ b/internal/cmd/branch/get.go
@@ -53,7 +53,8 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(source))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(source), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/branch/list.go
+++ b/internal/cmd/branch/list.go
@@ -53,7 +53,8 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n", cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("database %s does not exist in organization %s\n",
+						cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/branch/status.go
+++ b/internal/cmd/branch/status.go
@@ -39,7 +39,8 @@ func StatusCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s", cmdutil.BoldBlue(branch), cmdutil.BoldBlue(source))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(source), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -54,7 +54,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in\n", cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("organization %s does not exist\n", cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/database/delete.go
+++ b/internal/cmd/database/delete.go
@@ -70,7 +70,8 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n", cmdutil.BoldBlue(name), cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("database %s does not exist in organization %s\n",
+						cmdutil.BoldBlue(name), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/database/get.go
+++ b/internal/cmd/database/get.go
@@ -51,7 +51,8 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n", cmdutil.BoldBlue(name), cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("database %s does not exist in organization %s\n",
+						cmdutil.BoldBlue(name), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/database/list.go
+++ b/internal/cmd/database/list.go
@@ -50,7 +50,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist\n", cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("organization %s does not exist\n", cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/deployrequest/close.go
+++ b/internal/cmd/deployrequest/close.go
@@ -41,7 +41,7 @@ func CloseCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s/%s does not exist in %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(number), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/deployrequest/create.go
+++ b/internal/cmd/deployrequest/create.go
@@ -44,7 +44,7 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n",
+					return fmt.Errorf("database %s does not exist in %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -42,7 +42,7 @@ func DeployCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s/%s does not exist in %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(number), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/deployrequest/diff.go
+++ b/internal/cmd/deployrequest/diff.go
@@ -55,7 +55,7 @@ func DiffCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s/%s does not exist in %s\n",
+					return fmt.Errorf("deploy rquest '%s/%s' does not exist in organization %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(number), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/deployrequest/list.go
+++ b/internal/cmd/deployrequest/list.go
@@ -54,7 +54,7 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/deployrequest/review.go
+++ b/internal/cmd/deployrequest/review.go
@@ -59,7 +59,7 @@ func ReviewCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s/%s does not exist in %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(number), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/deployrequest/show.go
+++ b/internal/cmd/deployrequest/show.go
@@ -52,7 +52,7 @@ func ShowCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s/%s does not exist in %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
 						cmdutil.BoldBlue(database), cmdutil.BoldBlue(number), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/org/switch.go
+++ b/internal/cmd/org/switch.go
@@ -44,7 +44,7 @@ func SwitchCmd(cfg *config.Config) *cobra.Command {
 				if err != nil {
 					switch cmdutil.ErrCode(err) {
 					case planetscale.ErrNotFound:
-						return fmt.Errorf("%s does not exist\n", cmdutil.BoldBlue(orgName))
+						return fmt.Errorf("organization %s does not exist\n", cmdutil.BoldBlue(orgName))
 					case planetscale.ErrResponseMalformed:
 						return cmdutil.MalformedError(err)
 					default:

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -117,8 +117,8 @@ second argument:
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s",
-						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/snapshot/create.go
+++ b/internal/cmd/snapshot/create.go
@@ -37,8 +37,8 @@ func CreateCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s",
-						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/snapshot/get.go
+++ b/internal/cmd/snapshot/get.go
@@ -36,7 +36,7 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("snapshot id %q does not exist", cmdutil.BoldBlue(id))
+					return fmt.Errorf("snapshot id %s does not exist (organization: %s)", cmdutil.BoldBlue(id), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/snapshot/list.go
+++ b/internal/cmd/snapshot/list.go
@@ -39,8 +39,8 @@ func ListCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n",
-						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database))
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						cmdutil.BoldBlue(branch), cmdutil.BoldBlue(database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/snapshot/request_deploy.go
+++ b/internal/cmd/snapshot/request_deploy.go
@@ -34,7 +34,8 @@ func RequestDeployCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("snapshot id %q does not exist", cmdutil.BoldBlue(id))
+					return fmt.Errorf("snapshot id %s does not exist (organization: %s)",
+						cmdutil.BoldBlue(id), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/token/add-access.go
+++ b/internal/cmd/token/add-access.go
@@ -50,7 +50,7 @@ For a complete list of the access permissions that can be granted to a token, se
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s\n",
 						cmdutil.BoldBlue(cfg.Database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/token/delete-access.go
+++ b/internal/cmd/token/delete-access.go
@@ -41,7 +41,7 @@ func DeleteAccessCmd(cfg *config.Config) *cobra.Command {
 			if err := client.ServiceTokens.DeleteAccess(ctx, req); err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n",
+					return fmt.Errorf("database %s or token does not exist in organization %s\n",
 						cmdutil.BoldBlue(cfg.Database), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)

--- a/internal/cmd/token/delete.go
+++ b/internal/cmd/token/delete.go
@@ -38,7 +38,8 @@ func DeleteCmd(cfg *config.Config) *cobra.Command {
 			if err := client.ServiceTokens.Delete(ctx, req); err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("token does not exist in %s\n", cmdutil.BoldBlue(cfg.Organization))
+					return fmt.Errorf("token does not exist in organization %s\n",
+						cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)
 				default:

--- a/internal/cmd/token/get-access.go
+++ b/internal/cmd/token/get-access.go
@@ -40,7 +40,7 @@ func GetCmd(cfg *config.Config) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("%s does not exist in %s\n",
+					return fmt.Errorf("access %s does not exist in organization %s\n",
 						cmdutil.BoldBlue(name), cmdutil.BoldBlue(cfg.Organization))
 				case planetscale.ErrResponseMalformed:
 					return cmdutil.MalformedError(err)


### PR DESCRIPTION
This PR improves all generic `Error: Not Found` messages with more detailed and useful messages. Also in every single message, we also include the organization, to make sure the user didn't accidentally execute the CLI command on a different organization.

depends on: #147

closes: planetscale/project-big-bang#163