### PR TITLE
cmd: add shell completion for subcommands

### DIFF
--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script for your shell",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(pscale completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ pscale completion bash > /etc/bash_completion.d/pscale
+  # macOS:
+  $ pscale completion bash > /usr/local/etc/bash_completion.d/pscale
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ pscale completion zsh > "${fpath[1]}/_yourprogram"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ pscale completion fish | source
+
+  # To load completions for each session, execute once:
+  $ pscale completion fish > ~/.config/fish/completions/pscale.fish
+
+PowerShell:
+
+  PS> pscale completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> pscale completion powershell > pscale.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cmdutil.RequiredArgs("shell"),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}

--- a/internal/cmd/org/switch.go
+++ b/internal/cmd/org/switch.go
@@ -23,6 +23,28 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "switch <organization>",
 		Short: "Switch the currently active organization",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			orgs, err := client.Organizations.List(context.Background())
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			orgNames := make([]string, 0, len(orgs))
+			for _, org := range orgs {
+				orgNames = append(orgNames, org.Name)
+			}
+
+			return orgNames, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -133,6 +133,9 @@ func runCmd(ver, commit, buildDate string, format *printer.Format, debug *bool) 
 	if err := viper.BindPFlag("format", rootCmd.PersistentFlags().Lookup("format")); err != nil {
 		return err
 	}
+	rootCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"human", "json", "csv"}, cobra.ShellCompDirectiveDefault
+	})
 
 	rootCmd.PersistentFlags().BoolVar(debug, "debug", false, "Enable debug mode")
 	if err := viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")); err != nil {


### PR DESCRIPTION
This PR adds shell (Bash, Zsh, fish, and PowerShell) completions for all our subcommands and flags.

We also added a couple of dynamic completions to make it easy to choose
certain arguments, such as:

* `pscale org switch <complete organization ...>`
* `pscale branch create <complete database...>`
* `pscale database show <complete database...>`

Here is a demo that shows it in action for fish shell:


https://user-images.githubusercontent.com/438920/121519579-8a0c4900-c9fa-11eb-8fd8-f56737678a02.mp4

