### PR TITLE
README: update correct URL to the build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PlanetScale CLI [![Build status](https://badge.buildkite.com/2307000d934b6a245eb9b84bcac9c1eea1a7c13f010b20c8ba.svg?branch=main)](https://buildkite.com/planetscale/cli)
+# PlanetScale CLI [![Build status](https://badge.buildkite.com/cf225eb6ccc163b365267fd8172a6e5bd9baa7c8fcdd10c77c.svg?branch=main)](https://buildkite.com/planetscale/cli)
 
 PlanetScale is more than a database and our CLI is more than a jumble of commands. The `pscale` command line tool brings branches, deploy requests, and other PlanetScale concepts to your finger tips.
 


### PR DESCRIPTION
It looks like after replacing our old BuildKite pipeline, the link to the badge was invalidated. Let's replace it with the new one.
