### PR TITLE
shell: don't double quote with bold sequence

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -220,7 +220,7 @@ func formatMySQLBranch(database, branch string) string {
 		branchStyled = printer.BoldRed(branch)
 	}
 
-	return printer.Bold(fmt.Sprintf("%s/%s> ", database, branchStyled))
+	return fmt.Sprintf("%s/%s> ", printer.Bold(database), branchStyled)
 }
 
 // createLoginFile creates a temporary file to store the username and password, so we don't have to


### PR DESCRIPTION
This is an attempt to fix: https://github.com/planetscale/project-big-bang/issues/260 Instead of wrapping an already bold text, we now only wrap the part which is not bold (i.e.: database).
