### PR TITLE
Update github.com/AlecAivazis/survey/v2 and licensed cache

### DIFF
--- a/.licenses/go/github.com/AlecAivazis/survey/v2.dep.yml
+++ b/.licenses/go/github.com/AlecAivazis/survey/v2.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/AlecAivazis/survey/v2
-version: v2.2.12
+version: v2.2.13
 type: go
 summary: 
 homepage: https://godoc.org/github.com/AlecAivazis/survey/v2

--- a/.licenses/go/github.com/AlecAivazis/survey/v2/core.dep.yml
+++ b/.licenses/go/github.com/AlecAivazis/survey/v2/core.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/AlecAivazis/survey/v2/core
-version: v2.2.12
+version: v2.2.13
 type: go
 summary: 
 homepage: https://godoc.org/github.com/AlecAivazis/survey/v2/core
 license: mit
 licenses:
-- sources: v2@v2.2.12/LICENSE
+- sources: v2@v2.2.13/LICENSE
   text: |
     MIT License
 

--- a/.licenses/go/github.com/AlecAivazis/survey/v2/terminal.dep.yml
+++ b/.licenses/go/github.com/AlecAivazis/survey/v2/terminal.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/AlecAivazis/survey/v2/terminal
-version: v2.2.12
+version: v2.2.13
 type: go
 summary: 
 homepage: https://godoc.org/github.com/AlecAivazis/survey/v2/terminal
 license: mit
 licenses:
-- sources: v2@v2.2.12/LICENSE
+- sources: v2@v2.2.13/LICENSE
   text: |
     MIT License
 

--- a/.licenses/go/github.com/briandowns/spinner.dep.yml
+++ b/.licenses/go/github.com/briandowns/spinner.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/briandowns/spinner
-version: v1.15.0
+version: v1.16.0
 type: go
 summary: Package spinner is a simple package to add a spinner / progress indicator
   to any terminal application.

--- a/.licenses/go/github.com/planetscale/planetscale-go/planetscale.dep.yml
+++ b/.licenses/go/github.com/planetscale/planetscale-go/planetscale.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: github.com/planetscale/planetscale-go/planetscale
-version: v0.30.0
+version: v0.31.0
 type: go
 summary: 
 homepage: https://godoc.org/github.com/planetscale/planetscale-go/planetscale
 license: apache-2.0
 licenses:
-- sources: planetscale-go@v0.30.0/LICENSE
+- sources: planetscale-go@v0.31.0/LICENSE
   text: |2
 
                                      Apache License

--- a/.licenses/go/github.com/spf13/viper.dep.yml
+++ b/.licenses/go/github.com/spf13/viper.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/spf13/viper
-version: v1.8.0
+version: v1.8.1
 type: go
 summary: 
 homepage: https://godoc.org/github.com/spf13/viper

--- a/.licenses/go/go.uber.org/zap.dep.yml
+++ b/.licenses/go/go.uber.org/zap.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: go.uber.org/zap
-version: v1.17.0
+version: v1.18.1
 type: go
 summary: Package zap provides fast, structured, leveled logging.
 homepage: https://godoc.org/go.uber.org/zap

--- a/.licenses/go/go.uber.org/zap/buffer.dep.yml
+++ b/.licenses/go/go.uber.org/zap/buffer.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.uber.org/zap/buffer
-version: v1.17.0
+version: v1.18.1
 type: go
 summary: Package buffer provides a thin wrapper around a byte slice.
 homepage: https://godoc.org/go.uber.org/zap/buffer
 license: mit
 licenses:
-- sources: zap@v1.17.0/LICENSE.txt
+- sources: zap@v1.18.1/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/internal/bufferpool.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/bufferpool.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.uber.org/zap/internal/bufferpool
-version: v1.17.0
+version: v1.18.1
 type: go
 summary: Package bufferpool houses zap's shared internal buffer pool.
 homepage: https://godoc.org/go.uber.org/zap/internal/bufferpool
 license: mit
 licenses:
-- sources: zap@v1.17.0/LICENSE.txt
+- sources: zap@v1.18.1/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/internal/color.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/color.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.uber.org/zap/internal/color
-version: v1.17.0
+version: v1.18.1
 type: go
 summary: Package color adds coloring functionality for TTY output.
 homepage: https://godoc.org/go.uber.org/zap/internal/color
 license: mit
 licenses:
