### PR TITLE
cmd: don't bind to nil flags

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -117,18 +117,6 @@ func runCmd(ver, commit, buildDate string, format *printer.Format, debug *bool) 
 	rootCmd.PersistentFlags().StringVar(&cfg.AccessToken,
 		"api-token", cfg.AccessToken, "The API token to use for authenticating against the PlanetScale API.")
 
-	if err := viper.BindPFlag("org", rootCmd.PersistentFlags().Lookup("org")); err != nil {
-		return err
-	}
-
-	if err := viper.BindPFlag("database", rootCmd.PersistentFlags().Lookup("database")); err != nil {
-		return err
-	}
-
-	if err := viper.BindPFlag("branch", rootCmd.PersistentFlags().Lookup("branch")); err != nil {
-		return err
-	}
-
 	rootCmd.PersistentFlags().VarP(printer.NewFormatValue(printer.Human, format), "format", "f",
 		"Show output in a specific format. Possible values: [human, json, csv]")
 	if err := viper.BindPFlag("format", rootCmd.PersistentFlags().Lookup("format")); err != nil {


### PR DESCRIPTION
Currently our `main` branch is broken due the latest `spf13/viper`
upgrade to `v1.8.0`. Viper now returns an error if we try to bind to a
nil flag (flag's that are not yet defined).

Fixes the following error:

```
$ pscale
Error: flag for "org" is nil
````
