### PR TITLE
Ignore the `vendor/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 dist/
 completions/
+vendor/


### PR DESCRIPTION
Sometimes I vendor for local development purposes. We don't use vendoring, though. Let's ignore it, so we don't purposely add any code changes from a vendor folder.
