### PR TITLE
Add newline to connection established string

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -144,7 +144,7 @@ func runProxy(proxyOpts proxy.Options, database, branch string, ready chan strin
 			return
 		}
 
-		fmt.Printf("Secure connection to database %s and branch %s is established!.\n\nLocal address to connect your application: %s (press ctrl-c to quit)",
+		fmt.Printf("Secure connection to database %s and branch %s is established!.\n\nLocal address to connect your application: %s (press ctrl-c to quit)\n",
 			printer.BoldBlue(database),
 			printer.BoldBlue(branch),
 			printer.BoldBlue(addr.String()),


### PR DESCRIPTION
This adds a newline character to the connection established string so that any commands executed with `--execute` are printed cleanly on the following line.

**Before**

```shell
❯ pscale connect meow main --execute 'echo "Hello World"'
Secure connection to database meow and branch main is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)Hello World
```

**After**
```shell
❯ pscale connect meow main --execute 'echo "Hello World"'
Secure connection to database meow and branch main is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)
Hello World
```
