### PR TITLE
cmd: improve execution of the root command

### DIFF
--- a/cmd/pscale/main.go
+++ b/cmd/pscale/main.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	"os"
 
 	"github.com/planetscale/cli/internal/cmd"
-	"github.com/planetscale/cli/internal/cmdutil"
-	"github.com/planetscale/cli/internal/printer"
 )
 
 var (
@@ -17,20 +13,5 @@ var (
 )
 
 func main() {
-	var format printer.Format
-	if err := cmd.Execute(version, commit, date, &format); err != nil {
-		switch format {
-		case printer.JSON:
-			fmt.Fprintf(os.Stderr, `{"error": "%s"}`, err)
-		default:
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		}
-
-		var cmdErr *cmdutil.Error
-		if errors.As(err, &cmdErr) {
-			os.Exit(cmdErr.ExitCode)
-		} else {
-			os.Exit(1)
-		}
-	}
+	os.Exit(cmd.Execute(version, commit, date))
 }


### PR DESCRIPTION
This PR simplifies the execution and printing of the error message of the root command. Previously, we would print an error message inside the `cmd/pscale` package and the `internal/cmd` package. The exit status returned from the root command would also be shadowed from another function call. In our case, this was the `updater` logic. Having these two operations in different places makes it difficult to debug and also introduces bugs (see: https://github.com/planetscale/cli/issues/283#issuecomment-852393281)

With this PR, the `cmd/pscale` main package only exits with a given exit code. It's as minimal as its gets. By making sure we're also just exiting with a code in the main package, we also set an artificial boundary. This way, we don't print any message accidentally inside the `main` package (because all it receives is an integer value).

Next, we separated the actual execution of the root command and any post-function calls. The root command is now called with the `cmd.runCmd()` function. The `cmd.Execute()` is now responsible for calling the root command, printing any useful information/errors to the users, and returning the **correct** exit code to the `main` package. 

closes: https://github.com/planetscale/cli/issues/283