-- sources: zap@v1.17.0/LICENSE.txt
+- sources: zap@v1.18.1/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/internal/exit.dep.yml
+++ b/.licenses/go/go.uber.org/zap/internal/exit.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: go.uber.org/zap/internal/exit
-version: v1.17.0
+version: v1.18.1
 type: go
 summary: Package exit provides stubs so that unit tests can exercise code that calls
   os.Exit(1).
 homepage: https://godoc.org/go.uber.org/zap/internal/exit
 license: mit
 licenses:
-- sources: zap@v1.17.0/LICENSE.txt
+- sources: zap@v1.18.1/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/go.uber.org/zap/zapcore.dep.yml
+++ b/.licenses/go/go.uber.org/zap/zapcore.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: go.uber.org/zap/zapcore
-version: v1.17.0
+version: v1.18.1
 type: go
 summary: Package zapcore defines and implements the low-level interfaces upon which
   zap is built.
 homepage: https://godoc.org/go.uber.org/zap/zapcore
 license: mit
 licenses:
-- sources: zap@v1.17.0/LICENSE.txt
+- sources: zap@v1.18.1/LICENSE.txt
   text: |
     Copyright (c) 2016-2017 Uber Technologies, Inc.
 

--- a/.licenses/go/golang.org/x/term.dep.yml
+++ b/.licenses/go/golang.org/x/term.dep.yml
@@ -1,13 +1,13 @@
 ---
-name: golang.org/x/crypto/ssh/terminal
-version: v0.0.0-20200622213623-75b288015ac9
+name: golang.org/x/term
+version: v0.0.0-20210503060354-a79de5458b56
 type: go
-summary: Package terminal provides support functions for dealing with terminals, as
-  commonly found on UNIX systems.
-homepage: https://godoc.org/golang.org/x/crypto/ssh/terminal
+summary: Package term provides support functions for dealing with terminals, as commonly
+  found on UNIX systems.
+homepage: https://godoc.org/golang.org/x/term
 license: bsd-3-clause
 licenses:
-- sources: crypto@v0.0.0-20200622213623-75b288015ac9/LICENSE
+- sources: LICENSE
   text: |
     Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -36,7 +36,7 @@ licenses:
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-- sources: crypto@v0.0.0-20200622213623-75b288015ac9/PATENTS
+- sources: PATENTS
   text: |
     Additional IP Rights Grant (Patents)
 
@@ -60,4 +60,9 @@ licenses:
     infringement, or inducement of patent infringement, then any patent
     rights granted to you under this License for this implementation of Go
     shall terminate as of the date such litigation is filed.
-notices: []
+notices:
+- sources: AUTHORS
+  text: |-
+    # This source code refers to The Go Authors for copyright purposes.
+    # The master list of authors is in the main Go distribution,
+    # visible at http://tip.golang.org/AUTHORS.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/planetscale/cli
 go 1.16
 
 require (
-	github.com/AlecAivazis/survey/v2 v2.2.12
+	github.com/AlecAivazis/survey/v2 v2.2.13
 	github.com/benbjohnson/clock v1.1.0
 	github.com/briandowns/spinner v1.16.0
 	github.com/dustin/go-humanize v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AlecAivazis/survey/v2 v2.2.12 h1:5a07y93zA6SZ09gOa9wLVLznF5zTJMQ+pJ3cZK4IuO8=
 github.com/AlecAivazis/survey/v2 v2.2.12/go.mod h1:6d4saEvBsfSHXeN1a5OA5m2+HJ2LuVokllnC77pAIKI=
+github.com/AlecAivazis/survey/v2 v2.2.13 h1:7s6Msv/M4omLvZ0PfItdmr/VqPEgsLLuxj5NvREsQu8=
+github.com/AlecAivazis/survey/v2 v2.2.13/go.mod h1:TH2kPCDU3Kqq7pLbnCWwZXDBjnhZtmsCle5EiYDJ2fg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
@@ -546,6 +548,8 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744 h1:yhBbb4IRs2HS9PPlAg6DMC6mUOKexJBNsLf4Z+6En1Q=
 golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
+golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
`licensed` fails if a license can't be parsed properly. This happened during the dependabot PR https://github.com/planetscale/cli/pull/318 when the `survey` package introduced a new dependency.

This PR updates the `survey` package and fixes the licensed cache file.
