### PR TITLE
Update `planetscale-go` and fix branch creation command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.28.0
+	github.com/planetscale/planetscale-go v0.29.0
 	github.com/planetscale/sql-proxy v0.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -252,10 +252,9 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/planetscale/planetscale-go v0.27.0 h1:Mp9Kp7PbHUcExJoV77DelryhVsC4BFaRgFcxrWoNo34=
 github.com/planetscale/planetscale-go v0.27.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
-github.com/planetscale/planetscale-go v0.28.0 h1:oAPtRcUqRsdyGmqSGP16zvTH84vFLbFyzz7fFffNu9I=
-github.com/planetscale/planetscale-go v0.28.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
+github.com/planetscale/planetscale-go v0.29.0 h1:efDcRoPg0LZKj/f8aZjKIZRgJPJ6h+3siyCzwuJG4qM=
+github.com/planetscale/planetscale-go v0.29.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
 github.com/planetscale/sql-proxy v0.7.0 h1:jeHVcVSXVhiMIkNRojxRRL2RkqYjVfq/7jjTpqi2ZmY=
 github.com/planetscale/sql-proxy v0.7.0/go.mod h1:FaaWbGPcCINX+XghDfFoZr9hIkakf4Ei/4itTT7HzFI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -13,9 +13,7 @@ import (
 )
 
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
-	createReq := &ps.CreateDatabaseBranchRequest{
-		Branch: new(ps.DatabaseBranch),
-	}
+	createReq := &ps.CreateDatabaseBranchRequest{}
 
 	cmd := &cobra.Command{
 		Use:     "create <source-database> <branch> [options]",
@@ -67,7 +65,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			createReq.Database = source
-			createReq.Branch.Name = branch
+			createReq.Name = branch
 			createReq.Organization = ch.Config.Organization
 
 			web, err := cmd.Flags().GetBool("web")
@@ -79,7 +77,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				ch.Printer.Println("🌐  Redirecting you to branch a database in your web browser.")
 				err := browser.OpenURL(fmt.Sprintf(
 					"%s/%s/%s/branches?name=%s&notes=%s&showDialog=true",
-					cmdutil.ApplicationURL, ch.Config.Organization, source, url.QueryEscape(createReq.Branch.Name), url.QueryEscape(createReq.Branch.Notes),
+					cmdutil.ApplicationURL, ch.Config.Organization, source, url.QueryEscape(createReq.Name), url.QueryEscape(createReq.Notes),
 				))
 				if err != nil {
 					return err
@@ -116,8 +114,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&createReq.Branch.Notes, "notes", "", "notes for the database branch")
-	cmd.Flags().StringVar(&createReq.Branch.ParentBranch, "from", "", "branch to be created from")
+	cmd.Flags().StringVar(&createReq.Notes, "notes", "", "notes for the database branch")
+	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
 
 	return cmd

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -30,7 +30,7 @@ func TestBranch_CreateCmd(t *testing.T) {
 
 	svc := &mock.DatabaseBranchesService{
 		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
-			c.Assert(req.Branch.Name, qt.Equals, branch)
+			c.Assert(req.Name, qt.Equals, branch)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
 

--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -54,10 +54,8 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 				createReq := &ps.CreateDatabaseBranchRequest{
 					Organization: ch.Config.Organization,
 					Database:     ch.Config.Database,
-					Branch: &ps.DatabaseBranch{
-						Name:         branch,
-						ParentBranch: parentBranch,
-					},
+					Name:         branch,
+					ParentBranch: parentBranch,
 				}
 
 				_, err = client.DatabaseBranches.Create(ctx, createReq)


### PR DESCRIPTION
This pull request fixes the branch creation command to use the flattened `CreateDatabaseBranchRequest` object from the new `planetscale-go` version. 