### PR TITLE
Use new clients and proxy remote source to connect with DBSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.17.0
-	github.com/planetscale/sql-proxy v0.2.0
+	github.com/planetscale/planetscale-go v0.18.0
+	github.com/planetscale/sql-proxy v0.3.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -247,11 +247,10 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetscale/planetscale-go v0.9.0/go.mod h1:R+07GStW2oGSfeTwWoplnimSEFzxIzEofOHgPFxArg0=
-github.com/planetscale/planetscale-go v0.17.0 h1:zrLZAWoi2SREGCsXtaKp1CXKwMdm5qObdCYBMpOVqZA=
-github.com/planetscale/planetscale-go v0.17.0/go.mod h1:R+07GStW2oGSfeTwWoplnimSEFzxIzEofOHgPFxArg0=
-github.com/planetscale/sql-proxy v0.2.0 h1:E6BDEYSP+t68kTxnyCNEMowJfiyGcJUTYplY4Q+VMag=
-github.com/planetscale/sql-proxy v0.2.0/go.mod h1:ZEBm1sist+VFnuxx0lWcMSKq/NfIWRqn2uDIfCERcI4=
+github.com/planetscale/planetscale-go v0.18.0 h1:x1T+hmiCjy0UGEvwsV85itwaHriU9tNbWd3a9KZnnE0=
+github.com/planetscale/planetscale-go v0.18.0/go.mod h1:R+07GStW2oGSfeTwWoplnimSEFzxIzEofOHgPFxArg0=
+github.com/planetscale/sql-proxy v0.3.1 h1:TH5FAspsy43Z8xhn7G1RU7XLpSvARHHVMUXqFzwHIas=
+github.com/planetscale/sql-proxy v0.3.1/go.mod h1:kM7r4GMseGJ1UP1F96PEPPCvEYM3Npqp0WDvtmYTZtk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/internal/proxyutil/remotesource.go
+++ b/internal/proxyutil/remotesource.go
@@ -40,5 +40,9 @@ func (r *RemoteCertSource) Cert(ctx context.Context, org, db, branch string) (*p
 		ClientCert: cert.ClientCert,
 		CACert:     cert.CACert,
 		RemoteAddr: cert.RemoteAddr,
+		Ports: proxy.RemotePorts{
+			Proxy: cert.Ports.Proxy,
+			MySQL: cert.Ports.MySQL,
+		},
 	}, nil
 }

--- a/vendor/github.com/planetscale/planetscale-go/planetscale/certs.go
+++ b/vendor/github.com/planetscale/planetscale-go/planetscale/certs.go
@@ -31,6 +31,12 @@ type Cert struct {
 	ClientCert tls.Certificate
 	CACert     *x509.Certificate
 	RemoteAddr string
+	Ports      RemotePorts
+}
+
+type RemotePorts struct {
+	Proxy int
+	MySQL int
 }
 
 type certificatesService struct {
@@ -88,9 +94,10 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 	}
 
 	var cr struct {
-		Certificate      string `json:"certificate"`
-		CertificateChain string `json:"certificate_chain"`
-		RemoteAddr       string `json:"remote_addr"`
+		Certificate      string         `json:"certificate"`
+		CertificateChain string         `json:"certificate_chain"`
+		RemoteAddr       string         `json:"remote_addr"`
+		Ports            map[string]int `json:"ports"`
 	}
 
 	err = c.client.do(ctx, req, &cr)
@@ -119,6 +126,10 @@ func (c *certificatesService) Create(ctx context.Context, r *CreateCertificateRe
 		ClientCert: clientCert,
 		CACert:     caCert,
 		RemoteAddr: cr.RemoteAddr,
+		Ports: RemotePorts{
+			Proxy: cr.Ports["proxy"],
+			MySQL: cr.Ports["mysql-tls"],
+		},
 	}, nil
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -90,10 +90,10 @@ github.com/pkg/browser
 # github.com/pkg/errors v0.9.1
 ## explicit
 github.com/pkg/errors
-# github.com/planetscale/planetscale-go v0.17.0
+# github.com/planetscale/planetscale-go v0.18.0
 ## explicit
 github.com/planetscale/planetscale-go/planetscale
-# github.com/planetscale/sql-proxy v0.2.0
+# github.com/planetscale/sql-proxy v0.3.1
 ## explicit
 github.com/planetscale/sql-proxy/proxy
 github.com/planetscale/sql-proxy/sigutil


### PR DESCRIPTION
This is odds and ends bumping for the CLI that allows us to connect to DBSS.

We will also need to remove the fact that we set up a password at all, as there are no longer passwords. That doesn't break `pscale shell` though, so we can do it later. 