### PR TITLE
Fix release pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,3 +30,6 @@ require (
 	go.uber.org/zap v1.16.0
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+// git sha points to https://github.com/fatih/go-mysqlstack/tree/fatih/fix-windows
+replace github.com/xelabs/go-mysqlstack => github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1 h1:LKxR9aN8llef23XyWlvmjXVJ1GG6OWji8K8uXq4xCNw=
+github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1/go.mod h1:dM4awN1wFomcUCb5OVidPS3ptw2LljT1rHbFjWFksNU=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.12.1 h1:P6vQcHwZYgVGIpUzKB5DXzkEeYJppJOStPLuh9aB89c=
 github.com/frankban/quicktest v1.12.1/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
@@ -309,8 +311,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/xelabs/go-mysqlstack v0.0.0-20210217114447-6f59da6c3358 h1:pGXhKR0dCFh2p19DOXhAwvaWO1R6m6ZmPEvjqVqX7c4=
-github.com/xelabs/go-mysqlstack v0.0.0-20210217114447-6f59da6c3358/go.mod h1:m9feITJq0ZXhBKK0R5BIJa5/2XDQguOWPRvMVyV4i4A=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/github.com/xelabs/go-mysqlstack/xlog/syslog.go
+++ b/vendor/github.com/xelabs/go-mysqlstack/xlog/syslog.go
@@ -1,0 +1,14 @@
+// +build linux darwin dragonfly freebsd netbsd openbsd solaris
+
+package xlog
+
+import "log/syslog"
+
+// NewSysLog creates a new sys log.
+func NewSysLog(opts ...Option) *Log {
+	w, err := syslog.New(syslog.LOG_DEBUG, "")
+	if err != nil {
+		panic(err)
+	}
+	return NewXLog(w, opts...)
+}

--- a/vendor/github.com/xelabs/go-mysqlstack/xlog/syslog_windows.go
+++ b/vendor/github.com/xelabs/go-mysqlstack/xlog/syslog_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package xlog
+
+import (
+	"os"
+)
+
+// NewSysLog creates a new sys log. Because there is no syslog support for
+// Windows, we output to os.Stdout.
+func NewSysLog(opts ...Option) *Log {
+	return NewXLog(os.Stdout, opts...)
+}

--- a/vendor/github.com/xelabs/go-mysqlstack/xlog/xlog.go
+++ b/vendor/github.com/xelabs/go-mysqlstack/xlog/xlog.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/syslog"
 	"os"
 	"strings"
 )
@@ -59,15 +58,6 @@ const (
 type Log struct {
 	opts *Options
 	*log.Logger
-}
-
-// NewSysLog creates a new sys log.
-func NewSysLog(opts ...Option) *Log {
-	w, err := syslog.New(syslog.LOG_DEBUG, "")
-	if err != nil {
-		panic(err)
-	}
-	return NewXLog(w, opts...)
 }
 
 // NewStdLog creates a new std log.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,7 +125,7 @@ github.com/spf13/viper
 github.com/stretchr/testify/assert
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
-# github.com/xelabs/go-mysqlstack v0.0.0-20210217114447-6f59da6c3358
+# github.com/xelabs/go-mysqlstack v0.0.0-20210217114447-6f59da6c3358 => github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1
 ## explicit
 github.com/xelabs/go-mysqlstack/driver
 github.com/xelabs/go-mysqlstack/packet
@@ -210,3 +210,4 @@ gopkg.in/ini.v1
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 gopkg.in/yaml.v3
+# github.com/xelabs/go-mysqlstack => github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1


### PR DESCRIPTION
This PR fixes our broken release pipeline. After adding support for `pscale database dump`, it started to depend on a new package, `github.com/xelabs/go-mysqlstack/xlog`. This package, unfortunately, imports `syslog`, which doesn't work under Windows.

I opened a fix to upstream: https://github.com/xelabs/go-mysqlstack/pull/10, but until that PR is merged, we should make sure we're not blocked on releasing a new version of the CLI. Hence in this PR, we change `go.mod`, so it relies on my fork for now: https://github.com/fatih/go-mysqlstack/tree/fatih/fix-windows. We're going to remove the `replace` directive once the upstream PR is merged.

closes: https://github.com/planetscale/project-big-bang/issues/285
