### PR TITLE
Unhide region flag for branches and databases

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -114,7 +114,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
-	cmd.Flags().MarkHidden("region")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := cmd.Context()
 		client, err := ch.Client()

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -70,7 +70,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&createReq.Notes, "notes", "", "notes for the database")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
-	cmd.Flags().MarkHidden("region")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := cmd.Context()
 		client, err := ch.Client()


### PR DESCRIPTION
This pull request unhides the `--region` flag for database and branch creation.