### PR TITLE
Update to the latest planetscale go client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.33.0
+	github.com/planetscale/planetscale-go v0.34.0
 	github.com/planetscale/sql-proxy v0.8.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -254,7 +254,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/planetscale/planetscale-go v0.33.0 h1:ciR7H32fy757y0mOLuaFMq9lFbQdPFRH1F1X2txPhjY=
 github.com/planetscale/planetscale-go v0.33.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
 github.com/planetscale/planetscale-go v0.34.0 h1:/nxR5P3HD/ESwX6qdoBZWRdu2RxAGHD90C0P3rijSBo=
 github.com/planetscale/planetscale-go v0.34.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/planetscale/planetscale-go v0.33.0 h1:ciR7H32fy757y0mOLuaFMq9lFbQdPFRH1F1X2txPhjY=
 github.com/planetscale/planetscale-go v0.33.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
+github.com/planetscale/planetscale-go v0.34.0 h1:/nxR5P3HD/ESwX6qdoBZWRdu2RxAGHD90C0P3rijSBo=
+github.com/planetscale/planetscale-go v0.34.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
 github.com/planetscale/sql-proxy v0.8.0 h1:EeWQhocldn0ldrTxPIIIrbHWWqNqHrNFYiSdp4tUY0E=
 github.com/planetscale/sql-proxy v0.8.0/go.mod h1:vOcL5jRMzaza+8q79hRRhMj3ABpYHy3cgenr2FOhDWU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/token/addaccess_test.go
+++ b/internal/cmd/token/addaccess_test.go
@@ -29,12 +29,12 @@ func TestServiceToken_AddAccessCmd(t *testing.T) {
 
 	orig := []*ps.ServiceTokenAccess{
 		{
-			ID:       1,
+			ID:       "id-1",
 			Access:   "read_branch",
 			Resource: ps.Database{Name: db},
 		},
 		{
-			ID:       2,
+			ID:       "id-2",
 			Access:   "delete_branch",
 			Resource: ps.Database{Name: db},
 		},

--- a/internal/cmd/token/showaccess_test.go
+++ b/internal/cmd/token/showaccess_test.go
@@ -28,12 +28,12 @@ func TestServiceToken_ShowAccess(t *testing.T) {
 
 	orig := []*ps.ServiceTokenAccess{
 		{
-			ID:       1,
+			ID:       "id-1",
 			Access:   "read_branch",
 			Resource: ps.Database{Name: db},
 		},
 		{
-			ID:       2,
+			ID:       "id-2",
 			Access:   "delete_branch",
 			Resource: ps.Database{Name: db},
 		},


### PR DESCRIPTION
This fixes the bugs we are having with users creating service-tokens
```go
~$ pscale service-token add-access te2okcpjdb5t connect_branch --database again
Error: json: cannot unmarshal string into Go struct field ServiceTokenAccess.data.id of type int
~$ pscale service-token show-access te2okcpjdb5t
Error: json: cannot unmarshal string into Go struct field ServiceTokenAccess.data.id of type int
```