### PR TITLE
Fix add-access example text

### DIFF
--- a/internal/cmd/token/addaccess.go
+++ b/internal/cmd/token/addaccess.go
@@ -19,7 +19,7 @@ func AddAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 
 For example, to give a service token the ability to create, read and delete branches on a specific database:
 
-  pscale token add-access <token id> read_branch delete_branch create_branch --database <database name>
+  pscale service-token add-access <token id> read_branch delete_branch create_branch --database <database name>
 
 For a complete list of the access permissions that can be granted to a token, see: https://docs.planetscale.com/reference/planetscale-cli#service-tokens-in-organizations.`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Example syntax should use `pscale service-token...`