### PR TITLE
backup: remove shorthand flag for the `--force` flag

### DIFF
--- a/internal/cmd/backup/delete.go
+++ b/internal/cmd/backup/delete.go
@@ -104,6 +104,6 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&force, "force", "f", false, "Delete a backup without confirmation")
+	cmd.Flags().BoolVar(&force, "force", false, "Delete a backup without confirmation")
 	return cmd
 }


### PR DESCRIPTION
This is a leftover when we introduced the `--format` and its shorthand flag `-f` (see: https://github.com/planetscale/project-big-bang/issues/168 for more detail).

The user has to explicitly pass the `--force` flag, and we don't allow the `-f` shorthand flag to be used anymore.

closes: https://github.com/planetscale/project-big-bang/issues/328
