### PR TITLE
Add licensed CI check

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -1,0 +1,45 @@
+name: licensed-ci
+
+on: [push]
+
+jobs:
+  licensed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure git private repo access
+        env:
+          GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
+        run: |
+          git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install licensed
+        uses: jonabc/setup-licensed@v1
+        with:
+          version: 2.x
+
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+
+      - name: Run licensed
+        id: licensed
+        uses: jonabc/licensed-ci@v1
+        with:
+          github_token: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
+
+      - name: Report licensed activity
+        uses: actions/github-script@0.2.0
+        if: always() && steps.licensed.outputs.pr_number
+        with:
+          github-token: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
+          script: |
+            github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.licensed.outputs.pr_number }},
+              body: 'licensed has detected incompatible changes'
+            })

--- a/.licensed.yml
+++ b/.licensed.yml
@@ -1,0 +1,11 @@
+sources:
+  go: true
+  
+source_path: cmd/pscale
+
+allowed:
+  - mit
+  - apache-2.0
+  - bsd-2-clause
+  - bsd-3-clause
+  - mpl-2.0

--- a/.licenses/go/github.com/AlecAivazis/survey/v2.dep.yml
+++ b/.licenses/go/github.com/AlecAivazis/survey/v2.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/AlecAivazis/survey/v2
+version: v2.2.12
+type: go
+summary: 
+homepage: https://godoc.org/github.com/AlecAivazis/survey/v2
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2018 Alec Aivazis
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/AlecAivazis/survey/v2/core.dep.yml
+++ b/.licenses/go/github.com/AlecAivazis/survey/v2/core.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/AlecAivazis/survey/v2/core
+version: v2.2.12
+type: go
+summary: 
+homepage: https://godoc.org/github.com/AlecAivazis/survey/v2/core
+license: mit
+licenses:
+- sources: v2@v2.2.12/LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2018 Alec Aivazis
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/AlecAivazis/survey/v2/terminal.dep.yml
+++ b/.licenses/go/github.com/AlecAivazis/survey/v2/terminal.dep.yml
@@ -1,0 +1,56 @@
+---
+name: github.com/AlecAivazis/survey/v2/terminal
+version: v2.2.12
+type: go
+summary: 
+homepage: https://godoc.org/github.com/AlecAivazis/survey/v2/terminal
+license: mit
+licenses:
+- sources: v2@v2.2.12/LICENSE
+  text: |
+    MIT License
+
+    Copyright (c) 2018 Alec Aivazis
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) 2014 Takashi Kokubun
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/benbjohnson/clock.dep.yml
+++ b/.licenses/go/github.com/benbjohnson/clock.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/benbjohnson/clock
+version: v1.1.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/benbjohnson/clock
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Ben Johnson
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/briandowns/spinner.dep.yml
+++ b/.licenses/go/github.com/briandowns/spinner.dep.yml
@@ -1,0 +1,186 @@
+---
+name: github.com/briandowns/spinner
+version: v1.12.0
+type: go
+summary: Package spinner is a simple package to add a spinner / progress indicator
+  to any terminal application.
+homepage: https://godoc.org/github.com/briandowns/spinner
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+notices: []

--- a/.licenses/go/github.com/cli/safeexec.dep.yml
+++ b/.licenses/go/github.com/cli/safeexec.dep.yml
@@ -1,0 +1,36 @@
+---
+name: github.com/cli/safeexec
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/cli/safeexec
+license: bsd-2-clause
+licenses:
+- sources: LICENSE
+  text: |
+    BSD 2-Clause License
+
+    Copyright (c) 2020, GitHub Inc.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices: []

--- a/.licenses/go/github.com/dustin/go-humanize.dep.yml
+++ b/.licenses/go/github.com/dustin/go-humanize.dep.yml
@@ -1,0 +1,33 @@
+---
+name: github.com/dustin/go-humanize
+version: v1.0.0
+type: go
+summary: Package humanize converts boring ugly numbers to human-friendly strings and
+  back.
+homepage: https://godoc.org/github.com/dustin/go-humanize
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2005-2008  Dustin Sallings <dustin@spy.net>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+    <http://www.opensource.org/licenses/mit-license.php>
+notices: []

