### PR TITLE
Do not try and enhance MySQL Prompt in Linux

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -312,7 +312,7 @@ func checkLibs(ctx context.Context, mysqlPath string) (bool, error) {
 		name = "otool"
 		args = []string{"-L"}
 	case "linux":
-		name = "ldd"
+		return false, nil
 	case "unix":
 		return false, nil
 	}


### PR DESCRIPTION
We're not confident that we can do this the way that we want, so we'll leave it as the default for now. Same as Windows. 