### PR TITLE
Feature: show friendly message if there are no tokens

### DIFF
--- a/internal/cmd/token/list.go
+++ b/internal/cmd/token/list.go
@@ -38,6 +38,11 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			end()
+			
+			if len(tokens) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Println("No service tokens have been created yet.")
+				return nil
+			}
 
 			return ch.Printer.PrintResource(toServiceTokens(tokens))
 		},


### PR DESCRIPTION
## Summary

Hello, `@planetscale`! 👋  🌍 

This PR shows a friendly message if there are no service tokens to list:

```
➜  ~ pscale service-token list  
No service tokens have been created yet.
```

This copies the same pattern when a client asks for a list of databases, but there aren't any:

https://github.com/planetscale/cli/blob/73c0ca7b9147fe5c582293a68c5d451998b3b2bd/internal/cmd/database/list.go#L58-L61

This is my first time contributing to a CLI based on Cobra -- I'd be happy to write tests for these, if it's expected/welcome with some pointers. Thanks ya'll! :v: 
