### PR TITLE
cmd: improve the authentication warning for service token's

### DIFF
--- a/internal/cmd/org/show.go
+++ b/internal/cmd/org/show.go
@@ -31,7 +31,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				cfg, err = ch.ConfigFS.NewFileConfig(configPath)
 				if os.IsNotExist(err) {
-					return errors.New("not authenticated, please authenticate with: \"pscale auth login\"")
+					return errors.New(cmdutil.WarnAuthMessage)
 				}
 
 				if err != nil {

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -19,6 +19,9 @@ import (
 	exec "golang.org/x/sys/execabs"
 )
 
+const WarnAuthMessage = "not authenticated yet. Please run 'pscale auth login'" +
+	"or create a service token with 'pscale service-token create'"
+
 // Helper is passed to every single command and is used by individual
 // subcommands.
 type Helper struct {
@@ -70,7 +73,7 @@ func CheckAuthentication(cfg *config.Config) func(cmd *cobra.Command, args []str
 			return nil
 		}
 
-		return errors.New("not authenticated yet. Please run 'pscale auth login'")
+		return errors.New(WarnAuthMessage)
 	}
 }
 


### PR DESCRIPTION
Not all users want to use access tokens while using the CLI. Some users prefer to create a service token and use that. However, our warning assumes that pscale was called interactively, and the user intends to use an access token.

This PR improves the message to make it clear that there are other options.
