### PR TITLE
dumper: don't rely on the common package

### DIFF
--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -1,6 +1,7 @@
 package dumper
 
 import (
+	"bytes"
 	"context"
 	"encoding/csv"
 	"fmt"
@@ -13,7 +14,6 @@ import (
 	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
-	"github.com/xelabs/go-mysqlstack/sqlparser/depends/common"
 	querypb "github.com/xelabs/go-mysqlstack/sqlparser/depends/query"
 
 	"go.uber.org/zap"
@@ -608,7 +608,7 @@ func writeFile(file string, data string) error {
 	}
 	defer f.Close()
 
-	n, err := f.Write(common.StringToBytes(data))
+	n, err := f.Write([]byte(data))
 	if err != nil {
 		return err
 	}
@@ -619,33 +619,33 @@ func writeFile(file string, data string) error {
 }
 
 // escapeBytes used to escape the literal byte.
-func escapeBytes(bytes []byte) []byte {
-	buffer := common.NewBuffer(128)
-	for _, b := range bytes {
-		// See https://dev.mysql.com/doc/refman/5.7/en/string-literals.html
-		// for more information on how to escape string literals in MySQL.
+// See https://dev.mysql.com/doc/refman/5.7/en/string-literals.html
+// for more information on how to escape string literals in MySQL.
+func escapeBytes(data []byte) []byte {
+	var buf bytes.Buffer
+	for _, b := range data {
 		switch b {
 		case 0:
-			buffer.WriteString(`\0`)
+			buf.WriteString(`\0`)
 		case '\'':
-			buffer.WriteString(`\'`)
+			buf.WriteString(`\'`)
 		case '"':
-			buffer.WriteString(`\"`)
+			buf.WriteString(`\"`)
 		case '\b':
-			buffer.WriteString(`\b`)
+			buf.WriteString(`\b`)
 		case '\n':
-			buffer.WriteString(`\n`)
+			buf.WriteString(`\n`)
 		case '\r':
-			buffer.WriteString(`\r`)
+			buf.WriteString(`\r`)
 		case '\t':
-			buffer.WriteString(`\t`)
+			buf.WriteString(`\t`)
 		case 0x1A:
-			buffer.WriteString(`\Z`)
+			buf.WriteString(`\Z`)
 		case '\\':
-			buffer.WriteString(`\\`)
+			buf.WriteString(`\\`)
 		default:
-			buffer.WriteU8(b)
+			buf.WriteByte(b)
 		}
 	}
-	return buffer.Datas()
+	return buf.Bytes()
 }

--- a/internal/dumper/loader.go
+++ b/internal/dumper/loader.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
-	"github.com/xelabs/go-mysqlstack/sqlparser/depends/common"
 
 	"go.uber.org/zap"
 )
@@ -160,9 +159,7 @@ func (l *Loader) restoreDatabaseSchema(dbs []string, conn *Connection) error {
 			return err
 		}
 
-		sql := common.BytesToString(data)
-
-		err = conn.Execute(sql)
+		err = conn.Execute(string(data))
 		if err != nil {
 			return err
 		}
@@ -201,7 +198,7 @@ func (l *Loader) restoreTableSchema(overwrite bool, tables []string, conn *Conne
 		if err != nil {
 			return err
 		}
-		query1 := common.BytesToString(data)
+		query1 := string(data)
 		querys := strings.Split(query1, ";\n")
 		for _, query := range querys {
 			if !strings.HasPrefix(query, "/*") && query != "" {
@@ -267,7 +264,7 @@ func (l *Loader) restoreTable(table string, conn *Connection) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	query1 := common.BytesToString(data)
+	query1 := string(data)
 	querys := strings.Split(query1, ";\n")
 	bytes = len(query1)
 	for _, query := range querys {


### PR DESCRIPTION
It looks like we don't need to rely on the common package. The `[]byte`
to `string` conversions shouldn't be an issue for us. The Go compiler is
smart enough to make some optimizations already and there are some work
on this area: https://github.com/golang/go/issues/2205
