### PR TITLE
chmod 0600 access-token

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -153,7 +153,7 @@ func writeAccessToken(ctx context.Context, accessToken string) error {
 	}
 
 	tokenBytes := []byte(accessToken)
-	err = ioutil.WriteFile(tokenPath, tokenBytes, 0600)
+	err = ioutil.WriteFile(tokenPath, tokenBytes, config.TokenFileMode)
 	if err != nil {
 		return errors.Wrap(err, "error writing token")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ const (
 	defaultConfigPath = "~/.config/planetscale"
 	projectConfigName = ".pscale.yml"
 	configName        = "pscale.yml"
+	TokenFileMode     = 0600
 )
 
 // Config is dynamically sourced from various files and environment variables.
@@ -41,12 +42,18 @@ func New() (*Config, error) {
 		return nil, err
 	}
 
-	_, err = os.Stat(tokenPath)
+	stat, err := os.Stat(tokenPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			log.Fatal(err)
 		}
 	} else {
+		if stat.Mode()&^TokenFileMode != 0 {
+			err = os.Chmod(tokenPath, TokenFileMode)
+			if err != nil {
+				log.Printf("Unable to change %v file mode to 0%o: %v", tokenPath, TokenFileMode, err)
+			}
+		}
 		accessToken, err = ioutil.ReadFile(tokenPath)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
#139 changed the default file mode for `access-token` to 0600 (not readable by anyone except the owner).  That's good.  But any existing file will still be whatever the old `mode&^umask` was, generally 0644.  That's bad.

So this change silently resets the mode on the token file to 0600 if necessary any time the config is loaded.