--- a/.licenses/go/github.com/fatih/color.dep.yml
+++ b/.licenses/go/github.com/fatih/color.dep.yml
@@ -1,0 +1,35 @@
+---
+name: github.com/fatih/color
+version: v1.10.0
+type: go
+summary: Package color is an ANSI color package to output colorized or SGR defined
+  output to the standard output.
+homepage: https://godoc.org/github.com/fatih/color
+license: mit
+licenses:
+- sources: LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Fatih Arslan
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: The MIT License (MIT) - see [`LICENSE.md`](https://github.com/fatih/color/blob/master/LICENSE.md)
+    for more details
+notices: []

--- a/.licenses/go/github.com/fsnotify/fsnotify.dep.yml
+++ b/.licenses/go/github.com/fsnotify/fsnotify.dep.yml
@@ -1,0 +1,62 @@
+---
+name: github.com/fsnotify/fsnotify
+version: v1.4.7
+type: go
+summary: Package fsnotify provides a platform-independent interface for file system
+  notifications.
+homepage: https://godoc.org/github.com/fsnotify/fsnotify
+license: bsd-3-clause
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2012 The Go Authors. All rights reserved.
+    Copyright (c) 2012 fsnotify Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices:
+- sources: AUTHORS
+  text: "# Names should be added to this file as\n#\tName or Organization <email address>\n#
+    The email address is not required for organizations.\n\n# You can update this
+    list using the following command:\n#\n#   $ git shortlog -se | awk '{print $2
+    \" \" $3 \" \" $4}'\n\n# Please keep the list sorted.\n\nAaron L <aaron@bettercoder.net>\nAdrien
+    Bustany <adrien@bustany.org>\nAmit Krishnan <amit.krishnan@oracle.com>\nAnmol
+    Sethi <me@anmol.io>\nBjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>\nBruno
+    Bigras <bigras.bruno@gmail.com>\nCaleb Spare <cespare@gmail.com>\nCase Nelson
+    <case@teammating.com>\nChris Howey <chris@howey.me> <howeyc@gmail.com>\nChristoffer
+    Buchholz <christoffer.buchholz@gmail.com>\nDaniel Wagner-Hall <dawagner@gmail.com>\nDave
+    Cheney <dave@cheney.net>\nEvan Phoenix <evan@fallingsnow.net>\nFrancisco Souza
+    <f@souza.cc>\nHari haran <hariharan.uno@gmail.com>\nJohn C Barstow\nKelvin Fo
+    <vmirage@gmail.com>\nKen-ichirou MATSUZAWA <chamas@h4.dion.ne.jp>\nMatt Layher
+    <mdlayher@gmail.com>\nNathan Youngman <git@nathany.com>\nNickolai Zeldovich <nickolai@csail.mit.edu>\nPatrick
+    <patrick@dropbox.com>\nPaul Hammond <paul@paulhammond.org>\nPawel Knap <pawelknap88@gmail.com>\nPieter
+    Droogendijk <pieter@binky.org.uk>\nPursuit92 <JoshChase@techpursuit.net>\nRiku
+    Voipio <riku.voipio@linaro.org>\nRob Figueiredo <robfig@gmail.com>\nRodrigo Chiossi
+    <rodrigochiossi@gmail.com>\nSlawek Ligus <root@ooz.ie>\nSoge Zhang <zhssoge@gmail.com>\nTiffany
+    Jernigan <tiffany.jernigan@intel.com>\nTilak Sharma <tilaks@google.com>\nTom Payne
+    <twpayne@gmail.com>\nTravis Cline <travis.cline@gmail.com>\nTudor Golubenco <tudor.g@gmail.com>\nVahe
+    Khachikyan <vahe@live.ca>\nYukang <moorekang@gmail.com>\nbronze1man <bronze1man@gmail.com>\ndebrando
+    <denis.brandolini@gmail.com>\nhenrikedwards <henrik.edwards@gmail.com>\n铁哥 <guotie.9@gmail.com>"

--- a/.licenses/go/github.com/gocarina/gocsv.dep.yml
+++ b/.licenses/go/github.com/gocarina/gocsv.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/gocarina/gocsv
+version: v0.0.0-20210326111627-0340a0229e98
+type: go
+summary: 
+homepage: https://godoc.org/github.com/gocarina/gocsv
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Jonathan Picques
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/hashicorp/go-cleanhttp.dep.yml
+++ b/.licenses/go/github.com/hashicorp/go-cleanhttp.dep.yml
@@ -1,0 +1,375 @@
+---
+name: github.com/hashicorp/go-cleanhttp
+version: v0.5.2
+type: go
+summary: Package cleanhttp offers convenience utilities for acquiring "clean" http.Transport
+  and http.Client structs.
+homepage: https://godoc.org/github.com/hashicorp/go-cleanhttp
+license: mpl-2.0
+licenses:
+- sources: LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. "Contributor"
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. "Contributor Version"
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor's Contribution.
+
+    1.3. "Contribution"
+
+         means Covered Software of a particular Contributor.
+
+    1.4. "Covered Software"
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. "Incompatible With Secondary Licenses"
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of
+            version 1.1 or earlier of the License, but not also under the terms of
+            a Secondary License.
+
+    1.6. "Executable Form"
+
+         means any form of the work other than Source Code Form.
+
+    1.7. "Larger Work"
+
+         means a work that combines Covered Software with other material, in a
+         separate file or files, that is not Covered Software.
+
+    1.8. "License"
+
+         means this document.
+
+    1.9. "Licensable"
+
+         means having the right to grant, to the maximum extent possible, whether
+         at the time of the initial grant or subsequently, any and all of the
+         rights conveyed by this License.
+
+    1.10. "Modifications"
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to,
+            deletion from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. "Patent Claims" of a Contributor
+
+          means any patent claim(s), including without limitation, method,
+          process, and apparatus claims, in any patent Licensable by such
+          Contributor that would be infringed, but for the grant of the License,
+          by the making, using, selling, offering for sale, having made, import,
+          or transfer of either its Contributions or its Contributor Version.
+
+    1.12. "Secondary License"
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. "Source Code Form"
+
+          means the form of the work preferred for making modifications.
+
+    1.14. "You" (or "Your")
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, "You" includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, "control" means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or
+            as part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its
+            Contributions or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution
+         become effective for each Contribution on the date the Contributor first
+         distributes such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under
+         this License. No additional rights or licenses will be implied from the
+         distribution or licensing of Covered Software under this License.
+         Notwithstanding Section 2.1(b) above, no patent license is granted by a
+         Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party's
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of
+            its Contributions.
+
+         This License does not grant any rights in the trademarks, service marks,
+         or logos of any Contributor (except as may be necessary to comply with
+         the notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this
+         License (see Section 10.2) or under the terms of a Secondary License (if
+         permitted under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its
+         Contributions are its original creation(s) or it has sufficient rights to
+         grant the rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under
+         applicable copyright doctrines of fair use, fair dealing, or other
+         equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under
+         the terms of this License. You must inform recipients that the Source
+         Code Form of the Covered Software is governed by the terms of this
+         License, and how they can obtain a copy of this License. You may not
+         attempt to alter or restrict the recipients' rights in the Source Code
+         Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this
+            License, or sublicense it under different terms, provided that the
+            license for the Executable Form does not attempt to limit or alter the
+            recipients' rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for
+         the Covered Software. If the Larger Work is a combination of Covered
+         Software with a work governed by one or more Secondary Licenses, and the
+         Covered Software is not Incompatible With Secondary Licenses, this
+         License permits You to additionally distribute such Covered Software
+         under the terms of such Secondary License(s), so that the recipient of
+         the Larger Work may, at their option, further distribute the Covered
+         Software under the terms of either this License or such Secondary
+         License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices
+         (including copyright notices, patent notices, disclaimers of warranty, or
+         limitations of liability) contained within the Source Code Form of the
+         Covered Software, except that You may alter any license notices to the
+         extent required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on
+         behalf of any Contributor. You must make it absolutely clear that any
+         such warranty, support, indemnity, or liability obligation is offered by
+         You alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute,
+       judicial order, or regulation then You must: (a) comply with the terms of
+       this License to the maximum extent possible; and (b) describe the
+       limitations and the code they affect. Such description must be placed in a
+       text file included with all distributions of the Covered Software under
+       this License. Except to the extent prohibited by statute or regulation,
+       such description must be sufficiently detailed for a recipient of ordinary
+       skill to be able to understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing
+         basis, if such Contributor fails to notify You of the non-compliance by
+         some reasonable means prior to 60 days after You have come back into
+         compliance. Moreover, Your grants from a particular Contributor are
+         reinstated on an ongoing basis if such Contributor notifies You of the
+         non-compliance by some reasonable means, this is the first time You have
+         received notice of non-compliance with this License from such
+         Contributor, and You become compliant prior to 30 days after Your receipt
+         of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions,
+         counter-claims, and cross-claims) alleging that a Contributor Version
+         directly or indirectly infringes any patent, then the rights granted to
+         You by any and all Contributors for the Covered Software under Section
+         2.1 of this License shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an "as is" basis,
+       without warranty of any kind, either expressed, implied, or statutory,
+       including, without limitation, warranties that the Covered Software is free
+       of defects, merchantable, fit for a particular purpose or non-infringing.
+       The entire risk as to the quality and performance of the Covered Software
+       is with You. Should any Covered Software prove defective in any respect,
+       You (not any Contributor) assume the cost of any necessary servicing,
+       repair, or correction. This disclaimer of warranty constitutes an essential
+       part of this License. No use of  any Covered Software is authorized under
+       this License except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from
+       such party's negligence to the extent applicable law prohibits such
+       limitation. Some jurisdictions do not allow the exclusion or limitation of
+       incidental or consequential damages, so this exclusion and limitation may
+       not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts
+       of a jurisdiction where the defendant maintains its principal place of
+       business and such litigation shall be governed by laws of that
+       jurisdiction, without reference to its conflict-of-law provisions. Nothing
+       in this Section shall prevent a party's ability to bring cross-claims or
+       counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject
+       matter hereof. If any provision of this License is held to be
+       unenforceable, such provision shall be reformed only to the extent
+       necessary to make it enforceable. Any law or regulation which provides that
+       the language of a contract shall be construed against the drafter shall not
+       be used to construe this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version
+          of the License under which You originally received the Covered Software,
+          or under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a
+          modified version of this License if you rename the license and remove
+          any references to the name of the license steward (except to note that
+          such modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary
+          Licenses If You choose to distribute Source Code Form that is
+          Incompatible With Secondary Licenses under the terms of this version of
+          the License, the notice described in Exhibit B of this License must be
+          attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file,
+    then You may include the notice in a location (such as a LICENSE file in a
+    relevant directory) where a recipient would be likely to look for such a
+    notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+          This Source Code Form is "Incompatible
+          With Secondary Licenses", as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/go-version.dep.yml
+++ b/.licenses/go/github.com/hashicorp/go-version.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/go-version
+version: v1.3.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/hashicorp/go-version
+license: mpl-2.0
+licenses:
+- sources: LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl
+version: v1.0.0
+type: go
+summary: Package hcl decodes HCL into usable Go structures.
+homepage: https://godoc.org/github.com/hashicorp/hcl
+license: mpl-2.0
+licenses:
+- sources: LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/hcl/ast.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/hcl/ast.dep.yml
@@ -1,0 +1,366 @@
+---
+name: github.com/hashicorp/hcl/hcl/ast
+version: v1.0.0
+type: go
+summary: Package ast declares the types used to represent syntax trees for HCL (HashiCorp
+  Configuration Language)
+homepage: https://godoc.org/github.com/hashicorp/hcl/hcl/ast
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/hcl/parser.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/hcl/parser.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl/hcl/parser
+version: v1.0.0
+type: go
+summary: Package parser implements a parser for HCL (HashiCorp Configuration Language)
+homepage: https://godoc.org/github.com/hashicorp/hcl/hcl/parser
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/hcl/printer.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/hcl/printer.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl/hcl/printer
+version: v1.0.0
+type: go
+summary: Package printer implements printing of AST nodes to HCL format.
+homepage: https://godoc.org/github.com/hashicorp/hcl/hcl/printer
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/hcl/scanner.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/hcl/scanner.dep.yml
@@ -1,0 +1,366 @@
+---
+name: github.com/hashicorp/hcl/hcl/scanner
+version: v1.0.0
+type: go
+summary: Package scanner implements a scanner for HCL (HashiCorp Configuration Language)
+  source text.
+homepage: https://godoc.org/github.com/hashicorp/hcl/hcl/scanner
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/hcl/strconv.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/hcl/strconv.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl/hcl/strconv
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/hashicorp/hcl/hcl/strconv
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/hcl/token.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/hcl/token.dep.yml
@@ -1,0 +1,366 @@
+---
+name: github.com/hashicorp/hcl/hcl/token
+version: v1.0.0
+type: go
+summary: Package token defines constants representing the lexical tokens for HCL (HashiCorp
+  Configuration Language)
+homepage: https://godoc.org/github.com/hashicorp/hcl/hcl/token
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/json/parser.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/json/parser.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl/json/parser
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/hashicorp/hcl/json/parser
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/json/scanner.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/json/scanner.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl/json/scanner
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/hashicorp/hcl/json/scanner
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/hashicorp/hcl/json/token.dep.yml
+++ b/.licenses/go/github.com/hashicorp/hcl/json/token.dep.yml
@@ -1,0 +1,365 @@
+---
+name: github.com/hashicorp/hcl/json/token
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/hashicorp/hcl/json/token
+license: mpl-2.0
+licenses:
+- sources: hcl@v1.0.0/LICENSE
+  text: |+
+    Mozilla Public License, version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+         means each individual or legal entity that creates, contributes to the
+         creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+         means the combination of the Contributions of others (if any) used by a
+         Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+         means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+         means Source Code Form to which the initial Contributor has attached the
+         notice in Exhibit A, the Executable Form of such Source Code Form, and
+         Modifications of such Source Code Form, in each case including portions
+         thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+         means
+
+         a. that the initial Contributor has attached the notice described in
+            Exhibit B to the Covered Software; or
+
+         b. that the Covered Software was made available under the terms of version
+            1.1 or earlier of the License, but not also under the terms of a
+            Secondary License.
+
+    1.6. “Executable Form”
+
+         means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+         means a work that combines Covered Software with other material, in a separate
+         file or files, that is not Covered Software.
+
+    1.8. “License”
+
+         means this document.
+
+    1.9. “Licensable”
+
+         means having the right to grant, to the maximum extent possible, whether at the
+         time of the initial grant or subsequently, any and all of the rights conveyed by
+         this License.
+
+    1.10. “Modifications”
+
+         means any of the following:
+
+         a. any file in Source Code Form that results from an addition to, deletion
+            from, or modification of the contents of Covered Software; or
+
+         b. any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+          means any patent claim(s), including without limitation, method, process,
+          and apparatus claims, in any patent Licensable by such Contributor that
+          would be infringed, but for the grant of the License, by the making,
+          using, selling, offering for sale, having made, import, or transfer of
+          either its Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+          means either the GNU General Public License, Version 2.0, the GNU Lesser
+          General Public License, Version 2.1, the GNU Affero General Public
+          License, Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+          means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+          means an individual or a legal entity exercising rights under this
+          License. For legal entities, “You” includes any entity that controls, is
+          controlled by, or is under common control with You. For purposes of this
+          definition, “control” means (a) the power, direct or indirect, to cause
+          the direction or management of such entity, whether by contract or
+          otherwise, or (b) ownership of more than fifty percent (50%) of the
+          outstanding shares or beneficial ownership of such entity.
+
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+         Each Contributor hereby grants You a world-wide, royalty-free,
+         non-exclusive license:
+
+         a. under intellectual property rights (other than patent or trademark)
+            Licensable by such Contributor to use, reproduce, make available,
+            modify, display, perform, distribute, and otherwise exploit its
+            Contributions, either on an unmodified basis, with Modifications, or as
+            part of a Larger Work; and
+
+         b. under Patent Claims of such Contributor to make, use, sell, offer for
+            sale, have made, import, and otherwise transfer either its Contributions
+            or its Contributor Version.
+
+    2.2. Effective Date
+
+         The licenses granted in Section 2.1 with respect to any Contribution become
+         effective for each Contribution on the date the Contributor first distributes
+         such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+         The licenses granted in this Section 2 are the only rights granted under this
+         License. No additional rights or licenses will be implied from the distribution
+         or licensing of Covered Software under this License. Notwithstanding Section
+         2.1(b) above, no patent license is granted by a Contributor:
+
+         a. for any code that a Contributor has removed from Covered Software; or
+
+         b. for infringements caused by: (i) Your and any other third party’s
+            modifications of Covered Software, or (ii) the combination of its
+            Contributions with other software (except as part of its Contributor
+            Version); or
+
+         c. under Patent Claims infringed by Covered Software in the absence of its
+            Contributions.
+
+         This License does not grant any rights in the trademarks, service marks, or
+         logos of any Contributor (except as may be necessary to comply with the
+         notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+         No Contributor makes additional grants as a result of Your choice to
+         distribute the Covered Software under a subsequent version of this License
+         (see Section 10.2) or under the terms of a Secondary License (if permitted
+         under the terms of Section 3.3).
+
+    2.5. Representation
+
+         Each Contributor represents that the Contributor believes its Contributions
+         are its original creation(s) or it has sufficient rights to grant the
+         rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+         This License is not intended to limit any rights You have under applicable
+         copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+         Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+         Section 2.1.
+
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+         All distribution of Covered Software in Source Code Form, including any
+         Modifications that You create or to which You contribute, must be under the
+         terms of this License. You must inform recipients that the Source Code Form
+         of the Covered Software is governed by the terms of this License, and how
+         they can obtain a copy of this License. You may not attempt to alter or
+         restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+         If You distribute Covered Software in Executable Form then:
+
+         a. such Covered Software must also be made available in Source Code Form,
+            as described in Section 3.1, and You must inform recipients of the
+            Executable Form how they can obtain a copy of such Source Code Form by
+            reasonable means in a timely manner, at a charge no more than the cost
+            of distribution to the recipient; and
+
+         b. You may distribute such Executable Form under the terms of this License,
+            or sublicense it under different terms, provided that the license for
+            the Executable Form does not attempt to limit or alter the recipients’
+            rights in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+         You may create and distribute a Larger Work under terms of Your choice,
+         provided that You also comply with the requirements of this License for the
+         Covered Software. If the Larger Work is a combination of Covered Software
+         with a work governed by one or more Secondary Licenses, and the Covered
+         Software is not Incompatible With Secondary Licenses, this License permits
+         You to additionally distribute such Covered Software under the terms of
+         such Secondary License(s), so that the recipient of the Larger Work may, at
+         their option, further distribute the Covered Software under the terms of
+         either this License or such Secondary License(s).
+
+    3.4. Notices
+
+         You may not remove or alter the substance of any license notices (including
+         copyright notices, patent notices, disclaimers of warranty, or limitations
+         of liability) contained within the Source Code Form of the Covered
+         Software, except that You may alter any license notices to the extent
+         required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+         You may choose to offer, and to charge a fee for, warranty, support,
+         indemnity or liability obligations to one or more recipients of Covered
+         Software. However, You may do so only on Your own behalf, and not on behalf
+         of any Contributor. You must make it absolutely clear that any such
+         warranty, support, indemnity, or liability obligation is offered by You
+         alone, and You hereby agree to indemnify every Contributor for any
+         liability incurred by such Contributor as a result of warranty, support,
+         indemnity or liability terms You offer. You may include additional
+         disclaimers of warranty and limitations of liability specific to any
+         jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+       If it is impossible for You to comply with any of the terms of this License
+       with respect to some or all of the Covered Software due to statute, judicial
+       order, or regulation then You must: (a) comply with the terms of this License
+       to the maximum extent possible; and (b) describe the limitations and the code
+       they affect. Such description must be placed in a text file included with all
+       distributions of the Covered Software under this License. Except to the
+       extent prohibited by statute or regulation, such description must be
+       sufficiently detailed for a recipient of ordinary skill to be able to
+       understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if You
+         fail to comply with any of its terms. However, if You become compliant,
+         then the rights granted under this License from a particular Contributor
+         are reinstated (a) provisionally, unless and until such Contributor
+         explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+         if such Contributor fails to notify You of the non-compliance by some
+         reasonable means prior to 60 days after You have come back into compliance.
+         Moreover, Your grants from a particular Contributor are reinstated on an
+         ongoing basis if such Contributor notifies You of the non-compliance by
+         some reasonable means, this is the first time You have received notice of
+         non-compliance with this License from such Contributor, and You become
+         compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+         infringement claim (excluding declaratory judgment actions, counter-claims,
+         and cross-claims) alleging that a Contributor Version directly or
+         indirectly infringes any patent, then the rights granted to You by any and
+         all Contributors for the Covered Software under Section 2.1 of this License
+         shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+         license agreements (excluding distributors and resellers) which have been
+         validly granted by You or Your distributors under this License prior to
+         termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+       Covered Software is provided under this License on an “as is” basis, without
+       warranty of any kind, either expressed, implied, or statutory, including,
+       without limitation, warranties that the Covered Software is free of defects,
+       merchantable, fit for a particular purpose or non-infringing. The entire
+       risk as to the quality and performance of the Covered Software is with You.
+       Should any Covered Software prove defective in any respect, You (not any
+       Contributor) assume the cost of any necessary servicing, repair, or
+       correction. This disclaimer of warranty constitutes an essential part of this
+       License. No use of  any Covered Software is authorized under this License
+       except under this disclaimer.
+
+    7. Limitation of Liability
+
+       Under no circumstances and under no legal theory, whether tort (including
+       negligence), contract, or otherwise, shall any Contributor, or anyone who
+       distributes Covered Software as permitted above, be liable to You for any
+       direct, indirect, special, incidental, or consequential damages of any
+       character including, without limitation, damages for lost profits, loss of
+       goodwill, work stoppage, computer failure or malfunction, or any and all
+       other commercial damages or losses, even if such party shall have been
+       informed of the possibility of such damages. This limitation of liability
+       shall not apply to liability for death or personal injury resulting from such
+       party’s negligence to the extent applicable law prohibits such limitation.
+       Some jurisdictions do not allow the exclusion or limitation of incidental or
+       consequential damages, so this exclusion and limitation may not apply to You.
+
+    8. Litigation
+
+       Any litigation relating to this License may be brought only in the courts of
+       a jurisdiction where the defendant maintains its principal place of business
+       and such litigation shall be governed by laws of that jurisdiction, without
+       reference to its conflict-of-law provisions. Nothing in this Section shall
+       prevent a party’s ability to bring cross-claims or counter-claims.
+
+    9. Miscellaneous
+
+       This License represents the complete agreement concerning the subject matter
+       hereof. If any provision of this License is held to be unenforceable, such
+       provision shall be reformed only to the extent necessary to make it
+       enforceable. Any law or regulation which provides that the language of a
+       contract shall be construed against the drafter shall not be used to construe
+       this License against a Contributor.
+
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+          Mozilla Foundation is the license steward. Except as provided in Section
+          10.3, no one other than the license steward has the right to modify or
+          publish new versions of this License. Each version will be given a
+          distinguishing version number.
+
+    10.2. Effect of New Versions
+
+          You may distribute the Covered Software under the terms of the version of
+          the License under which You originally received the Covered Software, or
+          under the terms of any subsequent version published by the license
+          steward.
+
+    10.3. Modified Versions
+
+          If you create software not governed by this License, and you want to
+          create a new license for such software, you may create and use a modified
+          version of this License if you rename the license and remove any
+          references to the name of the license steward (except to note that such
+          modified license differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+          If You choose to distribute Source Code Form that is Incompatible With
+          Secondary Licenses under the terms of this version of the License, the
+          notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice
+
+          This Source Code Form is subject to the
+          terms of the Mozilla Public License, v.
+          2.0. If a copy of the MPL was not
+          distributed with this file, You can
+          obtain one at
+          http://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file, then
+    You may include the notice in a location (such as a LICENSE file in a relevant
+    directory) where a recipient would be likely to look for such a notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+          This Source Code Form is “Incompatible
+          With Secondary Licenses”, as defined by
+          the Mozilla Public License, v. 2.0.
+
+notices: []

--- a/.licenses/go/github.com/kataras/tablewriter.dep.yml
+++ b/.licenses/go/github.com/kataras/tablewriter.dep.yml
@@ -1,0 +1,30 @@
+---
+name: github.com/kataras/tablewriter
+version: v0.0.0-20180708051242-e063d29b7c23
+type: go
+summary: Create & Generate text based table
+homepage: https://godoc.org/github.com/kataras/tablewriter
+license: mit
+licenses:
+- sources: LICENCE.md
+  text: |-
+    Copyright (C) 2014 by Oleku Konko
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/kballard/go-shellquote.dep.yml
+++ b/.licenses/go/github.com/kballard/go-shellquote.dep.yml
@@ -1,0 +1,31 @@
+---
+name: github.com/kballard/go-shellquote
+version: v0.0.0-20180428030007-95032a82bc51
+type: go
+summary: Shellquote provides utilities for joining/splitting strings using sh's word-splitting
+  rules.
+homepage: https://godoc.org/github.com/kballard/go-shellquote
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (C) 2014 Kevin Ballard
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+    OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+    OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/lensesio/tableprinter.dep.yml
+++ b/.licenses/go/github.com/lensesio/tableprinter.dep.yml
@@ -1,0 +1,205 @@
+---
+name: github.com/lensesio/tableprinter
+version: v0.0.0-20201125135848-89e81fc956e7
+type: go
+summary: 
+homepage: https://godoc.org/github.com/lensesio/tableprinter
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2-
+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       Copyright 2018 lensesio
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+- sources: README.md
+  text: Distributed under Apache Version 2.0, see [LICENSE](LICENSE) for more information.
+notices:
+- sources: NOTICE
+  text: |-
+    Third Party libraries and components
+    ------------------------------------
+
+    tablewriter      : MIT                 - https://github.com/kataras/tablewriter
+    go-humanize      : MIT                 - https://github.com/dustin/go-humanize

--- a/.licenses/go/github.com/magiconair/properties.dep.yml
+++ b/.licenses/go/github.com/magiconair/properties.dep.yml
@@ -1,0 +1,40 @@
+---
+name: github.com/magiconair/properties
+version: v1.8.1
+type: go
+summary: Package properties provides functions for reading and writing ISO-8859-1
+  and UTF-8 encoded .properties files and has support for recursive property expansion.
+homepage: https://godoc.org/github.com/magiconair/properties
+license: bsd-2-clause
+licenses:
+- sources: LICENSE
+  text: |
+    goproperties - properties file decoder for Go
+
+    Copyright (c) 2013-2018 - Frank Schroeder
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: README.md
+  text: 2 clause BSD license. See [LICENSE](https://github.com/magiconair/properties/blob/master/LICENSE)
+    file for details.
+notices: []

--- a/.licenses/go/github.com/mattn/go-colorable.dep.yml
+++ b/.licenses/go/github.com/mattn/go-colorable.dep.yml
@@ -1,0 +1,34 @@
+---
+name: github.com/mattn/go-colorable
+version: v0.1.8
+type: go
+summary: 
+homepage: https://godoc.org/github.com/mattn/go-colorable
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2016 Yasuhiro Matsumoto
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: MIT
+notices: []

--- a/.licenses/go/github.com/mattn/go-isatty.dep.yml
+++ b/.licenses/go/github.com/mattn/go-isatty.dep.yml
@@ -1,0 +1,22 @@
+---
+name: github.com/mattn/go-isatty
+version: v0.0.12
+type: go
+summary: Package isatty implements interface to isatty
+homepage: https://godoc.org/github.com/mattn/go-isatty
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+    MIT License (Expat)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+- sources: README.md
+  text: MIT
+notices: []

--- a/.licenses/go/github.com/mattn/go-runewidth.dep.yml
+++ b/.licenses/go/github.com/mattn/go-runewidth.dep.yml
@@ -1,0 +1,34 @@
+---
+name: github.com/mattn/go-runewidth
+version: v0.0.9
+type: go
+summary: 
+homepage: https://godoc.org/github.com/mattn/go-runewidth
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2016 Yasuhiro Matsumoto
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: 'under the MIT License: http://mattn.mit-license.org/2013'
+notices: []

--- a/.licenses/go/github.com/mgutz/ansi.dep.yml
+++ b/.licenses/go/github.com/mgutz/ansi.dep.yml
@@ -1,0 +1,21 @@
+---
+name: github.com/mgutz/ansi
+version: v0.0.0-20170206155736-9520e82c474b
+type: go
+summary: Package ansi is a small, fast library to create ANSI colored strings and
+  codes.
+homepage: https://godoc.org/github.com/mgutz/ansi
+license: mit
+licenses:
+- sources: LICENSE
+  text: |+
+    The MIT License (MIT)
+    Copyright (c) 2013 Mario L. Gutierrez
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+notices: []

--- a/.licenses/go/github.com/mitchellh/go-homedir.dep.yml
+++ b/.licenses/go/github.com/mitchellh/go-homedir.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/mitchellh/go-homedir
+version: v1.1.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/mitchellh/go-homedir
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Mitchell Hashimoto
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/mitchellh/mapstructure.dep.yml
+++ b/.licenses/go/github.com/mitchellh/mapstructure.dep.yml
@@ -1,0 +1,33 @@
+---
+name: github.com/mitchellh/mapstructure
+version: v1.1.2
+type: go
+summary: Package mapstructure exposes functionality to convert an arbitrary map[string]interface{}
+  into a native Go structure.
+homepage: https://godoc.org/github.com/mitchellh/mapstructure
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Mitchell Hashimoto
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/pelletier/go-toml.dep.yml
+++ b/.licenses/go/github.com/pelletier/go-toml.dep.yml
@@ -1,0 +1,34 @@
+---
+name: github.com/pelletier/go-toml
+version: v1.2.0
+type: go
+summary: Package toml is a TOML parser and manipulation library.
+homepage: https://godoc.org/github.com/pelletier/go-toml
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2013 - 2017 Thomas Pelletier, Eric Anderton
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: The MIT License (MIT). Read [LICENSE](LICENSE).
+notices: []

--- a/.licenses/go/github.com/pkg/browser.dep.yml
+++ b/.licenses/go/github.com/pkg/browser.dep.yml
@@ -1,0 +1,35 @@
+---
+name: github.com/pkg/browser
+version: v0.0.0-20201112035734-206646e67786
+type: go
+summary: Package browser provides helpers to open files, readers, and urls in a browser
+  window.
+homepage: https://godoc.org/github.com/pkg/browser
+license: bsd-2-clause
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2014, Dave Cheney <dave@cheney.net>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices: []

--- a/.licenses/go/github.com/pkg/errors.dep.yml
+++ b/.licenses/go/github.com/pkg/errors.dep.yml
@@ -1,0 +1,36 @@
+---
+name: github.com/pkg/errors
+version: v0.9.1
+type: go
+summary: Package errors provides simple error handling primitives.
+homepage: https://godoc.org/github.com/pkg/errors
+license: bsd-2-clause
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: README.md
+  text: BSD-2-Clause
+notices: []

--- a/.licenses/go/github.com/planetscale/planetscale-go/planetscale.dep.yml
+++ b/.licenses/go/github.com/planetscale/planetscale-go/planetscale.dep.yml
@@ -1,0 +1,185 @@
+---
+name: github.com/planetscale/planetscale-go/planetscale
+version: v0.25.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/planetscale/planetscale-go/planetscale
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+notices: []

--- a/.licenses/go/github.com/planetscale/sql-proxy/proxy.dep.yml
+++ b/.licenses/go/github.com/planetscale/sql-proxy/proxy.dep.yml
@@ -1,0 +1,213 @@
+---
+name: github.com/planetscale/sql-proxy/proxy
+version: v0.3.2
+type: go
+summary: 
+homepage: https://godoc.org/github.com/planetscale/sql-proxy/proxy
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+
+                                   Apache License
+                             Version 2.0, January 2004
+                          http://www.apache.org/licenses/
+
+     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+     1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction,
+        and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by
+        the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all
+        other entities that control, are controlled by, or are under common
+        control with that entity. For the purposes of this definition,
+        "control" means (i) the power, direct or indirect, to cause the
+        direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity
+        exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications,
+        including but not limited to software source code, documentation
+        source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical
+        transformation or translation of a Source form, including but
+        not limited to compiled object code, generated documentation,
+        and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or
+        Object form, made available under the License, as indicated by a
+        copyright notice that is included in or attached to the work
+        (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object
+        form, that is based on (or derived from) the Work and for which the
+        editorial revisions, annotations, elaborations, or other modifications
+        represent, as a whole, an original work of authorship. For the purposes
+        of this License, Derivative Works shall not include works that remain
+        separable from, or merely link (or bind by name) to the interfaces of,
+        the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including
+        the original version of the Work and any modifications or additions
+        to that Work or Derivative Works thereof, that is intentionally
+        submitted to Licensor for inclusion in the Work by the copyright owner
+        or by an individual or Legal Entity authorized to submit on behalf of
+        the copyright owner. For the purposes of this definition, "submitted"
+        means any form of electronic, verbal, or written communication sent
+        to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems,
+        and issue tracking systems that are managed by, or on behalf of, the
+        Licensor for the purpose of discussing and improving the Work, but
+        excluding communication that is conspicuously marked or otherwise
+        designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity
+        on behalf of whom a Contribution has been received by Licensor and
+        subsequently incorporated within the Work.
+
+     2. Grant of Copyright License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        copyright license to reproduce, prepare Derivative Works of,
+        publicly display, publicly perform, sublicense, and distribute the
+        Work and such Derivative Works in Source or Object form.
+
+     3. Grant of Patent License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        (except as stated in this section) patent license to make, have made,
+        use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable
+        by such Contributor that are necessarily infringed by their
+        Contribution(s) alone or by combination of their Contribution(s)
+        with the Work to which such Contribution(s) was submitted. If You
+        institute patent litigation against any entity (including a
+        cross-claim or counterclaim in a lawsuit) alleging that the Work
+        or a Contribution incorporated within the Work constitutes direct
+        or contributory patent infringement, then any patent licenses
+        granted to You under this License for that Work shall terminate
+        as of the date such litigation is filed.
+
+     4. Redistribution. You may reproduce and distribute copies of the
+        Work or Derivative Works thereof in any medium, with or without
+        modifications, and in Source or Object form, provided that You
+        meet the following conditions:
+
+        (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+
+        (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+
+        (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
+
+        (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+
+        You may add Your own copyright statement to Your modifications and
+        may provide additional or different license terms and conditions
+        for use, reproduction, or distribution of Your modifications, or
+        for any such Derivative Works as a whole, provided Your use,
+        reproduction, and distribution of the Work otherwise complies with
+        the conditions stated in this License.
+
+     5. Submission of Contributions. Unless You explicitly state otherwise,
+        any Contribution intentionally submitted for inclusion in the Work
+        by You to the Licensor shall be under the terms and conditions of
+        this License, without any additional terms or conditions.
+        Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed
+        with Licensor regarding such Contributions.
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor,
+        except as required for reasonable and customary use in describing the
+        origin of the Work and reproducing the content of the NOTICE file.
+
+     7. Disclaimer of Warranty. Unless required by applicable law or
+        agreed to in writing, Licensor provides the Work (and each
+        Contributor provides its Contributions) on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied, including, without limitation, any warranties or conditions
+        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        PARTICULAR PURPOSE. You are solely responsible for determining the
+        appropriateness of using or redistributing the Work and assume any
+        risks associated with Your exercise of permissions under this License.
+
+     8. Limitation of Liability. In no event and under no legal theory,
+        whether in tort (including negligence), contract, or otherwise,
+        unless required by applicable law (such as deliberate and grossly
+        negligent acts) or agreed to in writing, shall any Contributor be
+        liable to You for damages, including any direct, indirect, special,
+        incidental, or consequential damages of any character arising as a
+        result of this License or out of the use or inability to use the
+        Work (including but not limited to damages for loss of goodwill,
+        work stoppage, computer failure or malfunction, or any and all
+        other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.
+
+     9. Accepting Warranty or Additional Liability. While redistributing
+        the Work or Derivative Works thereof, You may choose to offer,
+        and charge a fee for, acceptance of support, warranty, indemnity,
+        or other liability obligations and/or rights consistent with this
+        License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf
+        of any other Contributor, and only if You agree to indemnify,
+        defend, and hold each Contributor harmless for any liability
+        incurred by, or claims asserted against, such Contributor by reason
+        of your accepting any such warranty or additional liability.
+
+     END OF TERMS AND CONDITIONS
+
+     APPENDIX: How to apply the Apache License to your work.
+
+        To apply the Apache License to your work, attach the following
+        boilerplate notice, with the fields enclosed by brackets "[]"
+        replaced with your own identifying information. (Don't include
+        the brackets!)  The text should be enclosed in the appropriate
+        comment syntax for the file format. We also recommend that a
+        file or class name and description of purpose be included on the
+        same "printed page" as the copyright notice for easier
+        identification within third-party archives.
+
+     Copyright 2021 PlanetScale, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+notices: []

--- a/.licenses/go/github.com/planetscale/sql-proxy/sigutil.dep.yml
+++ b/.licenses/go/github.com/planetscale/sql-proxy/sigutil.dep.yml
@@ -1,0 +1,213 @@
+---
+name: github.com/planetscale/sql-proxy/sigutil
+version: v0.3.2
+type: go
+summary: 
+homepage: https://godoc.org/github.com/planetscale/sql-proxy/sigutil
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+
+                                   Apache License
+                             Version 2.0, January 2004
+                          http://www.apache.org/licenses/
+
+     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+     1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction,
+        and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by
+        the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all
+        other entities that control, are controlled by, or are under common
+        control with that entity. For the purposes of this definition,
+        "control" means (i) the power, direct or indirect, to cause the
+        direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity
+        exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications,
+        including but not limited to software source code, documentation
+        source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical
+        transformation or translation of a Source form, including but
+        not limited to compiled object code, generated documentation,
+        and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or
+        Object form, made available under the License, as indicated by a
+        copyright notice that is included in or attached to the work
+        (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object
+        form, that is based on (or derived from) the Work and for which the
+        editorial revisions, annotations, elaborations, or other modifications
+        represent, as a whole, an original work of authorship. For the purposes
+        of this License, Derivative Works shall not include works that remain
+        separable from, or merely link (or bind by name) to the interfaces of,
+        the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including
+        the original version of the Work and any modifications or additions
+        to that Work or Derivative Works thereof, that is intentionally
+        submitted to Licensor for inclusion in the Work by the copyright owner
+        or by an individual or Legal Entity authorized to submit on behalf of
+        the copyright owner. For the purposes of this definition, "submitted"
+        means any form of electronic, verbal, or written communication sent
+        to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems,
+        and issue tracking systems that are managed by, or on behalf of, the
+        Licensor for the purpose of discussing and improving the Work, but
+        excluding communication that is conspicuously marked or otherwise
+        designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity
+        on behalf of whom a Contribution has been received by Licensor and
+        subsequently incorporated within the Work.
+
+     2. Grant of Copyright License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        copyright license to reproduce, prepare Derivative Works of,
+        publicly display, publicly perform, sublicense, and distribute the
+        Work and such Derivative Works in Source or Object form.
+
+     3. Grant of Patent License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        (except as stated in this section) patent license to make, have made,
+        use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable
+        by such Contributor that are necessarily infringed by their
+        Contribution(s) alone or by combination of their Contribution(s)
+        with the Work to which such Contribution(s) was submitted. If You
+        institute patent litigation against any entity (including a
+        cross-claim or counterclaim in a lawsuit) alleging that the Work
+        or a Contribution incorporated within the Work constitutes direct
+        or contributory patent infringement, then any patent licenses
+        granted to You under this License for that Work shall terminate
+        as of the date such litigation is filed.
+
+     4. Redistribution. You may reproduce and distribute copies of the
+        Work or Derivative Works thereof in any medium, with or without
+        modifications, and in Source or Object form, provided that You
+        meet the following conditions:
+
+        (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+
+        (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+
+        (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
+
+        (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+
+        You may add Your own copyright statement to Your modifications and
+        may provide additional or different license terms and conditions
+        for use, reproduction, or distribution of Your modifications, or
+        for any such Derivative Works as a whole, provided Your use,
+        reproduction, and distribution of the Work otherwise complies with
+        the conditions stated in this License.
+
+     5. Submission of Contributions. Unless You explicitly state otherwise,
+        any Contribution intentionally submitted for inclusion in the Work
+        by You to the Licensor shall be under the terms and conditions of
+        this License, without any additional terms or conditions.
+        Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed
+        with Licensor regarding such Contributions.
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor,
+        except as required for reasonable and customary use in describing the
+        origin of the Work and reproducing the content of the NOTICE file.
+
+     7. Disclaimer of Warranty. Unless required by applicable law or
+        agreed to in writing, Licensor provides the Work (and each
+        Contributor provides its Contributions) on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied, including, without limitation, any warranties or conditions
+        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        PARTICULAR PURPOSE. You are solely responsible for determining the
+        appropriateness of using or redistributing the Work and assume any
+        risks associated with Your exercise of permissions under this License.
+
+     8. Limitation of Liability. In no event and under no legal theory,
+        whether in tort (including negligence), contract, or otherwise,
+        unless required by applicable law (such as deliberate and grossly
+        negligent acts) or agreed to in writing, shall any Contributor be
+        liable to You for damages, including any direct, indirect, special,
+        incidental, or consequential damages of any character arising as a
+        result of this License or out of the use or inability to use the
+        Work (including but not limited to damages for loss of goodwill,
+        work stoppage, computer failure or malfunction, or any and all
+        other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.
+
+     9. Accepting Warranty or Additional Liability. While redistributing
+        the Work or Derivative Works thereof, You may choose to offer,
+        and charge a fee for, acceptance of support, warranty, indemnity,
+        or other liability obligations and/or rights consistent with this
+        License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf
+        of any other Contributor, and only if You agree to indemnify,
+        defend, and hold each Contributor harmless for any liability
+        incurred by, or claims asserted against, such Contributor by reason
+        of your accepting any such warranty or additional liability.
+
+     END OF TERMS AND CONDITIONS
+
+     APPENDIX: How to apply the Apache License to your work.
+
+        To apply the Apache License to your work, attach the following
+        boilerplate notice, with the fields enclosed by brackets "[]"
+        replaced with your own identifying information. (Don't include
+        the brackets!)  The text should be enclosed in the appropriate
+        comment syntax for the file format. We also recommend that a
+        file or class name and description of purpose be included on the
+        same "printed page" as the copyright notice for easier
+        identification within third-party archives.
+
+     Copyright 2021 PlanetScale, Inc.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+notices: []

--- a/.licenses/go/github.com/shopspring/decimal.dep.yml
+++ b/.licenses/go/github.com/shopspring/decimal.dep.yml
@@ -1,0 +1,61 @@
+---
+name: github.com/shopspring/decimal
+version: v1.2.0
+type: go
+summary: Package decimal implements an arbitrary precision fixed-point decimal.
+homepage: https://godoc.org/github.com/shopspring/decimal
+license: other
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2015 Spring, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+    - Based on https://github.com/oguzbilgic/fpd, which has the following license:
+    """
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Oguz Bilgic
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    """
+- sources: README.md
+  text: |-
+    The MIT License (MIT)
+
+    This is a heavily modified fork of [fpd.Decimal](https://github.com/oguzbilgic/fpd), which was also released under the MIT License.
+notices: []

--- a/.licenses/go/github.com/spf13/afero.dep.yml
+++ b/.licenses/go/github.com/spf13/afero.dep.yml
@@ -1,0 +1,189 @@
+---
+name: github.com/spf13/afero
+version: v1.1.2
+type: go
+summary: 
+homepage: https://godoc.org/github.com/spf13/afero
+license: apache-2.0
+licenses:
+- sources: LICENSE.txt
+  text: |2
+                                    Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+- sources: README.md
+  text: |-
+    Afero is released under the Apache 2.0 license. See
+    [LICENSE.txt](https://github.com/spf13/afero/blob/master/LICENSE.txt)
+notices: []

--- a/.licenses/go/github.com/spf13/afero/mem.dep.yml
+++ b/.licenses/go/github.com/spf13/afero/mem.dep.yml
@@ -1,0 +1,189 @@
+---
+name: github.com/spf13/afero/mem
+version: v1.1.2
+type: go
+summary: 
+homepage: https://godoc.org/github.com/spf13/afero/mem
+license: apache-2.0
+licenses:
+- sources: afero@v1.1.2/LICENSE.txt
+  text: |2
+                                    Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+- sources: afero@v1.1.2/README.md
+  text: |-
+    Afero is released under the Apache 2.0 license. See
+    [LICENSE.txt](https://github.com/spf13/afero/blob/master/LICENSE.txt)
+notices: []

--- a/.licenses/go/github.com/spf13/cast.dep.yml
+++ b/.licenses/go/github.com/spf13/cast.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/spf13/cast
+version: v1.3.0
+type: go
+summary: Package cast provides easy and safe casting in Go.
+homepage: https://godoc.org/github.com/spf13/cast
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Steve Francia
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/spf13/cobra.dep.yml
+++ b/.licenses/go/github.com/spf13/cobra.dep.yml
@@ -1,0 +1,188 @@
+---
+name: github.com/spf13/cobra
+version: v1.1.3
+type: go
+summary: Package cobra is a commander providing a simple interface to create powerful
+  modern CLI interfaces.
+homepage: https://godoc.org/github.com/spf13/cobra
+license: apache-2.0
+licenses:
+- sources: LICENSE.txt
+  text: |2
+                                    Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+- sources: README.md
+  text: Cobra is released under the Apache 2.0 license. See [LICENSE.txt](https://github.com/spf13/cobra/blob/master/LICENSE.txt)
+notices: []

--- a/.licenses/go/github.com/spf13/jwalterweatherman.dep.yml
+++ b/.licenses/go/github.com/spf13/jwalterweatherman.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/spf13/jwalterweatherman
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/spf13/jwalterweatherman
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Steve Francia
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/spf13/pflag.dep.yml
+++ b/.licenses/go/github.com/spf13/pflag.dep.yml
@@ -1,0 +1,40 @@
+---
+name: github.com/spf13/pflag
+version: v1.0.5
+type: go
+summary: Package pflag is a drop-in replacement for Go's flag package, implementing
+  POSIX/GNU-style --flags.
+homepage: https://godoc.org/github.com/spf13/pflag
+license: bsd-3-clause
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2012 Alex Ogier. All rights reserved.
+    Copyright (c) 2012 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices: []

--- a/.licenses/go/github.com/spf13/viper.dep.yml
+++ b/.licenses/go/github.com/spf13/viper.dep.yml
@@ -1,0 +1,32 @@
+---
+name: github.com/spf13/viper
+version: v1.7.1
+type: go
+summary: 
+homepage: https://godoc.org/github.com/spf13/viper
+license: mit
+licenses:
+- sources: LICENSE
+  text: |-
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Steve Francia
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/subosito/gotenv.dep.yml
+++ b/.licenses/go/github.com/subosito/gotenv.dep.yml
@@ -1,0 +1,33 @@
+---
+name: github.com/subosito/gotenv
+version: v1.2.0
+type: go
+summary: Package gotenv provides functionality to dynamically load the environment
+  variables
+homepage: https://godoc.org/github.com/subosito/gotenv
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2013 Alif Rachmawadi
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/driver.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/driver.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/driver
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/driver
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/packet.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/packet.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/packet
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/packet
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/proto.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/proto.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/proto
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/proto
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/sqldb.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/sqldb.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/sqldb
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/sqldb
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/sqlparser/depends/common.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/sqlparser/depends/common.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/sqlparser/depends/common
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/sqlparser/depends/common
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/sqlparser/depends/query.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/sqlparser/depends/query.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/sqlparser/depends/query
+version: v1.0.0
+type: go
+summary: Package query is a generated protocol buffer package.
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/sqlparser/depends/query
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes
+version: v1.0.0
+type: go
+summary: Package sqltypes implements interfaces and types that represent SQL values.
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/github.com/xelabs/go-mysqlstack/xlog.dep.yml
+++ b/.licenses/go/github.com/xelabs/go-mysqlstack/xlog.dep.yml
@@ -1,0 +1,42 @@
+---
+name: github.com/xelabs/go-mysqlstack/xlog
+version: v1.0.0
+type: go
+summary: 
+homepage: https://godoc.org/github.com/xelabs/go-mysqlstack/xlog
+license: bsd-3-clause
+licenses:
+- sources: go-mysqlstack@v1.0.0/LICENSE
+  text: |
+    BSD 3-Clause License
+
+    Copyright (c) 2021, xelabs
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: go-mysqlstack@v1.0.0/README.md
+  text: go-mysqlstack is released under the GPLv3. See LICENSE
+notices: []

--- a/.licenses/go/go.uber.org/atomic.dep.yml
+++ b/.licenses/go/go.uber.org/atomic.dep.yml
@@ -1,0 +1,31 @@
+---
+name: go.uber.org/atomic
+version: v1.7.0
+type: go
+summary: Package atomic provides simple wrappers around numerics to enforce atomic
+  access.
+homepage: https://godoc.org/go.uber.org/atomic
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) 2016 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/multierr.dep.yml
+++ b/.licenses/go/go.uber.org/multierr.dep.yml
@@ -1,0 +1,30 @@
+---
+name: go.uber.org/multierr
+version: v1.6.0
+type: go
+summary: Package multierr allows combining one or more errors together.
+homepage: https://godoc.org/go.uber.org/multierr
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) 2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/zap.dep.yml
+++ b/.licenses/go/go.uber.org/zap.dep.yml
@@ -1,0 +1,30 @@
+---
+name: go.uber.org/zap
+version: v1.16.0
+type: go
+summary: Package zap provides fast, structured, leveled logging.
+homepage: https://godoc.org/go.uber.org/zap
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/zap/buffer.dep.yml
+++ b/.licenses/go/go.uber.org/zap/buffer.dep.yml
@@ -1,0 +1,30 @@
+---
+name: go.uber.org/zap/buffer
+version: v1.16.0
+type: go
+summary: Package buffer provides a thin wrapper around a byte slice.
+homepage: https://godoc.org/go.uber.org/zap/buffer
+license: mit
+licenses:
+- sources: zap@v1.16.0/LICENSE.txt
+  text: |
+    Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/zap/internal/bufferpool.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/bufferpool.dep.yml
@@ -1,0 +1,30 @@
+---
+name: go.uber.org/zap/internal/bufferpool
+version: v1.16.0
+type: go
+summary: Package bufferpool houses zap's shared internal buffer pool.
+homepage: https://godoc.org/go.uber.org/zap/internal/bufferpool
+license: mit
+licenses:
+- sources: zap@v1.16.0/LICENSE.txt
+  text: |
+    Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/zap/internal/color.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/color.dep.yml
@@ -1,0 +1,30 @@
+---
+name: go.uber.org/zap/internal/color
+version: v1.16.0
+type: go
+summary: Package color adds coloring functionality for TTY output.
+homepage: https://godoc.org/go.uber.org/zap/internal/color
+license: mit
+licenses:
+- sources: zap@v1.16.0/LICENSE.txt
+  text: |
+    Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/zap/internal/exit.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/exit.dep.yml
@@ -1,0 +1,31 @@
+---
+name: go.uber.org/zap/internal/exit
+version: v1.16.0
+type: go
+summary: Package exit provides stubs so that unit tests can exercise code that calls
+  os.Exit(1).
+homepage: https://godoc.org/go.uber.org/zap/internal/exit
+license: mit
+licenses:
+- sources: zap@v1.16.0/LICENSE.txt
+  text: |
+    Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/go.uber.org/zap/zapcore.dep.yml
+++ b/.licenses/go/go.uber.org/zap/zapcore.dep.yml
@@ -1,0 +1,31 @@
+---
+name: go.uber.org/zap/zapcore
+version: v1.16.0
+type: go
+summary: Package zapcore defines and implements the low-level interfaces upon which
+  zap is built.
+homepage: https://godoc.org/go.uber.org/zap/zapcore
+license: mit
+licenses:
+- sources: zap@v1.16.0/LICENSE.txt
+  text: |
+    Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+notices: []

--- a/.licenses/go/golang.org/x/crypto/ssh/terminal.dep.yml
+++ b/.licenses/go/golang.org/x/crypto/ssh/terminal.dep.yml
@@ -1,0 +1,63 @@
+---
+name: golang.org/x/crypto/ssh/terminal
+version: v0.0.0-20200622213623-75b288015ac9
+type: go
+summary: Package terminal provides support functions for dealing with terminals, as
+  commonly found on UNIX systems.
+homepage: https://godoc.org/golang.org/x/crypto/ssh/terminal
+license: bsd-3-clause
+licenses:
+- sources: crypto@v0.0.0-20200622213623-75b288015ac9/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: crypto@v0.0.0-20200622213623-75b288015ac9/PATENTS
+  text: |
+    Additional IP Rights Grant (Patents)
+
+    "This implementation" means the copyrightable works distributed by
+    Google as part of the Go project.
+
+    Google hereby grants to You a perpetual, worldwide, non-exclusive,
+    no-charge, royalty-free, irrevocable (except as stated in this section)
+    patent license to make, have made, use, offer to sell, sell, import,
+    transfer and otherwise run, modify and propagate the contents of this
+    implementation of Go, where such license applies only to those patent
+    claims, both currently owned or controlled by Google and acquired in
+    the future, licensable by Google that are necessarily infringed by this
+    implementation of Go.  This grant does not include claims that would be
+    infringed only as a consequence of further modification of this
+    implementation.  If you or your agent or exclusive licensee institute or
+    order or agree to the institution of patent litigation against any
+    entity (including a cross-claim or counterclaim in a lawsuit) alleging
+    that this implementation of Go or any code incorporated within this
+    implementation of Go constitutes direct or contributory patent
+    infringement, or inducement of patent infringement, then any patent
+    rights granted to you under this License for this implementation of Go
+    shall terminate as of the date such litigation is filed.
+notices: []

--- a/.licenses/go/golang.org/x/net/context/ctxhttp.dep.yml
+++ b/.licenses/go/golang.org/x/net/context/ctxhttp.dep.yml
@@ -1,0 +1,63 @@
+---
+name: golang.org/x/net/context/ctxhttp
+version: v0.0.0-20210119194325-5f4716e94777
+type: go
+summary: Package ctxhttp provides helper functions for performing context-aware HTTP
+  requests.
+homepage: https://godoc.org/golang.org/x/net/context/ctxhttp
+license: bsd-3-clause
+licenses:
+- sources: net@v0.0.0-20210119194325-5f4716e94777/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: net@v0.0.0-20210119194325-5f4716e94777/PATENTS
+  text: |
+    Additional IP Rights Grant (Patents)
+
+    "This implementation" means the copyrightable works distributed by
+    Google as part of the Go project.
+
+    Google hereby grants to You a perpetual, worldwide, non-exclusive,
+    no-charge, royalty-free, irrevocable (except as stated in this section)
+    patent license to make, have made, use, offer to sell, sell, import,
+    transfer and otherwise run, modify and propagate the contents of this
+    implementation of Go, where such license applies only to those patent
+    claims, both currently owned or controlled by Google and acquired in
+    the future, licensable by Google that are necessarily infringed by this
+    implementation of Go.  This grant does not include claims that would be
+    infringed only as a consequence of further modification of this
+    implementation.  If you or your agent or exclusive licensee institute or
+    order or agree to the institution of patent litigation against any
+    entity (including a cross-claim or counterclaim in a lawsuit) alleging
+    that this implementation of Go or any code incorporated within this
+    implementation of Go constitutes direct or contributory patent
+    infringement, or inducement of patent infringement, then any patent
+    rights granted to you under this License for this implementation of Go
+    shall terminate as of the date such litigation is filed.
+notices: []

--- a/.licenses/go/golang.org/x/oauth2.dep.yml
+++ b/.licenses/go/golang.org/x/oauth2.dep.yml
@@ -1,0 +1,44 @@
+---
+name: golang.org/x/oauth2
+version: v0.0.0-20201208152858-08078c50e5b5
+type: go
+summary: Package oauth2 provides support for making OAuth2 authorized and authenticated
+  HTTP requests, as specified in RFC 6749.
+homepage: https://godoc.org/golang.org/x/oauth2
+license: bsd-3-clause
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices:
+- sources: AUTHORS
+  text: |-
+    # This source code refers to The Go Authors for copyright purposes.
+    # The master list of authors is in the main Go distribution,
+    # visible at http://tip.golang.org/AUTHORS.

--- a/.licenses/go/golang.org/x/oauth2/internal.dep.yml
+++ b/.licenses/go/golang.org/x/oauth2/internal.dep.yml
@@ -1,0 +1,38 @@
+---
+name: golang.org/x/oauth2/internal
+version: v0.0.0-20201208152858-08078c50e5b5
+type: go
+summary: Package internal contains support packages for oauth2 package.
+homepage: https://godoc.org/golang.org/x/oauth2/internal
+license: bsd-3-clause
+licenses:
+- sources: oauth2@v0.0.0-20201208152858-08078c50e5b5/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices: []

--- a/.licenses/go/golang.org/x/sys/internal/unsafeheader.dep.yml
+++ b/.licenses/go/golang.org/x/sys/internal/unsafeheader.dep.yml
@@ -1,0 +1,63 @@
+---
+name: golang.org/x/sys/internal/unsafeheader
+version: v0.0.0-20201119102817-f84b799fce68
+type: go
+summary: Package unsafeheader contains header declarations for the Go runtime's slice
+  and string implementations.
+homepage: https://godoc.org/golang.org/x/sys/internal/unsafeheader
+license: bsd-3-clause
+licenses:
+- sources: sys@v0.0.0-20201119102817-f84b799fce68/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: sys@v0.0.0-20201119102817-f84b799fce68/PATENTS
+  text: |
+    Additional IP Rights Grant (Patents)
+
+    "This implementation" means the copyrightable works distributed by
+    Google as part of the Go project.
+
+    Google hereby grants to You a perpetual, worldwide, non-exclusive,
+    no-charge, royalty-free, irrevocable (except as stated in this section)
+    patent license to make, have made, use, offer to sell, sell, import,
+    transfer and otherwise run, modify and propagate the contents of this
+    implementation of Go, where such license applies only to those patent
+    claims, both currently owned or controlled by Google and acquired in
+    the future, licensable by Google that are necessarily infringed by this
+    implementation of Go.  This grant does not include claims that would be
+    infringed only as a consequence of further modification of this
+    implementation.  If you or your agent or exclusive licensee institute or
+    order or agree to the institution of patent litigation against any
+    entity (including a cross-claim or counterclaim in a lawsuit) alleging
+    that this implementation of Go or any code incorporated within this
+    implementation of Go constitutes direct or contributory patent
+    infringement, or inducement of patent infringement, then any patent
+    rights granted to you under this License for this implementation of Go
+    shall terminate as of the date such litigation is filed.
+notices: []

--- a/.licenses/go/golang.org/x/sys/unix.dep.yml
+++ b/.licenses/go/golang.org/x/sys/unix.dep.yml
@@ -1,0 +1,62 @@
+---
+name: golang.org/x/sys/unix
+version: v0.0.0-20201119102817-f84b799fce68
+type: go
+summary: Package unix contains an interface to the low-level operating system primitives.
+homepage: https://godoc.org/golang.org/x/sys/unix
+license: bsd-3-clause
+licenses:
+- sources: sys@v0.0.0-20201119102817-f84b799fce68/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: sys@v0.0.0-20201119102817-f84b799fce68/PATENTS
+  text: |
+    Additional IP Rights Grant (Patents)
+
+    "This implementation" means the copyrightable works distributed by
+    Google as part of the Go project.
+
+    Google hereby grants to You a perpetual, worldwide, non-exclusive,
+    no-charge, royalty-free, irrevocable (except as stated in this section)
+    patent license to make, have made, use, offer to sell, sell, import,
+    transfer and otherwise run, modify and propagate the contents of this
+    implementation of Go, where such license applies only to those patent
+    claims, both currently owned or controlled by Google and acquired in
+    the future, licensable by Google that are necessarily infringed by this
+    implementation of Go.  This grant does not include claims that would be
+    infringed only as a consequence of further modification of this
+    implementation.  If you or your agent or exclusive licensee institute or
+    order or agree to the institution of patent litigation against any
+    entity (including a cross-claim or counterclaim in a lawsuit) alleging
+    that this implementation of Go or any code incorporated within this
+    implementation of Go constitutes direct or contributory patent
+    infringement, or inducement of patent infringement, then any patent
+    rights granted to you under this License for this implementation of Go
+    shall terminate as of the date such litigation is filed.
+notices: []

--- a/.licenses/go/golang.org/x/text/width.dep.yml
+++ b/.licenses/go/golang.org/x/text/width.dep.yml
@@ -1,0 +1,62 @@
+---
+name: golang.org/x/text/width
+version: v0.3.3
+type: go
+summary: Package width provides functionality for handling different widths in text.
+homepage: https://godoc.org/golang.org/x/text/width
+license: bsd-3-clause
+licenses:
+- sources: text@v0.3.3/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+- sources: text@v0.3.3/PATENTS
+  text: |
+    Additional IP Rights Grant (Patents)
+
+    "This implementation" means the copyrightable works distributed by
+    Google as part of the Go project.
+
+    Google hereby grants to You a perpetual, worldwide, non-exclusive,
+    no-charge, royalty-free, irrevocable (except as stated in this section)
+    patent license to make, have made, use, offer to sell, sell, import,
+    transfer and otherwise run, modify and propagate the contents of this
+    implementation of Go, where such license applies only to those patent
+    claims, both currently owned or controlled by Google and acquired in
+    the future, licensable by Google that are necessarily infringed by this
+    implementation of Go.  This grant does not include claims that would be
+    infringed only as a consequence of further modification of this
+    implementation.  If you or your agent or exclusive licensee institute or
+    order or agree to the institution of patent litigation against any
+    entity (including a cross-claim or counterclaim in a lawsuit) alleging
+    that this implementation of Go or any code incorporated within this
+    implementation of Go constitutes direct or contributory patent
+    infringement, or inducement of patent infringement, then any patent
+    rights granted to you under this License for this implementation of Go
+    shall terminate as of the date such litigation is filed.
+notices: []

--- a/.licenses/go/gopkg.in/ini.v1.dep.yml
+++ b/.licenses/go/gopkg.in/ini.v1.dep.yml
@@ -1,0 +1,205 @@
+---
+name: gopkg.in/ini.v1
+version: v1.51.0
+type: go
+summary: Package ini provides INI file read and write functionality in Go.
+homepage: https://godoc.org/gopkg.in/ini.v1
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |
+    Apache License
+    Version 2.0, January 2004
+    http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction, and
+    distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by the copyright
+    owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all other entities
+    that control, are controlled by, or are under common control with that entity.
+    For the purposes of this definition, "control" means (i) the power, direct or
+    indirect, to cause the direction or management of such entity, whether by
+    contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity exercising
+    permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications, including
+    but not limited to software source code, documentation source, and configuration
+    files.
+
+    "Object" form shall mean any form resulting from mechanical transformation or
+    translation of a Source form, including but not limited to compiled object code,
+    generated documentation, and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or Object form, made
+    available under the License, as indicated by a copyright notice that is included
+    in or attached to the work (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object form, that
+    is based on (or derived from) the Work and for which the editorial revisions,
+    annotations, elaborations, or other modifications represent, as a whole, an
+    original work of authorship. For the purposes of this License, Derivative Works
+    shall not include works that remain separable from, or merely link (or bind by
+    name) to the interfaces of, the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including the original version
+    of the Work and any modifications or additions to that Work or Derivative Works
+    thereof, that is intentionally submitted to Licensor for inclusion in the Work
+    by the copyright owner or by an individual or Legal Entity authorized to submit
+    on behalf of the copyright owner. For the purposes of this definition,
+    "submitted" means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems, and
+    issue tracking systems that are managed by, or on behalf of, the Licensor for
+    the purpose of discussing and improving the Work, but excluding communication
+    that is conspicuously marked or otherwise designated in writing by the copyright
+    owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+    of whom a Contribution has been received by Licensor and subsequently
+    incorporated within the Work.
+
+    2. Grant of Copyright License.
+
+    Subject to the terms and conditions of this License, each Contributor hereby
+    grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the Work and such
+    Derivative Works in Source or Object form.
+
+    3. Grant of Patent License.
+
+    Subject to the terms and conditions of this License, each Contributor hereby
+    grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+    irrevocable (except as stated in this section) patent license to make, have
+    made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+    such license applies only to those patent claims licensable by such Contributor
+    that are necessarily infringed by their Contribution(s) alone or by combination
+    of their Contribution(s) with the Work to which such Contribution(s) was
+    submitted. If You institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+    Contribution incorporated within the Work constitutes direct or contributory
+    patent infringement, then any patent licenses granted to You under this License
+    for that Work shall terminate as of the date such litigation is filed.
+
+    4. Redistribution.
+
+    You may reproduce and distribute copies of the Work or Derivative Works thereof
+    in any medium, with or without modifications, and in Source or Object form,
+    provided that You meet the following conditions:
+
+    You must give any other recipients of the Work or Derivative Works a copy of
+    this License; and
+    You must cause any modified files to carry prominent notices stating that You
+    changed the files; and
+    You must retain, in the Source form of any Derivative Works that You distribute,
+    all copyright, patent, trademark, and attribution notices from the Source form
+    of the Work, excluding those notices that do not pertain to any part of the
+    Derivative Works; and
+    If the Work includes a "NOTICE" text file as part of its distribution, then any
+    Derivative Works that You distribute must include a readable copy of the
+    attribution notices contained within such NOTICE file, excluding those notices
+    that do not pertain to any part of the Derivative Works, in at least one of the
+    following places: within a NOTICE text file distributed as part of the
+    Derivative Works; within the Source form or documentation, if provided along
+    with the Derivative Works; or, within a display generated by the Derivative
+    Works, if and wherever such third-party notices normally appear. The contents of
+    the NOTICE file are for informational purposes only and do not modify the
+    License. You may add Your own attribution notices within Derivative Works that
+    You distribute, alongside or as an addendum to the NOTICE text from the Work,
+    provided that such additional attribution notices cannot be construed as
+    modifying the License.
+    You may add Your own copyright statement to Your modifications and may provide
+    additional or different license terms and conditions for use, reproduction, or
+    distribution of Your modifications, or for any such Derivative Works as a whole,
+    provided Your use, reproduction, and distribution of the Work otherwise complies
+    with the conditions stated in this License.
+
+    5. Submission of Contributions.
+
+    Unless You explicitly state otherwise, any Contribution intentionally submitted
+    for inclusion in the Work by You to the Licensor shall be under the terms and
+    conditions of this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify the terms of
+    any separate license agreement you may have executed with Licensor regarding
+    such Contributions.
+
+    6. Trademarks.
+
+    This License does not grant permission to use the trade names, trademarks,
+    service marks, or product names of the Licensor, except as required for
+    reasonable and customary use in describing the origin of the Work and
+    reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty.
+
+    Unless required by applicable law or agreed to in writing, Licensor provides the
+    Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+    including, without limitation, any warranties or conditions of TITLE,
+    NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+    solely responsible for determining the appropriateness of using or
+    redistributing the Work and assume any risks associated with Your exercise of
+    permissions under this License.
+
+    8. Limitation of Liability.
+
+    In no event and under no legal theory, whether in tort (including negligence),
+    contract, or otherwise, unless required by applicable law (such as deliberate
+    and grossly negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special, incidental,
+    or consequential damages of any character arising as a result of this License or
+    out of the use or inability to use the Work (including but not limited to
+    damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+    any and all other commercial damages or losses), even if such Contributor has
+    been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability.
+
+    While redistributing the Work or Derivative Works thereof, You may choose to
+    offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+    other liability obligations and/or rights consistent with this License. However,
+    in accepting such obligations, You may act only on Your own behalf and on Your
+    sole responsibility, not on behalf of any other Contributor, and only if You
+    agree to indemnify, defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason of your
+    accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work
+
+    To apply the Apache License to your work, attach the following boilerplate
+    notice, with the fields enclosed by brackets "[]" replaced with your own
+    identifying information. (Don't include the brackets!) The text should be
+    enclosed in the appropriate comment syntax for the file format. We also
+    recommend that a file or class name and description of purpose be included on
+    the same "printed page" as the copyright notice for easier identification within
+    third-party archives.
+
+       Copyright 2014 Unknwon
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+- sources: README.md
+  text: This project is under Apache v2 License. See the [LICENSE](LICENSE) file for
+    the full license text.
+notices: []

--- a/.licenses/go/gopkg.in/yaml.v2.dep.yml
+++ b/.licenses/go/gopkg.in/yaml.v2.dep.yml
@@ -1,0 +1,263 @@
+---
+name: gopkg.in/yaml.v2
+version: v2.4.0
+type: go
+summary: Package yaml implements YAML support for the Go language.
+homepage: https://godoc.org/gopkg.in/yaml.v2
+license: apache-2.0
+licenses:
+- sources: LICENSE
+  text: |2
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+       1. Definitions.
+
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+
+       END OF TERMS AND CONDITIONS
+
+       APPENDIX: How to apply the Apache License to your work.
+
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "{}"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+
+       Copyright {yyyy} {name of copyright owner}
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+- sources: LICENSE.libyaml
+  text: |
+    The following files were ported to Go from C files of libyaml, and thus
+    are still covered by their original copyright and license:
+
+        apic.go
+        emitterc.go
+        parserc.go
+        readerc.go
+        scannerc.go
+        writerc.go
+        yamlh.go
+        yamlprivateh.go
+
+    Copyright (c) 2006 Kirill Simonov
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+    of the Software, and to permit persons to whom the Software is furnished to do
+    so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+- sources: README.md
+  text: The yaml package is licensed under the Apache License 2.0. Please see the
+    LICENSE file for details.
+notices:
+- sources: NOTICE
+  text: |-
+    Copyright 2011-2016 Canonical Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.


### PR DESCRIPTION
This PR adds a new CI workflow that checks continously for new
dependencies and their licenses. We use the
https://github.com/github/licensed tool for this check.

`licensed` caches all the dependencies licenses and then checks
according to the `.licensed.yml` file whether a license is allowed or
not. This will make sure we detect dependencies we introduce have the
correct licenses and agreements:

```
allowed:
  - mit
  - apache-2.0
  - bsd-2-clause
  - bsd-3-clause
  - mpl-2.0
```

/xref https://github.com/planetscale/project-big-bang/issues/307
