### PR TITLE
Update to BSD-3 licensed go-mysqlstack library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/planetscale/cli
 
-go 1.15
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.12
@@ -21,12 +21,11 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/planetscale-go v0.25.0
 	github.com/planetscale/sql-proxy v0.3.2
-	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
-	github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b
+	github.com/xelabs/go-mysqlstack v1.0.0
 	go.uber.org/zap v1.16.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b h1:jnkwSPPvgmxqPakUUrsoRnkZsnJ4EJE9FLnKpEFlW6c=
-github.com/xelabs/go-mysqlstack v0.0.0-20210509133322-082114d9069b/go.mod h1:m9feITJq0ZXhBKK0R5BIJa5/2XDQguOWPRvMVyV4i4A=
+github.com/xelabs/go-mysqlstack v1.0.0 h1:go/UqwlxKRNh9df+AQ/pAAgcCCHCaeyv0PYZ/quRbbw=
+github.com/xelabs/go-mysqlstack v1.0.0/go.mod h1:xw+rgelmcSTN/55nk7EcfriA9EeblS8w3nMSbad2yTc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
After talking to the author of the `go-mysqlstack` library, [he was OK changing the license from GPLv3 to BSD 3-Clause.](https://github.com/xelabs/go-mysqlstack/pull/12)

While at it,[ I also opened a PR and added a `go.mod` to the repository](https://github.com/xelabs/go-mysqlstack/pull/13) and we tagged the version with `v1.0.0`.

/xref https://github.com/planetscale/project-big-bang/issues/307
