### PR TITLE
Add Dockerfile to run `pscale` as a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build github.com/planetscale/cli/cmd/pscale
 
 FROM alpine:latest  
-RUN apk --no-cache add ca-certificates
-RUN apk add mysql-client
+RUN apk --no-cache add ca-certificates mysql-client
 
 WORKDIR /app
 COPY --from=build /app/pscale /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.16 as build
+WORKDIR /app
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build github.com/planetscale/cli/cmd/pscale
+
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates
+RUN apk add mysql-client
+
+WORKDIR /app
+COPY --from=build /app/pscale /usr/bin
+ENTRYPOINT ["/usr/bin/pscale"] 


### PR DESCRIPTION
This PR introduces a simple `Dockerfile` that allows us to run `pscale` from within a container. Here are the commands if you want to try it out on your localhost:

```shell
# build the image
docker build -t pscale:latest .

# run the container
# create the service tokens via 'pscale service-token create'
docker run -it --env PLANETSCALE_SERVICE_TOKEN= <token> --env PLANETSCALE_SERVICE_TOKEN_NAME=<name> --env PLANETSCALE_ORG=<org>  pscale shell planetscale main
``` 

Three environment variables are required to make it work:

```
PLANETSCALE_SERVICE_TOKEN
PLANETSCALE_SERVICE_TOKEN_NAME
PLANETSCALE_ORG
```

Users can also use the `--env-file` option (https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file) to set the environment variables.

 There are several things that I'm planning to do in follow-up PRs: 

* Push to a public registry
* Configure `goreleaser` so it automatically publishes with the CLI version
* Check `pscale connect` and make it work. Users who wish to use `pscale connect` as a sidecar pattern will probably provide a container based on https://github.com/planetscale/sql-proxy. The `pscale connect` functionality is built on top of `planetscale/sql-proxy` codebase.


/xref https://github.com/planetscale/cli/issues/254
