### PR TITLE
cli: add context cancellation support to all commands

### DIFF
--- a/cmd/pscale/main.go
+++ b/cmd/pscale/main.go
@@ -15,8 +15,12 @@ var (
 )
 
 func main() {
+	os.Exit(realMain())
+}
+
+func realMain() int {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
 
-	os.Exit(cmd.Execute(ctx, version, commit, date))
+	return cmd.Execute(ctx, version, commit, date)
 }

--- a/cmd/pscale/main.go
+++ b/cmd/pscale/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
 
 	"github.com/planetscale/cli/internal/cmd"
 )
@@ -13,5 +15,8 @@ var (
 )
 
 func main() {
-	os.Exit(cmd.Execute(version, commit, date))
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
+
+	os.Exit(cmd.Execute(ctx, version, commit, date))
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -37,7 +37,8 @@ func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx := context.Background()
+
+			ctx := cmd.Context()
 
 			deviceVerification, err := authenticator.VerifyDevice(ctx)
 			if err != nil {

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"bufio"
-	"context"
 	"io"
 	"os"
 
@@ -40,7 +39,7 @@ func LogoutCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ctx := context.Background()
+			ctx := cmd.Context()
 
 			end := ch.Printer.PrintProgress("Logging out...")
 			defer end()

--- a/internal/cmd/backup/create.go
+++ b/internal/cmd/backup/create.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -19,7 +18,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cmdutil.RequiredArgs("database", "branch"),
 		Aliases: []string{"b"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
 

--- a/internal/cmd/backup/delete.go
+++ b/internal/cmd/backup/delete.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -25,7 +24,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cmdutil.RequiredArgs("database", "branch", "backup"),
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
 			backup := args[2]

--- a/internal/cmd/backup/list.go
+++ b/internal/cmd/backup/list.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -20,7 +19,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cmdutil.RequiredArgs("database", "branch"),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
 

--- a/internal/cmd/backup/show.go
+++ b/internal/cmd/backup/show.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -19,7 +18,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Show a specific backup of a branch",
 		Args:  cmdutil.RequiredArgs("database", "branch", "backup"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
 			backup := args[2]

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 
@@ -40,7 +39,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				org = cfg.Organization
 			}
 
-			databases, err := client.Databases.List(context.Background(), &ps.ListDatabasesRequest{
+			databases, err := client.Databases.List(cmd.Context(), &ps.ListDatabasesRequest{
 				Organization: org,
 			})
 			if err != nil {
@@ -55,7 +54,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return candidates, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
 			source := args[0]
 			branch := args[1]
 
@@ -92,7 +90,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating branch from %s...", printer.BoldBlue(source)))
 			defer end()
-			dbBranch, err := client.DatabaseBranches.Create(ctx, createReq)
+			dbBranch, err := client.DatabaseBranches.Create(cmd.Context(), createReq)
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
@@ -118,12 +116,13 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
 	cmd.Flags().MarkHidden("region")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := cmd.Context()
 		client, err := ch.Client()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		regions, err := client.Regions.List(context.Background(), &ps.ListRegionsRequest{})
+		regions, err := client.Regions.List(ctx, &ps.ListRegionsRequest{})
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/branch/delete.go
+++ b/internal/cmd/branch/delete.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -24,7 +23,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cmdutil.RequiredArgs("database", "branch"),
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			source := args[0]
 			branch := args[1]
 

--- a/internal/cmd/branch/diff.go
+++ b/internal/cmd/branch/diff.go
@@ -2,7 +2,6 @@ package branch
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"strings"
 
@@ -25,7 +24,7 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Show the diff of a branch",
 		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database, branch := args[0], args[1]
 
 			client, err := ch.Client()

--- a/internal/cmd/branch/list.go
+++ b/internal/cmd/branch/list.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -20,7 +19,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cmdutil.RequiredArgs("database"),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 
 			web, err := cmd.Flags().GetBool("web")

--- a/internal/cmd/branch/refresh_schema.go
+++ b/internal/cmd/branch/refresh_schema.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -16,7 +15,7 @@ func RefreshSchemaCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Refresh the schema for a database branch",
 		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database, branch := args[0], args[1]
 
 			client, err := ch.Client()

--- a/internal/cmd/branch/schema.go
+++ b/internal/cmd/branch/schema.go
@@ -2,7 +2,6 @@ package branch
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"strings"
 
@@ -25,7 +24,7 @@ func SchemaCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Show the schema of a branch",
 		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database, branch := args[0], args[1]
 
 			if flags.web {

--- a/internal/cmd/branch/show.go
+++ b/internal/cmd/branch/show.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -19,7 +18,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Show a specific branch of a database",
 		Args:  cmdutil.RequiredArgs("source-database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			source := args[0]
 			branch := args[1]
 

--- a/internal/cmd/branch/status.go
+++ b/internal/cmd/branch/status.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -19,7 +18,7 @@ func StatusCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Check the status of a branch of a database",
 		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			source := args[0]
 			branch := args[1]
 

--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -1,7 +1,6 @@
 package branch
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -23,7 +22,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Switches the current project to use the specified branch",
 		Args:  cmdutil.RequiredArgs("branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			branch := args[0]
 
 			client, err := ch.Config.NewClientFromConfig()

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -50,7 +50,7 @@ argument:
   pscale connect mydatabase mybranch`,
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
 			database := args[0]

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 
@@ -23,7 +22,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Create a database instance",
 		Args:  cmdutil.RequiredArgs("database"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			web, err := cmd.Flags().GetBool("web")
 			if err != nil {
 				return err
@@ -73,12 +72,13 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
 	cmd.Flags().MarkHidden("region")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		ctx := cmd.Context()
 		client, err := ch.Client()
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		regions, err := client.Regions.List(context.Background(), &ps.ListRegionsRequest{})
+		regions, err := client.Regions.List(ctx, &ps.ListRegionsRequest{})
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/internal/cmd/database/delete.go
+++ b/internal/cmd/database/delete.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -27,7 +26,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cmdutil.RequiredArgs("database"),
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			name := args[0]
 
 			client, err := ch.Client()

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"time"
 
@@ -49,7 +48,7 @@ func DumpCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []string) error {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
 	database := args[0]

--- a/internal/cmd/database/list.go
+++ b/internal/cmd/database/list.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -20,7 +19,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short:   "List databases",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			web, err := cmd.Flags().GetBool("web")
 			if err != nil {
 				return err

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -42,7 +40,7 @@ func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args []string) error {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
 	database := args[0]

--- a/internal/cmd/database/show.go
+++ b/internal/cmd/database/show.go
@@ -1,7 +1,6 @@
 package database
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -38,7 +37,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 				org = cfg.Organization
 			}
 
-			databases, err := client.Databases.List(context.Background(), &planetscale.ListDatabasesRequest{
+			databases, err := client.Databases.List(cmd.Context(), &planetscale.ListDatabasesRequest{
 				Organization: org,
 			})
 			if err != nil {
@@ -53,7 +52,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			return candidates, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			name := args[0]
 
 			web, err := cmd.Flags().GetBool("web")

--- a/internal/cmd/deployrequest/close.go
+++ b/internal/cmd/deployrequest/close.go
@@ -1,7 +1,6 @@
 package deployrequest
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
@@ -19,7 +18,7 @@ func CloseCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Close a deploy request",
 		Args:  cmdutil.RequiredArgs("database", "number"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			number := args[1]
 

--- a/internal/cmd/deployrequest/create.go
+++ b/internal/cmd/deployrequest/create.go
@@ -1,7 +1,6 @@
 package deployrequest
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -22,7 +21,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Create a deploy request from a branch",
 		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
 

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -1,7 +1,6 @@
 package deployrequest
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
@@ -19,7 +18,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Deploy a specific deploy request",
 		Args:  cmdutil.RequiredArgs("database", "number"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			number := args[1]
 

--- a/internal/cmd/deployrequest/diff.go
+++ b/internal/cmd/deployrequest/diff.go
@@ -2,7 +2,6 @@ package deployrequest
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,7 +26,7 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Show the diff of a deploy request",
 		Args:  cmdutil.RequiredArgs("database", "number"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			number := args[1]
 

--- a/internal/cmd/deployrequest/list.go
+++ b/internal/cmd/deployrequest/list.go
@@ -1,7 +1,6 @@
 package deployrequest
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -20,7 +19,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    cmdutil.RequiredArgs("database"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 
 			web, err := cmd.Flags().GetBool("web")

--- a/internal/cmd/deployrequest/review.go
+++ b/internal/cmd/deployrequest/review.go
@@ -1,7 +1,6 @@
 package deployrequest
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -30,7 +29,7 @@ func ReviewCmd(ch *cmdutil.Helper) *cobra.Command {
 				return errors.New("neither --approve nor --comment is set")
 			}
 
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			number := args[1]
 

--- a/internal/cmd/deployrequest/show.go
+++ b/internal/cmd/deployrequest/show.go
@@ -1,7 +1,6 @@
 package deployrequest
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
@@ -24,7 +23,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Show a specific deploy request",
 		Args:  cmdutil.RequiredArgs("database", "number"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			database := args[0]
 			number := args[1]
 

--- a/internal/cmd/org/list.go
+++ b/internal/cmd/org/list.go
@@ -1,8 +1,6 @@
 package org
 
 import (
-	"context"
-
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 
@@ -16,7 +14,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/cmd/org/switch.go
+++ b/internal/cmd/org/switch.go
@@ -1,7 +1,6 @@
 package org
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -33,7 +32,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
 
-			orgs, err := client.Organizations.List(context.Background())
+			orgs, err := client.Organizations.List(cmd.Context())
 			if err != nil {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
@@ -46,7 +45,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 			return orgNames, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 
 			organization := ""
 

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/signal"
 	"path/filepath"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -50,7 +49,7 @@ second argument:
   pscale shell mydatabase mybranch`,
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
 			database := args[0]

--- a/internal/cmd/token/addaccess.go
+++ b/internal/cmd/token/addaccess.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -24,7 +23,7 @@ For example, to give a service token the ability to create, read and delete bran
 
 For a complete list of the access permissions that can be granted to a token, see: https://docs.planetscale.com/reference/planetscale-cli#service-tokens-in-organizations.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/cmd/token/create.go
+++ b/internal/cmd/token/create.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -15,7 +14,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "create",
 		Short: "create a service token for the organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/cmd/token/delete.go
+++ b/internal/cmd/token/delete.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -15,7 +14,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "delete <token>",
 		Short: "delete an entire service token in an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/cmd/token/deleteaccess.go
+++ b/internal/cmd/token/deleteaccess.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -16,7 +15,7 @@ func DeleteAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "delete-access <token> <access> <access> ...",
 		Short: "delete access granted to a service token in the organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/cmd/token/list.go
+++ b/internal/cmd/token/list.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -15,7 +14,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "list",
 		Short: "list service tokens for the organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/cmd/token/showaccess.go
+++ b/internal/cmd/token/showaccess.go
@@ -1,7 +1,6 @@
 package token
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -15,7 +14,7 @@ func ShowAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "show-access <name>",
 		Short: "fetch a service token and it's accesses",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			client, err := ch.Client()
 			if err != nil {
 				return err

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestLatestVersion(t *testing.T) {
 			}))
 			defer ts.Close()
 
-			info, err := latestVersion(ts.URL)
+			info, err := latestVersion(context.Background(), ts.URL)
 
 			success := tt.statusCode >= 200 && tt.statusCode < 300
 			if !success {
@@ -104,9 +105,10 @@ func TestCheckVersion(t *testing.T) {
 			}
 
 			updateInfo, err := checkVersion(
+				context.Background(),
 				tt.buildVersion,
 				path,
-				func(addr string) (*ReleaseInfo, error) {
+				func(ctx context.Context, addr string) (*ReleaseInfo, error) {
 					return &ReleaseInfo{Version: tt.latestVersion}, nil
 				},
 			)


### PR DESCRIPTION
This PR adds proper context cancellation and propagation support to all commands. Even if the user cancels the operation, we will continue to make requests to our API.

With the changes introduced in this PR, we now listen to `os.Interrupt` and `os.Kill` signals. The context associated with the signals is passed down to all child commands. Any command accepting a `ctx` value will now be canceled automatically. 

Another benefit of this PR is that we got rid of custom context implementations (such as `pscale connect` or `pscale shell`). Now, all commands use the same context value created in the root command.
