### PR TITLE
Update README.md to include mysql-client install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PlanetScale is more than a database and our CLI is more than a jumble of command
 ```
 brew install planetscale/tap/pscale
 ```
-!! Note of importance: `pscale` requires the MySQL Client. You can install it by running:
+Optional: `pscale` requires the MySQL Client for certain commands. You can install it by running:
 
 ```
 brew install mysql-client
@@ -37,4 +37,3 @@ brew upgrade pscale
 ### Manually
 
 Download the pre-compiled binaries from the [releases](https://github.com/planetscale/cli/releases/latest) page and copy to the desired location.
-


### PR DESCRIPTION
Upon invoking the pscale cli, an error occurs stating:
`Error: couldn't find the 'msyql' client required to run this command.`
To resolve this, you need to run:
`brew install mysql-client` and set the appropriate PATH to be able to use it.
Once this has been done, the Planetscale CLI works properly.

Environment:
M1 ARM Mac
MacOS 11.2.3
Homebrew 3.1.8
