### PR TITLE
buildkite: add release step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+agents:
+  queue: "public"
+
 steps:
 - name: "Go build and test %n"
   command: make
@@ -10,3 +13,29 @@ steps:
   plugins:
     - docker-compose#v3.7.0:
         run: licensing
+
+- wait
+
+- block: ":rocket: Release !"
+  branches: "main"
+
+- command: script/release.sh
+  if: build.branch == "main"
+  label: ":arrow_up_small: Bump & tag version"
+
+- wait
+
+- label: ":github: Publishing artifacts"
+  if: build.branch == "main" && build.tag =~ /^v[0-9]+\.0\$/
+  plugins:
+    - docker#v3.8.0:
+        image: "goreleaser/goreleaser:v0.169.0"
+        command: ["release", "--rm-dist"]
+        propagate-environment: true
+        volumes:
+          - "/var/run/docker.sock:/var/run/docker.sock"
+  env:
+      GITHUB_TOKEN: "${ACTIONS_BOT_TOKEN}"
+      DOCKER_REGISTRY: "https://index.docker.io/v1/"
+      DOCKER_USERNAME: "${DOCKER_USERNAME}"
+      DOCKER_PASSWORD: "${DOCKER_PASSWORD}"

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+WORKDIR=$(pwd)
+SVU_BIN="${WORKDIR}/svu"
+
+echo "+++ :construction:  Installing 'svu' tool"
+curl -sfL https://install.goreleaser.com/github.com/caarlos0/svu.sh | bash -s -- -b $WORKDIR
+
+# TODO: change patch to minor
+RELEASE_VERSION=$($SVU_BIN patch)
+
+echo "+++ :boom: Bumping to version $RELEASE_VERSION"
+
+git config --global --add url."https://${ACTIONS_BOT_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+git tag "$RELEASE_VERSION"
+git push origin "$RELEASE_VERSION"
+
+echo "✅"


### PR DESCRIPTION
This PR adds a fully automated release pipeline for the CLI. PlanetScale authorized people will release a new version of the CLI by signing into BuildKite and then pressing the `Release!` button. The button will only be shown in the `main` branch.