### PR TITLE
dump: don't overwrite existing backup directory

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -118,6 +118,11 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	if flags.output != "" {
 		dir = flags.output
 	}
+
+	if _, err := os.Stat(dir); err == nil {
+		return fmt.Errorf("backup directory already exist: %s", dir)
+	}
+
 	err = os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err

--- a/internal/cmd/org/show_test.go
+++ b/internal/cmd/org/show_test.go
@@ -3,17 +3,13 @@ package org
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"io/fs"
-	"os"
-	"path"
 	"testing"
 	"testing/fstest"
-	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/cli/internal/testutil"
 
 	qt "github.com/frankban/quicktest"
 )
@@ -31,7 +27,7 @@ func TestOrganization_ShowCmd(t *testing.T) {
 
 	organization := "planetscale"
 
-	testfs := memFS{
+	testfs := testutil.MemFS{
 		configPath: &fstest.MapFile{
 			Data: []byte(fmt.Sprintf("org: %s", organization)),
 		},
@@ -49,53 +45,3 @@ func TestOrganization_ShowCmd(t *testing.T) {
 	res := map[string]string{"org": organization}
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
-
-// memFS is copied from fstest.MapFS to support absolute paths
-type memFS map[string]*fstest.MapFile
-
-func (m memFS) Open(name string) (fs.File, error) {
-	file, ok := m[name]
-	if !ok {
-		return nil, os.ErrNotExist
-	}
-
-	return &openMapFile{name, mapFileInfo{path.Base(name), file}, 0}, nil
-}
-
-// An openMapFile is a regular (non-directory) fs.File open for reading.
-type openMapFile struct {
-	path string
-	mapFileInfo
-	offset int64
-}
-
-func (f *openMapFile) Stat() (fs.FileInfo, error) { return &f.mapFileInfo, nil }
-
-func (f *openMapFile) Close() error { return nil }
-
-func (f *openMapFile) Read(b []byte) (int, error) {
-	if f.offset >= int64(len(f.f.Data)) {
-		return 0, io.EOF
-	}
-	if f.offset < 0 {
-		return 0, &fs.PathError{Op: "read", Path: f.path, Err: fs.ErrInvalid}
-	}
-	n := copy(b, f.f.Data[f.offset:])
-	f.offset += int64(n)
-	return n, nil
-}
-
-// A mapFileInfo implements fs.FileInfo and fs.DirEntry for a given map file.
-type mapFileInfo struct {
-	name string
-	f    *fstest.MapFile
-}
-
-func (i *mapFileInfo) Name() string               { return i.name }
-func (i *mapFileInfo) Size() int64                { return int64(len(i.f.Data)) }
-func (i *mapFileInfo) Mode() fs.FileMode          { return i.f.Mode }
-func (i *mapFileInfo) Type() fs.FileMode          { return i.f.Mode.Type() }
-func (i *mapFileInfo) ModTime() time.Time         { return i.f.ModTime }
-func (i *mapFileInfo) IsDir() bool                { return i.f.Mode&fs.ModeDir != 0 }
-func (i *mapFileInfo) Sys() interface{}           { return i.f.Sys }
-func (i *mapFileInfo) Info() (fs.FileInfo, error) { return i, nil }

--- a/internal/cmd/org/switch_test.go
+++ b/internal/cmd/org/switch_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/cli/internal/testutil"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	qt "github.com/frankban/quicktest"
@@ -26,7 +27,7 @@ func TestOrganization_SwitchCmd(t *testing.T) {
 	p.SetHumanOutput(&buf)
 
 	organization := "planetscale"
-	testfs := memFS{}
+	testfs := testutil.MemFS{}
 
 	svc := &mock.OrganizationsService{
 		GetFn: func(ctx context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {

--- a/internal/testutil/memfs.go
+++ b/internal/testutil/memfs.go
@@ -1,0 +1,60 @@
+package testutil
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"testing/fstest"
+	"time"
+)
+
+// MemFS is copied from fstest.MapFS to support absolute paths
+type MemFS map[string]*fstest.MapFile
+
+func (m MemFS) Open(name string) (fs.File, error) {
+	file, ok := m[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return &openMapFile{name, mapFileInfo{path.Base(name), file}, 0}, nil
+}
+
+// An openMapFile is a regular (non-directory) fs.File open for reading.
+type openMapFile struct {
+	path string
+	mapFileInfo
+	offset int64
+}
+
+func (f *openMapFile) Stat() (fs.FileInfo, error) { return &f.mapFileInfo, nil }
+
+func (f *openMapFile) Close() error { return nil }
+
+func (f *openMapFile) Read(b []byte) (int, error) {
+	if f.offset >= int64(len(f.f.Data)) {
+		return 0, io.EOF
+	}
+	if f.offset < 0 {
+		return 0, &fs.PathError{Op: "read", Path: f.path, Err: fs.ErrInvalid}
+	}
+	n := copy(b, f.f.Data[f.offset:])
+	f.offset += int64(n)
+	return n, nil
+}
+
+// A mapFileInfo implements fs.FileInfo and fs.DirEntry for a given map file.
+type mapFileInfo struct {
+	name string
+	f    *fstest.MapFile
+}
+
+func (i *mapFileInfo) Name() string               { return i.name }
+func (i *mapFileInfo) Size() int64                { return int64(len(i.f.Data)) }
+func (i *mapFileInfo) Mode() fs.FileMode          { return i.f.Mode }
+func (i *mapFileInfo) Type() fs.FileMode          { return i.f.Mode.Type() }
+func (i *mapFileInfo) ModTime() time.Time         { return i.f.ModTime }
+func (i *mapFileInfo) IsDir() bool                { return i.f.Mode&fs.ModeDir != 0 }
+func (i *mapFileInfo) Sys() interface{}           { return i.f.Sys }
+func (i *mapFileInfo) Info() (fs.FileInfo, error) { return i, nil }


### PR DESCRIPTION
Also, move our memFS implementation into the `testutil` package so it can be used by other packages as well.

closes: https://github.com/planetscale/project-big-bang/issues/311
