### PR TITLE
Update to the latest Go 1.16.6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
   command: script/release.sh
   plugins:
     - docker#v3.8.0:
-        image: "golang:1.16.5"
+        image: "golang:1.16.6"
         propagate-environment: true
         environment:
           - "GITHUB_TOKEN"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: golang:1.16.4
+    image: golang:1.16.6
     volumes:
       - .:/work
     working_dir: /work


### PR DESCRIPTION
This fixes some security issues, mostly one where a TLS client can be made to crash with a forged certificate.