### PR TITLE
Add region flag to database and branch creation commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.29.0
+	github.com/planetscale/planetscale-go v0.30.0
 	github.com/planetscale/sql-proxy v0.7.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/planetscale-go v0.27.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
-github.com/planetscale/planetscale-go v0.29.0 h1:efDcRoPg0LZKj/f8aZjKIZRgJPJ6h+3siyCzwuJG4qM=
-github.com/planetscale/planetscale-go v0.29.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
+github.com/planetscale/planetscale-go v0.30.0 h1:0LCQmesuGjCFmdrZqZCLi4s4J8eiCqoRZc56rHU8n0U=
+github.com/planetscale/planetscale-go v0.30.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
 github.com/planetscale/sql-proxy v0.7.0 h1:jeHVcVSXVhiMIkNRojxRRL2RkqYjVfq/7jjTpqi2ZmY=
 github.com/planetscale/sql-proxy v0.7.0/go.mod h1:FaaWbGPcCINX+XghDfFoZr9hIkakf4Ei/4itTT7HzFI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/browser"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
 )
@@ -116,6 +117,28 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&createReq.Notes, "notes", "", "notes for the database branch")
 	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
+	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
+	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		client, err := ch.Client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		regions, err := client.Regions.List(context.Background(), &planetscale.ListRegionsRequest{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		regionStrs := make([]string, 0)
+
+		for _, r := range regions {
+			if r.Enabled {
+				regionStrs = append(regionStrs, r.Slug)
+			}
+		}
+
+		return regionStrs, cobra.ShellCompDirectiveDefault
+	})
 	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
 
 	return cmd

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/browser"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
 )
@@ -124,7 +123,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		regions, err := client.Regions.List(context.Background(), &planetscale.ListRegionsRequest{})
+		regions, err := client.Regions.List(context.Background(), &ps.ListRegionsRequest{})
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -117,6 +117,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.Notes, "notes", "", "notes for the database branch")
 	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
+	cmd.Flags().MarkHidden("region")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		client, err := ch.Client()
 		if err != nil {

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -32,6 +32,7 @@ func TestBranch_CreateCmd(t *testing.T) {
 		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
 			c.Assert(req.Name, qt.Equals, branch)
 			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Region, qt.Equals, "us-east")
 			c.Assert(req.Organization, qt.Equals, org)
 
 			return res, nil
@@ -52,7 +53,7 @@ func TestBranch_CreateCmd(t *testing.T) {
 	}
 
 	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db, branch})
+	cmd.SetArgs([]string{db, branch, "--region", "us-east"})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -71,6 +71,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&createReq.Notes, "notes", "", "notes for the database")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
+	cmd.Flags().MarkHidden("region")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		client, err := ch.Client()
 		if err != nil {

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 
+	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/pkg/browser"
@@ -70,6 +71,29 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&createReq.Notes, "notes", "", "notes for the database")
+	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
+	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		client, err := ch.Client()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		regions, err := client.Regions.List(context.Background(), &planetscale.ListRegionsRequest{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		regionStrs := make([]string, 0)
+
+		for _, r := range regions {
+			if r.Enabled {
+				regionStrs = append(regionStrs, r.Slug)
+			}
+		}
+
+		return regionStrs, cobra.ShellCompDirectiveDefault
+	})
+
 	cmd.Flags().BoolP("web", "w", false, "Create a database in your web browser")
 
 	return cmd

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -8,7 +8,6 @@ import (
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 
-	"github.com/planetscale/planetscale-go/planetscale"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/pkg/browser"
@@ -78,7 +77,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		regions, err := client.Regions.List(context.Background(), &planetscale.ListRegionsRequest{})
+		regions, err := client.Regions.List(context.Background(), &ps.ListRegionsRequest{})
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -31,6 +31,7 @@ func TestDatabase_CreateCmd(t *testing.T) {
 		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Name, qt.Equals, db)
+			c.Assert(req.Region, qt.Equals, "us-east")
 
 			return res, nil
 		},
@@ -50,7 +51,7 @@ func TestDatabase_CreateCmd(t *testing.T) {
 	}
 
 	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db})
+	cmd.SetArgs([]string{db, "--region", "us-east"})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
This pull request adds the `--region` flag to the `branch create` and `database create` commands so we can eventually make regional databases and branches as we add them in. Also, we can get some auto-completion action going with hitting the regions API to pre-populate things.

Depends on https://github.com/planetscale/planetscale-go/pull/70 landing first and we gotta update our `planetscale-go` version.