### PR TITLE
branch: status information is not used anymore

### DIFF
--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -76,17 +76,7 @@ func toDatabaseBranches(branches []*ps.DatabaseBranch) []*DatabaseBranch {
 }
 
 type DatabaseBranchStatus struct {
-	Status      string `header:"status" json:"status"`
-	GatewayHost string `header:"gateway_host" json:"gateway_host"`
-	GatewayPort int    `header:"gateway_port,text" json:"gateway_port"`
-	User        string `header:"username" json:"user"`
-	Password    string `header:"password" json:"password"`
-
-	orig *ps.DatabaseBranchStatus
-}
-
-func (d *DatabaseBranchStatus) MarshalJSON() ([]byte, error) {
-	return json.MarshalIndent(d.orig, "", "  ")
+	Status string `header:"status" json:"status"`
 }
 
 func toDatabaseBranchStatus(status *ps.DatabaseBranchStatus) *DatabaseBranchStatus {
@@ -95,11 +85,6 @@ func toDatabaseBranchStatus(status *ps.DatabaseBranchStatus) *DatabaseBranchStat
 		ready = "not ready"
 	}
 	return &DatabaseBranchStatus{
-		Status:      ready,
-		GatewayHost: status.Credentials.GatewayHost,
-		GatewayPort: status.Credentials.GatewayPort,
-		User:        status.Credentials.User,
-		Password:    status.Credentials.Password,
-		orig:        status,
+		Status: ready,
 	}
 }

--- a/internal/cmd/branch/status_test.go
+++ b/internal/cmd/branch/status_test.go
@@ -57,5 +57,7 @@ func TestBranch_StatusCmd(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(svc.GetStatusFnInvoked, qt.IsTrue)
-	c.Assert(buf.String(), qt.JSONEquals, res)
+
+	orig := &DatabaseBranchStatus{Status: "ready"}
+	c.Assert(buf.String(), qt.JSONEquals, orig)
 }


### PR DESCRIPTION
This information is not used anymore. Just show the readiness of the
branch. We're going to either remove this branch or overhaul the
usage in the future.
