### PR TITLE
cmd: print errors in JSON format if --format is set to JSON

### DIFF
--- a/cmd/pscale/main.go
+++ b/cmd/pscale/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/planetscale/cli/internal/cmd"
@@ -14,7 +15,7 @@ var (
 
 func main() {
 	if err := cmd.Execute(version, commit, date); err != nil {
-		// we don't print the error, because cobra does it for us
+		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -64,6 +64,7 @@ func Execute(ver, commit, buildDate string) error {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config",
 		"", "Config file (default is $HOME/.config/planetscale/pscale.yml)")
 	rootCmd.SilenceUsage = true
+	rootCmd.SilenceErrors = true
 
 	v := version.Format(ver, commit, buildDate)
 	rootCmd.SetVersionTemplate(v)
@@ -137,7 +138,17 @@ func Execute(ver, commit, buildDate string) error {
 	rootCmd.AddCommand(token.TokenCmd(ch))
 	rootCmd.AddCommand(version.VersionCmd(ch, ver, commit, buildDate))
 
-	return rootCmd.Execute()
+	err = rootCmd.Execute()
+	if err != nil {
+		switch format {
+		case printer.JSON:
+			return fmt.Errorf(`{"error": "%s"}`, err)
+		default:
+			return fmt.Errorf("Error: %s", err)
+		}
+	}
+
+	return nil
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
This PR is a minor improvement to change the output of an error if the `--format` flag is set. Instead of printing it as a single line, we print the error in JSON format if the `--format json` flag is enabled.

Before:
```
$ pscale db list --format json
Error: not authenticated yet. Please run 'pscale auth login'
```

After:

```
$ pscale db list --format json
{"error": "not authenticated yet. Please run 'pscale auth login'"}
```

We still exist with exit status `1`, of course.

I checked other CLI's, and some print in the human-readable format even if you set the format output to JSON, such as `gcloud`.  Hence, I'm OK closing this issue if you think we should output in a human-readable format.
