### PR TITLE
cmd/connect: return exit status of `--execute` flag

### DIFF
--- a/cmd/pscale/main.go
+++ b/cmd/pscale/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/planetscale/cli/internal/cmd"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
 )
 
 var (
@@ -14,8 +17,20 @@ var (
 )
 
 func main() {
-	if err := cmd.Execute(version, commit, date); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+	var format printer.Format
+	if err := cmd.Execute(version, commit, date, &format); err != nil {
+		switch format {
+		case printer.JSON:
+			fmt.Fprintf(os.Stderr, `{"error": "%s"}`, err)
+		default:
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
+
+		var cmdErr *cmdutil.Error
+		if errors.As(err, &cmdErr) {
+			os.Exit(cmdErr.ExitCode)
+		} else {
+			os.Exit(1)
+		}
 	}
 }

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -6,6 +6,15 @@ import (
 	"github.com/planetscale/planetscale-go/planetscale"
 )
 
+// Error can be used by a command to change the exit status of the CLI.
+type Error struct {
+	Msg string
+	// Status
+	ExitCode int
+}
+
+func (e *Error) Error() string { return e.Msg }
+
 // ErrCode returns the code from a *planetscale.Error, if available. If the
 // error is not of type *planetscale.Error or is nil, it returns an empty,
 // undefined error code.


### PR DESCRIPTION
This PR improves the `pscale connect` commands `--execute` flag. It now
captures the exit code of the command passed to the `--execute` flag and
exits with the returned code.  

I wrote a simple tool that exits with the code passed to the tools. As you see here, it exits with `0` or `2` and we successfully capture it:  


```
$ pscale connect planetscale main --execute 'demo 0'
Secure connection to database planetscale and branch main is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)
exiting with 0
$ echo $status
0

$ pscale connect planetscale main --execute 'demo 2'
Secure connection to database planetscale and branch main is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)
exiting with 2
Error: running command with --execute has failed: exit status 2

$ echo $status
2
```

closes: https://github.com/planetscale/cli/issues/283
