### PR TITLE
Dockerfile: add build and push instructions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,18 @@ builds:
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: "pscale"   
+dockers:
+  - image_templates:
+    - "planetscale/pscale:latest"
+    - "planetscale/pscale:{{ .Tag }}"
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    dockerfile: Dockerfile.goreleaser
 nfpms:
   - maintainer: PlanetScale
     description: The PlanetScale CLI
@@ -52,3 +64,4 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+      - Merge pull request

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=$COM
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates mysql-client
+EXPOSE 3306
 
 WORKDIR /app
 COPY --from=build /app/pscale /usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM golang:1.16 as build
 WORKDIR /app
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build github.com/planetscale/cli/cmd/pscale
+
+ARG VERSION
+ARG COMMIT
+ARG DATE
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates mysql-client

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,6 @@
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates mysql-client
+EXPOSE 3306
 
 ENTRYPOINT ["/usr/bin/pscale"] 
 COPY pscale /usr/bin

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,5 @@
+FROM alpine:latest  
+RUN apk --no-cache add ca-certificates mysql-client
+
+ENTRYPOINT ["/usr/bin/pscale"] 
+COPY pscale /usr/bin

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,27 @@
+COMMIT := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
+VERSION := $(shell git describe --abbrev=0 HEAD 2>/dev/null)
+DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+ifeq ($(strip $(shell git status --porcelain 2>/dev/null)),)
+  GIT_TREE_STATE=clean
+else
+  GIT_TREE_STATE=dirty
+endif
+
+REPO=planetscale
+NAME=pscale
+BUILD_PKG=github.com/planetscale/cli/cmd/pscale
+
 .PHONY: all
 all: build test lint
 
 .PHONY: test
 test:
-	go test ./...
+	@go test ./...
 
 .PHONY: build
 build:
-	go build ./...
+	@go build ./... 
 
 .PHONY: lint
 lint: 
@@ -19,3 +33,24 @@ licensed:
 	licensed cache
 	licensed status
 
+.PHONY: build-image
+build-image: 
+	@echo "==> Building docker image ${REPO}/${NAME}:$(VERSION)"
+	@# Permit building only if the Git tree is clean
+	@echo "${GIT_TREE_STATE}" | grep -Eq "^clean" || ( echo "Git tree state is not clean"; exit 1 )
+	@docker build --build-arg VERSION=$(VERSION:v%=%) --build-arg COMMIT=$(COMMIT) --build-arg DATE=$(DATE) -t ${REPO}/${NAME}:$(VERSION) .
+	@docker tag ${REPO}/${NAME}:$(VERSION) ${REPO}/${NAME}:latest
+
+.PHONY: push
+push:
+	@# Permit releasing only if VERSION adheres to semver.
+	@echo "${VERSION}" | grep -Eq "^v[0-9]+\.[0-9]+\.[0-9]+$$" || ( echo "VERSION \"${VERSION}\" does not adhere to semver"; exit 1 )
+	@echo "==> Pushing docker image ${REPO}/${NAME}:$(VERSION)"
+	@docker push ${REPO}/${NAME}:latest
+	@docker push ${REPO}/${NAME}:$(VERSION)
+	@echo "==> Your image is now available at $(REPO)/${NAME}:$(VERSION)"
+
+.PHONY: clean
+clean:
+	@echo "==> Cleaning artifacts"
+	@rm ${NAME}


### PR DESCRIPTION
This PR adds the docker image build and push instructions for local development and adds Docker build/push integration into `goreleaser`. On **localhost**, to build and push the image, use the following commands:

```
make build-image
make push 
```

This will build the image and push it to the Docker hub (assuming you have the permission to make the push). The `make` tasks are mainly for debugging and making sure we can build an image if `goreleaser` is broken or need manual intervention.

---

The goreleaser integration uses a different Dockerfile, named `Dockerfile.goreleaser`. The `Dockerfile.goreleaser` is simpler than the base `Dockerfile` file because `goreleaser` does the heavy lifting of building the binary. To build and push with `goreleaser`, run the following command (assuming you have the permissions to make the push):

_(Note: this command will also build and release the archives and homebrew recipes)_

```
goreleaser release --rm-dist
```

---

I tried it now in conjunction with `pscale connect` and it works with the following command:

```
 $ docker run -it -p 127.0.0.1:3306:3306 \
  --env PLANETSCALE_SERVICE_TOKEN \
  --env PLANETSCALE_SERVICE_TOKEN_NAME \
  --env PLANETSCALE_ORG  \
  planetscale/pscale:dev connect planetscale main --host 0.0.0.0

Secure connection to database planetscale and branch main is established!.

Local address to connect your application: [::]:3306 (press ctrl-c to quit)
```

This commands publishes the container port `3306` to the host's `127.0.0.1:3306` port. After that one can connect with the following command:

```
$ mysql -u root -h 127.0.0.1 -P 3306
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 7521
Server version: 8.0.23-vitess Version: 11.0.0-SNAPSHOT (Git revision a4b07be branch 'main') built on Fri May 21 05:10:26 UTC 2021 by vitess@buildkitsandbox using go1.15.6 linux/amd64

Copyright (c) 2000, 2021, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql>
```