### PR TITLE
ci: update linter to use staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ test:
 build:
 	go build ./...
 
+.PHONY: lint
+lint: 
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
+	@staticcheck ./...
+
 .PHONY: licensed
 licensed:
 	licensed cache
 	licensed status
 
-.PHONY: lint
-lint: 
-	@script/lint

--- a/internal/cmd/backup/create.go
+++ b/internal/cmd/backup/create.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			bkp, err := client.Backups.Create(ctx, createReq)
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
-				case planetscale.ErrNotFound:
+				case ps.ErrNotFound:
 					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
 						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:

--- a/internal/cmd/backup/delete.go
+++ b/internal/cmd/backup/delete.go
@@ -37,12 +37,12 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("Cannot delete backup with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete backup with the output format %q (run with -force to override)", ch.Printer.Format())
 				}
 
 				confirmationName := fmt.Sprintf("%s/%s/%s", database, branch, backup)
 				if !printer.IsTTY {
-					return fmt.Errorf("Cannot confirm deletion of backup %q (run with -force to override)", confirmationName)
+					return fmt.Errorf("cannot confirm deletion of backup %q (run with -force to override)", confirmationName)
 				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"), printer.BoldBlue(confirmationName), printer.Bold("to confirm:"))
@@ -63,7 +63,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				// If the confirmations don't match up, let's return an error.
 				if userInput != confirmationName {
-					return errors.New("Incorrect backup name entered, skipping backup deletion...")
+					return errors.New("incorrect backup name entered, skipping backup deletion")
 				}
 			}
 
@@ -79,7 +79,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)\n",
+					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)",
 						printer.BoldBlue(backup), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/backup/list.go
+++ b/internal/cmd/backup/list.go
@@ -53,7 +53,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)\n",
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
 						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/backup/show.go
+++ b/internal/cmd/backup/show.go
@@ -54,7 +54,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)\n",
+					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)",
 						printer.BoldBlue(backup), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/browser"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +29,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			// Simplest case, the names are equivalent
 			if source == branch {
-				return fmt.Errorf("A branch named '%s' already exists", branch)
+				return fmt.Errorf("a branch named '%s' already exists", branch)
 			}
 
 			createReq.Database = source
