### PR TITLE
cmd/org: add unit tests

### DIFF
--- a/internal/cmd/org/list.go
+++ b/internal/cmd/org/list.go
@@ -18,7 +18,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			client, err := ch.Config.NewClientFromConfig()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/org/list_test.go
+++ b/internal/cmd/org/list_test.go
@@ -1,0 +1,59 @@
+package org
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestOrganization_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+
+	svc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{
+				{Name: "foo"},
+				{Name: "bar"},
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Organizations: svc,
+			}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+
+	orgs := []*organization{
+		{Name: "foo"},
+		{Name: "bar"},
+	}
+	c.Assert(buf.String(), qt.JSONEquals, orgs)
+}

--- a/internal/cmd/org/org.go
+++ b/internal/cmd/org/org.go
@@ -1,9 +1,8 @@
 package org
 
 import (
-	"time"
-
 	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
 )
@@ -43,7 +42,7 @@ func toOrgs(organizations []*ps.Organization) []*organization {
 func toOrg(org *ps.Organization) *organization {
 	return &organization{
 		Name:      org.Name,
-		CreatedAt: org.CreatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
-		UpdatedAt: org.UpdatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
+		CreatedAt: printer.GetMilliseconds(org.CreatedAt),
+		UpdatedAt: printer.GetMilliseconds(org.UpdatedAt),
 	}
 }

--- a/internal/cmd/org/show.go
+++ b/internal/cmd/org/show.go
@@ -17,19 +17,19 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Display the currently active organization",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configFile, err := config.ProjectConfigPath()
+			configPath, err := config.ProjectConfigPath()
 			if err != nil {
 				return err
 			}
 
-			cfg, err := config.NewFileConfig(configFile)
+			cfg, err := ch.ConfigFS.NewFileConfig(configPath)
 			if os.IsNotExist(err) {
-				configFile, err = config.DefaultConfigPath()
+				configPath, err = config.DefaultConfigPath()
 				if err != nil {
 					return err
 				}
 
-				cfg, err = config.NewFileConfig(configFile)
+				cfg, err = ch.ConfigFS.NewFileConfig(configPath)
 				if os.IsNotExist(err) {
 					return errors.New("not authenticated, please authenticate with: \"pscale auth login\"")
 				}
@@ -48,7 +48,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("%s (from file: %s)\n", printer.Bold(cfg.Organization), configFile)
+				ch.Printer.Printf("%s (from file: %s)\n", printer.Bold(cfg.Organization), configPath)
 				return nil
 			}
 

--- a/internal/cmd/org/show_test.go
+++ b/internal/cmd/org/show_test.go
@@ -1,0 +1,101 @@
+package org
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestOrganization_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	configPath, err := config.DefaultConfigPath()
+	c.Assert(err, qt.IsNil)
+
+	organization := "planetscale"
+
+	testfs := memFS{
+		configPath: &fstest.MapFile{
+			Data: []byte(fmt.Sprintf("org: %s", organization)),
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer:  p,
+		ConfigFS: config.NewConfigFS(testfs),
+	}
+
+	cmd := ShowCmd(ch)
+	err = cmd.Execute()
+	c.Assert(err, qt.IsNil)
+
+	res := map[string]string{"org": organization}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+// memFS is copied from fstest.MapFS to support absolute paths
+type memFS map[string]*fstest.MapFile
+
+func (m memFS) Open(name string) (fs.File, error) {
+	file, ok := m[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return &openMapFile{name, mapFileInfo{path.Base(name), file}, 0}, nil
+}
+
+// An openMapFile is a regular (non-directory) fs.File open for reading.
+type openMapFile struct {
+	path string
+	mapFileInfo
+	offset int64
+}
+
+func (f *openMapFile) Stat() (fs.FileInfo, error) { return &f.mapFileInfo, nil }
+
+func (f *openMapFile) Close() error { return nil }
+
+func (f *openMapFile) Read(b []byte) (int, error) {
+	if f.offset >= int64(len(f.f.Data)) {
+		return 0, io.EOF
+	}
+	if f.offset < 0 {
+		return 0, &fs.PathError{Op: "read", Path: f.path, Err: fs.ErrInvalid}
+	}
+	n := copy(b, f.f.Data[f.offset:])
+	f.offset += int64(n)
+	return n, nil
+}
+
+// A mapFileInfo implements fs.FileInfo and fs.DirEntry for a given map file.
+type mapFileInfo struct {
+	name string
+	f    *fstest.MapFile
+}
+
+func (i *mapFileInfo) Name() string               { return i.name }
+func (i *mapFileInfo) Size() int64                { return int64(len(i.f.Data)) }
+func (i *mapFileInfo) Mode() fs.FileMode          { return i.f.Mode }
+func (i *mapFileInfo) Type() fs.FileMode          { return i.f.Mode.Type() }
+func (i *mapFileInfo) ModTime() time.Time         { return i.f.ModTime }
+func (i *mapFileInfo) IsDir() bool                { return i.f.Mode&fs.ModeDir != 0 }
+func (i *mapFileInfo) Sys() interface{}           { return i.f.Sys }
+func (i *mapFileInfo) Info() (fs.FileInfo, error) { return i, nil }

--- a/internal/cmd/org/switch.go
+++ b/internal/cmd/org/switch.go
@@ -28,7 +28,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			organization := ""
 
-			client, err := ch.Config.NewClientFromConfig()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			// check if a file already exists, we don't want to accidently
 			// overwrite other values of the file config
-			fileCfg, err := config.NewFileConfig(filePath)
+			fileCfg, err := ch.ConfigFS.NewFileConfig(filePath)
 			if os.IsNotExist(err) {
 				// create a new file
 				fileCfg = &config.FileConfig{

--- a/internal/cmd/org/switch_test.go
+++ b/internal/cmd/org/switch_test.go
@@ -1,0 +1,58 @@
+package org
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestOrganization_SwitchCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	organization := "planetscale"
+	testfs := memFS{}
+
+	svc := &mock.OrganizationsService{
+		GetFn: func(ctx context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.Organization, qt.Equals, organization)
+			return &ps.Organization{Name: organization}, nil
+		},
+	}
+	ch := &cmdutil.Helper{
+		Printer:  p,
+		ConfigFS: config.NewConfigFS(testfs),
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Organizations: svc,
+			}, nil
+		},
+	}
+
+	configPath := filepath.Join(t.TempDir(), "pscale.yml")
+
+	cmd := SwitchCmd(ch)
+	cmd.SetArgs([]string{organization, "--save-config", configPath})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil)
+
+	out, err := os.ReadFile(configPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(out), qt.Equals, fmt.Sprintf("org: %s\n", organization))
+	c.Assert(buf.String(), qt.Contains, "Successfully switched to organization")
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 
@@ -108,8 +109,9 @@ func Execute(ver, commit, buildDate string) error {
 	}
 
 	ch := &cmdutil.Helper{
-		Printer: printer.NewPrinter(&format),
-		Config:  cfg,
+		Printer:  printer.NewPrinter(&format),
+		Config:   cfg,
+		ConfigFS: config.NewConfigFS(osFS{}),
 		Client: func() (*ps.Client, error) {
 			return cfg.NewClientFromConfig()
 		},
@@ -234,4 +236,11 @@ func presetRequiredFlags(cmd *cobra.Command) {
 			}
 		}
 	})
