### PR TITLE
cmdutil: handle arm64 Homebrew prefix

### DIFF
--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -130,8 +130,12 @@ func HasHomebrew() bool {
 func MySQLClientPath() (string, error) {
 	// brew install mysql-client installs the client into an unusual path
 	if runtime.GOOS == "darwin" {
+		homebrewPrefix := "/usr/local"
+		if runtime.GOARCH == "arm64" {
+			homebrewPrefix = "/opt/homebrew"
+		}
 		oldpath := os.Getenv("PATH")
-		newpath := "/usr/local/opt/mysql-client/bin/" + string(os.PathListSeparator) + oldpath
+		newpath := homebrewPrefix + "/opt/mysql-client/bin/" + string(os.PathListSeparator) + oldpath
 
 		defer func() {
 			if err := os.Setenv("PATH", oldpath); err != nil {


### PR DESCRIPTION
This is a follow-up to d19242e. From Homebrew:

> Homebrew’s pre-built binary packages (known as bottles) of many
> packages can only be used if you install in the default installation
> prefix, otherwise they have to be built from source. Building from
> source takes a long time, is prone to fail, and is not supported. Do
> yourself a favour and install to the default prefix so that you can use
> our pre-built binary packages. The default prefix is `/usr/local` for
> macOS on Intel, `/opt/homebrew` for macOS on ARM, and
> `/home/linuxbrew/.linuxbrew` for Linux. Pick another prefix at your peril!

https://docs.brew.sh/FAQ#why-should-i-install-homebrew-in-the-default-location

I've tested this on my M1 laptop with `go install ./...` on `94a168a7`.
Before this change, if I remove this from my shell profile...

```
export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"
```

...then `pscale shell test main --debug` prints:

```
Error: couldn't find the 'mysql' client required to run this command.
To install, run: brew install mysql-client
```

With this change, I'm able to connect.