@@ -64,8 +63,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			dbBranch, err := client.DatabaseBranches.Create(ctx, createReq)
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
-				case planetscale.ErrNotFound:
-					return fmt.Errorf("source database %s does not exist in organization %s\n",
+				case ps.ErrNotFound:
+					return fmt.Errorf("source database %s does not exist in organization %s",
 						printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/delete.go
+++ b/internal/cmd/branch/delete.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
-
 	"github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -36,12 +35,12 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("Cannot delete branch with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete branch with the output format %q (run with -force to override)", ch.Printer.Format())
 				}
 
 				confirmationName := fmt.Sprintf("%s/%s", source, branch)
 				if !printer.IsTTY {
-					return fmt.Errorf("Cannot confirm deletion of branch %q (run with -force to override)", confirmationName)
+					return fmt.Errorf("cannot confirm deletion of branch %q (run with -force to override)", confirmationName)
 				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"),
@@ -63,7 +62,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				// If the confirmations don't match up, let's return an error.
 				if userInput != confirmationName {
-					return errors.New("Incorrect database and branch name entered, skipping branch deletion...")
+					return errors.New("incorrect database and branch name entered, skipping branch deletion")
 				}
 			}
 
@@ -77,7 +76,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("source database %s does not exist in organization %s\n",
+					return fmt.Errorf("source database %s does not exist in organization %s",
 						printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/diff.go
+++ b/internal/cmd/branch/diff.go
@@ -41,7 +41,7 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)\n",
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
 						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/list.go
+++ b/internal/cmd/branch/list.go
@@ -52,7 +52,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/schema.go
+++ b/internal/cmd/branch/schema.go
@@ -45,7 +45,7 @@ func SchemaCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)\n",
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
 						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -9,8 +9,8 @@ import (
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/printer"
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
+
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +34,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 			ch.Printer.Printf("Finding branch %s on database %s\n",
 				printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Database))
 
-			_, err = client.DatabaseBranches.Get(ctx, &planetscale.GetDatabaseBranchRequest{
+			_, err = client.DatabaseBranches.Get(ctx, &ps.GetDatabaseBranchRequest{
 				Organization: ch.Config.Organization,
 				Database:     ch.Config.Database,
 				Branch:       branch,

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -78,7 +78,7 @@ argument:
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s and branch %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s and branch %s does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/pkg/browser"
@@ -52,8 +51,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			database, err := client.Databases.Create(ctx, createReq)
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
-				case planetscale.ErrNotFound:
-					return fmt.Errorf("organization %s does not exist\n", printer.BoldBlue(ch.Config.Organization))
+				case ps.ErrNotFound:
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}

--- a/internal/cmd/database/delete.go
+++ b/internal/cmd/database/delete.go
@@ -37,7 +37,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if !printer.IsTTY {
-					return fmt.Errorf("Cannot confirm deletion of database %q (run with -force to override)", name)
+					return fmt.Errorf("cannot confirm deletion of database %q (run with -force to override)", name)
 				}
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"), printer.BoldBlue(name), printer.Bold("to confirm:"))
 
@@ -56,7 +56,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 
 				if userInput != name {
-					return errors.New("Incorrect database name entered, skipping database deletion...")
+					return errors.New("incorrect database name entered, skipping database deletion")
 				}
 			}
 
@@ -70,7 +70,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s",
 						printer.BoldBlue(name), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -101,7 +101,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	}
 
 	if status.Credentials.User == "" {
-		return errors.New("database branch is not ready yet, please try again in a few minutes.")
+		return errors.New("database branch is not ready yet, please try again in a few minutes")
 	}
 
 	addr, err := p.LocalAddr()

--- a/internal/cmd/database/list.go
+++ b/internal/cmd/database/list.go
@@ -48,7 +48,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("organization %s does not exist\n", printer.BoldBlue(ch.Config.Organization))
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -100,7 +100,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 	}
 
 	if status.Credentials.User == "" {
-		return errors.New("database branch is not ready yet, please try again in a few minutes.")
+		return errors.New("database branch is not ready yet, please try again in a few minutes")
 	}
 
 	addr, err := p.LocalAddr()

--- a/internal/cmd/database/show.go
+++ b/internal/cmd/database/show.go
@@ -51,7 +51,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s",
 						printer.BoldBlue(name), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/close.go
+++ b/internal/cmd/deployrequest/close.go
@@ -30,7 +30,7 @@ func CloseCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("The argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
 			}
 
 			dr, err := client.DeployRequests.CloseDeploy(ctx, &planetscale.CloseDeployRequestRequest{
@@ -41,7 +41,7 @@ func CloseCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/create.go
+++ b/internal/cmd/deployrequest/create.go
@@ -43,7 +43,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s does not exist in %s\n",
+					return fmt.Errorf("database %s does not exist in %s",
 						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -30,7 +30,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("The argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
 			}
 
 			dr, err := client.DeployRequests.Deploy(ctx, &planetscale.PerformDeployRequest{
@@ -41,7 +41,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/diff.go
+++ b/internal/cmd/deployrequest/diff.go
@@ -43,7 +43,7 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("The argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
 			}
 
 			diffs, err := client.DeployRequests.Diff(ctx, &planetscale.DiffRequest{
@@ -54,7 +54,7 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("deploy rquest '%s/%s' does not exist in organization %s\n",
+					return fmt.Errorf("deploy rquest '%s/%s' does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/list.go
+++ b/internal/cmd/deployrequest/list.go
@@ -52,7 +52,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/review.go
+++ b/internal/cmd/deployrequest/review.go
@@ -36,7 +36,7 @@ func ReviewCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("The argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
 			}
 
 			client, err := ch.Client()
@@ -59,7 +59,7 @@ func ReviewCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/deployrequest/review_test.go
+++ b/internal/cmd/deployrequest/review_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/planetscale/cli/internal/printer"
 
 	qt "github.com/frankban/quicktest"
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 )
 
@@ -27,7 +26,7 @@ func TestDeployRequest_ReviewCmd(t *testing.T) {
 	org := "planetscale"
 	db := "planetscale"
 	var number uint64 = 10
-	action := planetscale.ReviewComment
+	action := ps.ReviewComment
 	comment := "this is a comment"
 
 	res := &ps.DeployRequestReview{

--- a/internal/cmd/deployrequest/show.go
+++ b/internal/cmd/deployrequest/show.go
@@ -40,7 +40,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("The argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
 			}
 
 			dr, err := client.DeployRequests.Get(ctx, &planetscale.GetDeployRequestRequest{
@@ -51,7 +51,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s\n",
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/org/switch.go
+++ b/internal/cmd/org/switch.go
@@ -45,7 +45,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 				if err != nil {
 					switch cmdutil.ErrCode(err) {
 					case planetscale.ErrNotFound:
-						return fmt.Errorf("organization %s does not exist\n", printer.BoldBlue(orgName))
+						return fmt.Errorf("organization %s does not exist", printer.BoldBlue(orgName))
 					default:
 						return cmdutil.HandleError(err)
 					}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -150,6 +150,7 @@ func Execute(ver, commit, buildDate string) error {
 		case printer.JSON:
 			return fmt.Errorf(`{"error": "%s"}`, err)
 		default:
+			//lint:ignore ST1005 This is shown to the user
 			return fmt.Errorf("Error: %s", err)
 		}
 	}

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -92,7 +92,7 @@ second argument:
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("database %s and branch %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s and branch %s does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/token/addaccess.go
+++ b/internal/cmd/token/addaccess.go
@@ -8,6 +8,7 @@ import (
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	"github.com/planetscale/planetscale-go/planetscale"
+
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +50,7 @@ For a complete list of the access permissions that can be granted to a token, se
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s does not exist in organization %s\n",
+					return fmt.Errorf("database %s does not exist in organization %s",
 						printer.BoldBlue(ch.Config.Database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/token/create.go
+++ b/internal/cmd/token/create.go
@@ -32,7 +32,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("organization %s does not exist\n", printer.BoldBlue(ch.Config.Organization))
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}

--- a/internal/cmd/token/delete.go
+++ b/internal/cmd/token/delete.go
@@ -38,7 +38,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err := client.ServiceTokens.Delete(ctx, req); err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("token does not exist in organization %s\n",
+					return fmt.Errorf("token does not exist in organization %s",
 						printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/token/deleteaccess.go
+++ b/internal/cmd/token/deleteaccess.go
@@ -41,7 +41,7 @@ func DeleteAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err := client.ServiceTokens.DeleteAccess(ctx, req); err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s or token does not exist in organization %s\n",
+					return fmt.Errorf("database %s or token does not exist in organization %s",
 						printer.BoldBlue(ch.Config.Database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/token/list.go
+++ b/internal/cmd/token/list.go
@@ -32,7 +32,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("organization %s does not exist\n", printer.BoldBlue(ch.Config.Organization))
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}

--- a/internal/cmd/token/showaccess.go
+++ b/internal/cmd/token/showaccess.go
@@ -39,7 +39,7 @@ func ShowAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("access %s does not exist in organization %s\n",
+					return fmt.Errorf("access %s does not exist in organization %s",
 						printer.BoldBlue(name), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/script/lint
+++ b/script/lint
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -e
-
-# binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1
-
-golangci-lint --version
-golangci-lint run ./...


### PR DESCRIPTION
`staticcheck` is better compared to other linters. It comes with sane
defaults and has a better release story (as an example it doesn't break
suddenly due to a new version).