### PR TITLE
tty: detect tty without depending on the color package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23 // indirect
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
+	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mattn/go-shellwords v1.0.11
 	github.com/mitchellh/go-homedir v1.1.0

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -14,9 +14,10 @@ import (
 	"github.com/fatih/color"
 	"github.com/gocarina/gocsv"
 	"github.com/lensesio/tableprinter"
+	"github.com/mattn/go-isatty"
 )
 
-var IsTTY = !color.NoColor
+var IsTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 
 // Format defines the option output format of a resource.
 type Format int


### PR DESCRIPTION
This PR fixes the issue when coloring is disabled with the `NO_COLOR` environment variable. This would set `color.NoColor` variable to `true`, and hence in an environment where `NO_COLOR` is set, commands like `pscale auth login` would fail:

```
$ pscale auth login
Error: The 'login' command requires an interactive shell
```

With this change, if the user sets the `NO_COLOR` environment variable, it continues to work, but only the colors are disabled.
