### PR TITLE
`pscale database dump`: support Demo DBs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.10.0
 	github.com/frankban/quicktest v1.13.0
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gocarina/gocsv v0.0.0-20210326111627-0340a0229e98
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gocarina/gocsv v0.0.0-20210326111627-0340a0229e98 h1:kmuCASO9n1dN4NLlOP7zx9svH8oIZiKB1tf6/rUAiyY=
 github.com/gocarina/gocsv v0.0.0-20210326111627-0340a0229e98/go.mod h1:5YoVOkjYAQumqlV356Hj3xeYh4BdZuLE0/nRkf2NKkI=

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -17,8 +18,12 @@ import (
 	"github.com/planetscale/sql-proxy/proxy"
 	"github.com/planetscale/sql-proxy/sigutil"
 
+	_ "github.com/go-sql-driver/mysql"
+
 	"github.com/spf13/cobra"
 )
+
+var demoDatabaseNames = map[string]struct{}{"onboarding-demo": struct{}{}}
 
 type dumpFlags struct {
 	localAddr string
@@ -109,6 +114,11 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 		return err
 	}
 
+	dbName, err := getDatabaseName(database, addr.String(), status.Credentials)
+	if err != nil {
+		return err
+	}
+
 	dir, err := os.Getwd()
 	if err != nil {
 		return err
@@ -132,7 +142,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	cfg.User = status.Credentials.User
 	cfg.Password = status.Credentials.Password
 	cfg.Address = addr.String()
-	cfg.Database = database
+	cfg.Database = dbName
 	cfg.Debug = ch.Debug()
 	cfg.StmtSize = 1000000
 	cfg.IntervalMs = 10 * 1000
@@ -169,4 +179,42 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	end()
 	ch.Printer.Printf("Dumping is finished! (elapsed time: %s)\n", time.Since(start))
 	return nil
+}
+
+func getDatabaseName(name, addr string, credentials ps.DatabaseBranchCredentials) (string, error) {
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/", credentials.User, credentials.Password, addr)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+
+	results, err := db.Query("SHOW DATABASES")
+	if err != nil {
+		return "", err
+	}
+
+	var dbs []string
+
+	for results.Next() {
+		var db string
+		if err := results.Scan(&db); err != nil {
+			return "", err
+		}
+
+		if name == db {
+			return db, nil
+		}
+
+		dbs = append(dbs, db)
+	}
+
+	// this means we didn't find a match.
+	for _, v := range dbs {
+		if _, ok := demoDatabaseNames[v]; ok {
+			return v, nil
+		}
+	}
+
+	return "", errors.New("could not find a valid database name for this database")
 }

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -194,6 +194,8 @@ func getDatabaseName(name, addr string, credentials ps.DatabaseBranchCredentials
 		return "", err
 	}
 
+	defer results.Close()
+
 	var dbs []string
 
 	for results.Next() {


### PR DESCRIPTION
The Demo databases come up with a database name that doesn't match the name in PlanetScale, which is unique to demo databases.

This PR changes `pscale databsae dump` to look at all of the MySQL databases to look for either:

1. The DB that matches the name of the database
2. Any of the demo names