### PR TITLE
shell: show a more user friendly message if `mysql` client doesn't exist

### DIFF
--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -4,8 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 
+	"github.com/cli/safeexec"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
@@ -90,4 +94,62 @@ func NewZapLogger(debug bool) *zap.Logger {
 	logger := zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(encoderCfg), os.Stdout, level))
 
 	return logger
+}
+
+// IsUnderHomebrew checks whether the given binary is under the homebrew path.
+// copied from: https://github.com/cli/cli/blob/trunk/cmd/gh/main.go#L298
+func IsUnderHomebrew(binpath string) bool {
+	if binpath == "" {
+		return false
+	}
+
+	brewExe, err := safeexec.LookPath("brew")
+	if err != nil {
+		return false
+	}
+
+	brewPrefixBytes, err := exec.Command(brewExe, "--prefix").Output()
+	if err != nil {
+		return false
+	}
+
+	brewBinPrefix := filepath.Join(strings.TrimSpace(string(brewPrefixBytes)), "bin") + string(filepath.Separator)
+	return strings.HasPrefix(binpath, brewBinPrefix)
+}
+
+// HasHomebrew check whether the user has installed brew
+func HasHomebrew() bool {
+	_, err := exec.LookPath("brew")
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+// MySQLClientPath checks whether the 'mysql' client exists and returns the
+// path to the binary. The returned error contains instructions to install the
+// client.
+func MySQLClientPath() (string, error) {
+	path, err := exec.LookPath("mysql")
+	if err == nil {
+		return path, nil
+	}
+
+	msg := "couldn't find the 'msyql' client required to run this command."
+	installURL := "https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install.html"
+
+	switch runtime.GOOS {
+	case "darwin":
+		if HasHomebrew() {
+			return "", fmt.Errorf("%s\nTo install, run: brew install mysql-client", msg)
+		}
+
+		installURL = "https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install-macos-quick.html"
+	case "linux":
+		installURL = "https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install-linux-quick.html"
+	case "windows":
+		installURL = "https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install-windows-quick.html"
+	}
+
+	return "", fmt.Errorf("%s\nTo install, follow the instructions: %s", msg, installURL)
 }


### PR DESCRIPTION
This PR improves how we check for the `msyql` client and show an error:

* We introduced a new `MySQLClientPath` function that checks and returns the path of the `msyql` client. If it doesn't exist, it returns an error with a user-friendly instruction on installing the client.
* It looks like we were checking twice for the existence of the `msyql` client; we now check only once.
* We moved the `isUnderHomebrew()` function to the `cmdutil` package.  This change is not related to this functionality, but we fixed a couple of issues while working on pathfinding problems.

---

Examples:

Under `linux`:

```
$ pscale shell planetscale main
Error: couldn't find the 'msyql' client CLI required to run this command.
To install, follow the instructions: https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install-linux-quick.html
```

Under `macOS`:

```
$ pscale shell planetscale main
Error: couldn't find the 'msyql' client CLI required to run this command.
To install, follow the instructions: https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-install-macos-quick.html
```

Under `macOS` and if we detect that the user is using homebrew:

```
$ pscale shell planetscale main
Error: couldn't find the 'msyql' client CLI required to run this command.
To install, run: brew install mysql-client
```

closes: https://github.com/planetscale/project-big-bang/issues/323
