### PR TITLE
shell: re-enable tabular output

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -166,6 +166,7 @@ second argument:
 			mysqlArgs := []string{
 				fmt.Sprintf("--defaults-extra-file=%s", tmpFile),
 				"-s",
+				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,
 				"-P", port,
 			}


### PR DESCRIPTION
After removing the welcome message from the mysql CLI (https://github.com/planetscale/cli/pull/204), I've found out that it also disables tabular output. This change looks like expected according to the man page:

```
   --silent, -s Silent mode. Produce less output. This option can be
given multiple times to produce less and less output.

This option results in nontabular output format and escaping of special
characters.  Escaping may be disabled by using raw mode; see the
description for the --raw option.
```

By adding the `-t` (shorthand for `--table`) flag, we re-enable tabular output:

Before:

```
restore-test/feature> show tables;
Tables_in_restore-test
feature
```

After:

```
restore-test/feature> show tables;
+------------------------+
| Tables_in_restore-test |
+------------------------+
| feature                |
+------------------------+
```
