### PR TITLE
Do not expose database name in DATABASE_URL env

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -189,7 +189,7 @@ func runCommand(ctx context.Context, command, protocol, database, branch string,
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	connStr := fmt.Sprintf("DATABASE_URL=%s://root@%s/%s", protocol, addr, database)
+	connStr := fmt.Sprintf("DATABASE_URL=%s://root@%s/", protocol, addr)
 	cmd.Env = append(cmd.Env, connStr)
 
 	hostEnv := fmt.Sprintf("PLANETSCALE_DATABASE_HOST=%s", addr)


### PR DESCRIPTION
### Problem

**Update**: [Currently there is a discussion going on](https://github.com/planetscale/cli/pull/307#issuecomment-861835771), whether the issue only appears for certain data bases with no primary keys in the main branch.

Fixes #308 

* `pscale connect` exposes the DB it connects to as default DB (without the DB name in the path):

```
codespace ➜ /workspaces/cli/cmd/pscale (main ✗) $ pscale connect monalisa main
Secure connection to database monalisa and branch main is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)
```
```bash
mysql -u root -P 3306 -h 127.0.0.1
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 9075
Server version: 8.0.23-vitess Version: 11.0.0-SNAPSHOT (Git revision 13dadf3 branch 'main') built on Mon Jun  7 17:05:20 UTC 2021 by vitess@buildkitsandbox using go1.15.6 linux/amd64

...

mysql> describe reminders;
+------------+---------------+------+-----+----------------------+-------------------+
| Field      | Type          | Null | Key | Default              | Extra             |
+------------+---------------+------+-----+----------------------+-------------------+
| id         | bigint        | NO   | PRI | NULL                 | auto_increment    |
| body       | varchar(1024) | NO   |     | NULL                 |                   |
| created_at | datetime(6)   | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED |
| updated_at | datetime(6)   | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED |
| is_done    | tinyint(1)    | NO   |     | 0                    |                   |
+------------+---------------+------+-----+----------------------+-------------------+
5 rows in set (0.09 sec)
```

* however, `pscale connect --execute` sets the _DATABASE_URL_ env variable to a value that contains the DB name in its path, in the example ☝️ , it would be set to mysql2://root@127.0.0.1:3306/**monalisa**, although in order to connect properly to the way, the DB was exposed, the value would actually need to be mysql2://root@127.0.0.1:3306/ if the [examples in the docs](https://docs.planetscale.com/tutorial/connect-any-application/#use-planetscale-in-production) or the way `pscale connect` exposes the DB should stay as is.

* consequently, the [examples in documentation](https://docs.planetscale.com/tutorial/connect-any-application/#use-planetscale-in-production) and [express example app](https://github.com/planetscale/express-example) on how to use `connect` command with `--execute` fail with "unknown database" errors.

Example:
```bash
pscale connect monalisa main --execute 'node app.js'
Secure connection to database monalisa and branch main is established!.

Local address to connect your application: 127.0.0.1:3306 (press ctrl-c to quit)
Example app listening at http://localhost:3000
/home/codespace/express-example/node_modules/mysql/lib/protocol/Parser.js:437
      throw err; // Rethrow non-MySQL errors
      ^

Error: ER_UNKNOWN_ERROR: unknown database 'monalisa'
    at Handshake.Sequence._packetToError (/home/codespace/express-example/node_modules/mysql/lib/protocol/sequences/Sequence.js:47:14)
    at Handshake.ErrorPacket (/home/codespace/express-example/node_modules/mysql/lib/protocol/sequences/Handshake.js:123:18)
    at Protocol._parsePacket (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:291:23)
    at Parser._parsePacket (/home/codespace/express-example/node_modules/mysql/lib/protocol/Parser.js:433:10)
    at Parser.write (/home/codespace/express-example/node_modules/mysql/lib/protocol/Parser.js:43:10)
    at Protocol.write (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:38:16)
    at Socket.<anonymous> (/home/codespace/express-example/node_modules/mysql/lib/Connection.js:88:28)
    at Socket.<anonymous> (/home/codespace/express-example/node_modules/mysql/lib/Connection.js:526:10)
    at Socket.emit (events.js:315:20)
    at addChunk (_stream_readable.js:309:12)
    --------------------
    at Protocol._enqueue (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:144:48)
    at Protocol.handshake (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:51:23)
    at Connection.connect (/home/codespace/express-example/node_modules/mysql/lib/Connection.js:116:18)
    at Object.<anonymous> (/home/codespace/express-example/app.js:8:12)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
    at internal/main/run_main_module.js:17:47
Emitted 'error' event on Connection instance at:
    at Connection._handleProtocolError (/home/codespace/express-example/node_modules/mysql/lib/Connection.js:423:8)
    at Protocol.emit (events.js:315:20)
    at Protocol._delegateError (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:398:10)
    at Handshake.<anonymous> (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:153:12)
    at Handshake.emit (events.js:315:20)
    at Handshake.Sequence.end (/home/codespace/express-example/node_modules/mysql/lib/protocol/sequences/Sequence.js:78:12)
    at Handshake.ErrorPacket (/home/codespace/express-example/node_modules/mysql/lib/protocol/sequences/Handshake.js:125:8)
    at Protocol._parsePacket (/home/codespace/express-example/node_modules/mysql/lib/protocol/Protocol.js:291:23)
    at Parser._parsePacket (/home/codespace/express-example/node_modules/mysql/lib/protocol/Parser.js:433:10)
    at Parser.write (/home/codespace/express-example/node_modules/mysql/lib/protocol/Parser.js:43:10) {
  code: 'ER_UNKNOWN_ERROR',
  errno: 1105,
  sqlMessage: "unknown database 'monalisa'",
  sqlState: 'HY000',
  fatal: true
}
Error: running command with --execute has failed: exit status 1
```

### Proposed solution

* changed `--execute` option to not include DB name in exposed _DATABASE_URL_ env anymore
* examples in docs and GitHub do not have to be adjusted

Proposed solution was tested successfully on Mac and Linux with express-example and a custom Python app.