### PR TITLE
Final preparations for the Beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Configure git private repo access
-      env:
-        GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
-      run: |
-        git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
@@ -55,17 +49,13 @@ jobs:
         version: v0.164.0
         args: release --rm-dist
       env:
-        GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
+        # https://github.com/goreleaser/goreleaser-action#limitation
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Configure git private repo access
-        env:
-          GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
-        run: |
-          git config --global --add url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -11,12 +11,6 @@ jobs:
   licensed:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure git private repo access
-        env:
-          GITHUB_TOKEN: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
-        run: |
-          git config --global --add url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-
       - name: Checkout repository
         uses: actions/checkout@v2
 
@@ -34,13 +28,12 @@ jobs:
         id: licensed
         uses: jonabc/licensed-ci@v1
         with:
-          github_token: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Report licensed activity
         uses: actions/github-script@0.2.0
         if: always() && steps.licensed.outputs.pr_number
         with:
-          github-token: ${{ secrets.PLANETSCALE_ACTIONS_BOT_TOKEN }}
           script: |
             github.issues.createComment({
               owner: context.repo.owner,

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,9 +33,6 @@ brews:
     dependencies:
       - name: mysql # needed for 'pscale shell'
         type: optional
-    # TODO: remove this once we make the repo public      
-    download_strategy: GitHubPrivateRepositoryReleaseDownloadStrategy
-    custom_require: "../custom_download_strategy"
     folder: Formula
     test: |
          system "#{bin}/pscale --version"


### PR DESCRIPTION
This PR includes the latest and final changes before we make the repository public. It removes the access to the org level PAT and removes the custom homebrew formula.

The CI will fail because it won't have access to some of the dependencies; hence once we merge it, the CI checks will fail until we make all repositories public.

This will also break homebrew publishing, even after we open source everything. The reason is the CI needs a PAT to write to the repo: https://github.com/planetscale/homebrew-tap. Hence, until we make  `pscale` part of the official homebrew release, we need to release it manually. Here is an example commit that updates a new homebrew version: https://github.com/planetscale/homebrew-tap/commit/f9db816fedf9fd067614d5a8b03b734d7e0f3307

/xref https://github.com/planetscale/project-big-bang/issues/307
