### PR TITLE
Use upstream go-mysqlstack instead of our fork.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/xelabs/go-mysqlstack v0.0.0-20210217114447-6f59da6c3358
+	github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b
 	go.uber.org/zap v1.16.0
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-// git sha points to https://github.com/fatih/go-mysqlstack/tree/fatih/fix-windows
-replace github.com/xelabs/go-mysqlstack => github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
-github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1 h1:LKxR9aN8llef23XyWlvmjXVJ1GG6OWji8K8uXq4xCNw=
-github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1/go.mod h1:dM4awN1wFomcUCb5OVidPS3ptw2LljT1rHbFjWFksNU=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.12.1 h1:P6vQcHwZYgVGIpUzKB5DXzkEeYJppJOStPLuh9aB89c=
 github.com/frankban/quicktest v1.12.1/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
@@ -311,6 +309,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b h1:jnkwSPPvgmxqPakUUrsoRnkZsnJ4EJE9FLnKpEFlW6c=
+github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b/go.mod h1:m9feITJq0ZXhBKK0R5BIJa5/2XDQguOWPRvMVyV4i4A=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,7 +125,7 @@ github.com/spf13/viper
 github.com/stretchr/testify/assert
 # github.com/subosito/gotenv v1.2.0
 github.com/subosito/gotenv
-# github.com/xelabs/go-mysqlstack v0.0.0-20210217114447-6f59da6c3358 => github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1
+# github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b
 ## explicit
 github.com/xelabs/go-mysqlstack/driver
 github.com/xelabs/go-mysqlstack/packet
@@ -210,4 +210,3 @@ gopkg.in/ini.v1
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 gopkg.in/yaml.v3
-# github.com/xelabs/go-mysqlstack => github.com/fatih/go-mysqlstack v0.0.0-20210504182522-ef614032cad1


### PR DESCRIPTION
Our fix to upstream was merged: https://github.com/xelabs/go-mysqlstack/pull/10. Let's use that instead of our fork.
