### PR TITLE
completion: include completions in archives, linux packages and homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-
 dist/
+completions/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,10 @@
 project_name: pscale
 release:
   prerelease: auto # don't publish release with -rc1,-pre, etc suffixes
+before:
+  hooks:
+    - go mod tidy
+    - ./script/completions
 builds:
   - env:
       - CGO_ENABLED=0
@@ -29,6 +33,13 @@ nfpms:
     description: The PlanetScale CLI
     homepage: https://github.com/planetscale/cli
     license: Apache 2.0
+    contents:
+      - src: ./completions/pscale.bash
+        dst: /etc/bash_completion.d/pscale
+      - src: ./completions/pscale.fish
+        dst: /usr/share/fish/completions/pscale.fish
+      - src: ./completions/pscale.zsh
+        dst: /usr/local/share/zsh/site-functions/_pscale
     formats:
     - deb
     - rpm
@@ -50,12 +61,19 @@ brews:
          system "#{bin}/pscale --version"
     install: |
       bin.install "pscale"
+      bash_completion.install "completions/pscale.bash" => "pscale"
+      zsh_completion.install "completions/pscale.zsh" => "_pscale"
+      fish_completion.install "completions/pscale.fish"
 archives:
   - replacements:
       darwin: macOS
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - README.md
+      - LICENSE
+      - completions/*
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:

--- a/script/completions
+++ b/script/completions
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+rm -rf completions
+mkdir -p completions
+
+for sh in bash zsh fish; do
+  go run cmd/pscale/main.go completion "$sh" >"completions/pscale.$sh"
+done


### PR DESCRIPTION
This PR includes the completions script generated by `pscale completion`
and adds them for the macOS and Linux packages. That way, the user
doesn't have to generate and install the completion scripts manually.
