### PR TITLE
proxy: use a custom logger that outputs errors by default

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -17,7 +17,6 @@ import (
 	"github.com/planetscale/sql-proxy/proxy"
 	"github.com/planetscale/sql-proxy/sigutil"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 func ConnectCmd(ch *cmdutil.Helper) *cobra.Command {
@@ -98,10 +97,7 @@ argument:
 				LocalAddr:  localAddr,
 				RemoteAddr: flags.remoteAddr,
 				Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
-			}
-
-			if !flags.debug {
-				proxyOpts.Logger = zap.NewNop()
+				Logger:     cmdutil.NewZapLogger(flags.debug),
 			}
 
 			err = runProxy(proxyOpts, database, branch)

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -22,7 +22,6 @@ import (
 	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 func ShellCmd(ch *cmdutil.Helper) *cobra.Command {
@@ -110,10 +109,7 @@ second argument:
 				LocalAddr:  localAddr,
 				RemoteAddr: flags.remoteAddr,
 				Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
-			}
-
-			if !flags.debug {
-				proxyOpts.Logger = zap.NewNop()
+				Logger:     cmdutil.NewZapLogger(flags.debug),
 			}
 
 			p, err := proxy.NewClient(proxyOpts)


### PR DESCRIPTION
This PR introduces a custom Zap logger that logs `error` leveled messages to the console by default. We still support the debug mode with the `--debug` flag. Previously we would send all log messages from the proxy to `ioutil.Discard` (a.k.a `/dev/null`).

fixes: https://github.com/planetscale/project-big-bang/issues/225