+}
+
+// https://github.com/golang/go/issues/44286
+type osFS struct{}
+
+func (c osFS) Open(name string) (fs.File, error) {
+	return os.Open(name)
 }

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -20,6 +20,8 @@ type Helper struct {
 	// Config contains globally sourced configuration
 	Config *config.Config
 
+	ConfigFS *config.ConfigFS
+
 	// Client returns the PlanetScale API client
 	Client func() (*ps.Client, error)
 

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -3,11 +3,22 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"path"
 
 	"gopkg.in/yaml.v2"
 )
+
+type ConfigFS struct {
+	fsys fs.FS
+}
+
+func NewConfigFS(fsys fs.FS) *ConfigFS {
+	return &ConfigFS{
+		fsys: fsys,
+	}
+}
 
 // FileConfig defines a pscale configuration from a file.
 type FileConfig struct {
@@ -18,8 +29,8 @@ type FileConfig struct {
 
 // NewFileConfig reads the file config from the designated path and returns a
 // new FileConfig.
-func NewFileConfig(path string) (*FileConfig, error) {
-	out, err := ioutil.ReadFile(path)
+func (c *ConfigFS) NewFileConfig(path string) (*FileConfig, error) {
+	out, err := fs.ReadFile(c.fsys, path)
 	if err != nil {
 		return nil, err
 	}
@@ -34,21 +45,21 @@ func NewFileConfig(path string) (*FileConfig, error) {
 }
 
 // DefaultConfig returns the file config from the default config path.
-func DefaultConfig() (*FileConfig, error) {
+func (c *ConfigFS) DefaultConfig() (*FileConfig, error) {
 	configFile, err := DefaultConfigPath()
 	if err != nil {
 		return nil, err
 	}
-	return NewFileConfig(configFile)
+	return c.NewFileConfig(configFile)
 }
 
 // ProjectConfig returns the file config from the git project
-func ProjectConfig() (*FileConfig, error) {
+func (c *ConfigFS) ProjectConfig() (*FileConfig, error) {
 	configFile, err := ProjectConfigPath()
 	if err != nil {
 		return nil, err
 	}
-	return NewFileConfig(configFile)
+	return c.NewFileConfig(configFile)
 }
 
 // Write persists the file config at the designated path.

--- a/internal/mock/org.go
+++ b/internal/mock/org.go
@@ -1,0 +1,25 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+type OrganizationsService struct {
+	GetFn        func(context.Context, *ps.GetOrganizationRequest) (*ps.Organization, error)
+	GetFnInvoked bool
+
+	ListFn        func(context.Context) ([]*ps.Organization, error)
+	ListFnInvoked bool
+}
+
+func (o *OrganizationsService) Get(ctx context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {
+	o.GetFnInvoked = true
+	return o.GetFn(ctx, req)
+}
+
+func (o *OrganizationsService) List(ctx context.Context) ([]*ps.Organization, error) {
+	o.ListFnInvoked = true
+	return o.ListFn(ctx)
+}


### PR DESCRIPTION
This PR extends the unit tests for the `org` subcommand.

```
$ go test -v
=== RUN   TestOrganization_ListCmd
--- PASS: TestOrganization_ListCmd (0.00s)
=== RUN   TestOrganization_ShowCmd
--- PASS: TestOrganization_ShowCmd (0.01s)
=== RUN   TestOrganization_SwitchCmd
--- PASS: TestOrganization_SwitchCmd (0.01s)
PASS
ok      github.com/planetscale/cli/internal/cmd/org     0.245s
```

/xref planetscale/project-big-bang#147
