### PR TITLE
cmd/backup: add unit tests

### DIFF
--- a/internal/cmd/backup/backup.go
+++ b/internal/cmd/backup/backup.go
@@ -2,13 +2,11 @@ package backup
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/lensesio/tableprinter"
 	"github.com/planetscale/cli/internal/cmdutil"
-	"github.com/planetscale/cli/internal/printer"
 	"github.com/spf13/cobra"
 
 	ps "github.com/planetscale/planetscale-go/planetscale"
@@ -50,10 +48,6 @@ type Backup struct {
 
 func (b *Backup) MarshalJSON() ([]byte, error) {
 	return json.MarshalIndent(b.orig, "", "  ")
-}
-
-func (b *Backup) String() string {
-	return fmt.Sprintf("Backup %s was successfully created!\n", printer.BoldBlue(b.Name))
 }
 
 func (b Backups) String() string {

--- a/internal/cmd/backup/create.go
+++ b/internal/cmd/backup/create.go
@@ -28,7 +28,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			createReq.Branch = branch
 			createReq.Organization = ch.Config.Organization
 
-			client, err := ch.Config.NewClientFromConfig()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/backup/create_test.go
+++ b/internal/cmd/backup/create_test.go
@@ -1,0 +1,61 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackup_CreateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	res := &ps.Backup{Name: "foo"}
+
+	svc := &mock.BackupsService{
+		CreateFn: func(ctx context.Context, req *ps.CreateBackupRequest) (*ps.Backup, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/cmd/backup/delete.go
+++ b/internal/cmd/backup/delete.go
@@ -30,7 +30,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			branch := args[1]
 			backup := args[2]
 
-			client, err := ch.Config.NewClientFromConfig()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/backup/delete_test.go
+++ b/internal/cmd/backup/delete_test.go
@@ -1,0 +1,67 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackup_DeleteCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	backup := "mybackup"
+
+	svc := &mock.BackupsService{
+		DeleteFn: func(ctx context.Context, req *ps.DeleteBackupRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Backup, qt.Equals, backup)
+
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := DeleteCmd(ch)
+	cmd.SetArgs([]string{db, branch, backup, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
+
+	res := map[string]string{
+		"result": "backup deleted",
+		"backup": backup,
+		"branch": branch,
+	}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/cmd/backup/list.go
+++ b/internal/cmd/backup/list.go
@@ -39,7 +39,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
-			client, err := ch.Config.NewClientFromConfig()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/backup/list_test.go
+++ b/internal/cmd/backup/list_test.go
@@ -1,0 +1,76 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackup_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	resp := []*ps.Backup{
+		{Name: "foo"},
+		{Name: "bar"},
+	}
+
+	svc := &mock.BackupsService{
+		ListFn: func(ctx context.Context, req *ps.ListBackupsRequest) ([]*ps.Backup, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+
+			return resp, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := ListCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+
+	backups := []*Backup{
+		{
+			Name: "foo",
+			orig: resp[0],
+		},
+		{
+			Name: "bar",
+			orig: resp[1],
+		},
+	}
+
+	c.Assert(buf.String(), qt.JSONEquals, backups)
+}

--- a/internal/cmd/backup/show.go
+++ b/internal/cmd/backup/show.go
@@ -38,7 +38,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
-			client, err := ch.Config.NewClientFromConfig()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/backup/show_test.go
+++ b/internal/cmd/backup/show_test.go
@@ -1,0 +1,63 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackup_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	backup := "mybackup"
+
+	res := &ps.Backup{Name: "foo"}
+
+	svc := &mock.BackupsService{
+		GetFn: func(ctx context.Context, req *ps.GetBackupRequest) (*ps.Backup, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Backup, qt.Equals, backup)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch, backup})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/mock/backup.go
+++ b/internal/mock/backup.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+type BackupsService struct {
+	CreateFn        func(context.Context, *ps.CreateBackupRequest) (*ps.Backup, error)
+	CreateFnInvoked bool
+
+	GetFn        func(context.Context, *ps.GetBackupRequest) (*ps.Backup, error)
+	GetFnInvoked bool
+
+	ListFn        func(context.Context, *ps.ListBackupsRequest) ([]*ps.Backup, error)
+	ListFnInvoked bool
+
+	DeleteFn        func(context.Context, *ps.DeleteBackupRequest) error
+	DeleteFnInvoked bool
+}
+
+func (b *BackupsService) Create(ctx context.Context, req *ps.CreateBackupRequest) (*ps.Backup, error) {
+	b.CreateFnInvoked = true
+	return b.CreateFn(ctx, req)
+}
+
+func (b *BackupsService) List(ctx context.Context, req *ps.ListBackupsRequest) ([]*ps.Backup, error) {
+	b.ListFnInvoked = true
+	return b.ListFn(ctx, req)
+}
+
+func (b *BackupsService) Get(ctx context.Context, req *ps.GetBackupRequest) (*ps.Backup, error) {
+	b.GetFnInvoked = true
+	return b.GetFn(ctx, req)
+}
+
+func (b *BackupsService) Delete(ctx context.Context, req *ps.DeleteBackupRequest) error {
+	b.DeleteFnInvoked = true
+	return b.DeleteFn(ctx, req)
+}


### PR DESCRIPTION
This PR extends the unit tests for the `backup` subcommand.

```
$ go test -v
=== RUN   TestBackup_CreateCmd
--- PASS: TestBackup_CreateCmd (0.00s)
=== RUN   TestBackup_DeleteCmd
--- PASS: TestBackup_DeleteCmd (0.00s)
=== RUN   TestBackup_ListCmd
--- PASS: TestBackup_ListCmd (0.00s)
=== RUN   TestBackup_ShowCmd
--- PASS: TestBackup_ShowCmd (0.00s)
PASS
ok      github.com/planetscale/cli/internal/cmd/backup  0.137s
```

/xref planetscale/project-big-bang#147
