### PR TITLE
passwords: support listing all passwords

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.43.0
+	github.com/planetscale/planetscale-go v0.44.0
 	github.com/planetscale/sql-proxy v0.9.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -254,8 +254,9 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/planetscale/planetscale-go v0.43.0 h1:TSz2dH7eaXhdyAdLFqo3wPiw0XVjC7zIbeWYp1PsEbs=
 github.com/planetscale/planetscale-go v0.43.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
+github.com/planetscale/planetscale-go v0.44.0 h1:m8Kvfnu0ObcCZxGgj/LAcoogEjHHMkYVF9lukkwD740=
+github.com/planetscale/planetscale-go v0.44.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
 github.com/planetscale/sql-proxy v0.9.0 h1:Uc/TWvUQn6KIaUvHCJ/V6dtmIA0kEOp6b/u6z1vJ7GE=
 github.com/planetscale/sql-proxy v0.9.0/go.mod h1:P1CWQsaA+gNdLnfPWM8WR/UgPMFedjP1SFz3b+QAbVw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -1,4 +1,4 @@
-package passwords
+package password
 
 import (
 	"fmt"

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -1,4 +1,4 @@
-package passwords
+package password
 
 import (
 	"bytes"
@@ -14,7 +14,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-func TestPassword_DeleteCmd(t *testing.T) {
+func TestPassword_CreateCmd(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
@@ -25,16 +25,17 @@ func TestPassword_DeleteCmd(t *testing.T) {
 	org := "planetscale"
 	db := "planetscale"
 	branch := "development"
-	password := "mypassword"
+	name := "production-password"
+	res := &ps.DatabaseBranchPassword{Name: "foo"}
 
 	svc := &mock.PasswordsService{
-		DeleteFn: func(ctx context.Context, req *ps.DeleteDatabaseBranchPasswordRequest) error {
+		CreateFn: func(ctx context.Context, req *ps.DatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
-			c.Assert(req.PasswordId, qt.Equals, password)
+			c.Assert(req.DisplayName, qt.Equals, name)
 
-			return nil
+			return res, nil
 		},
 	}
 
@@ -51,17 +52,10 @@ func TestPassword_DeleteCmd(t *testing.T) {
 		},
 	}
 
-	cmd := DeleteCmd(ch)
-	cmd.SetArgs([]string{db, branch, password, "--force"})
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, name})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
-
-	res := map[string]string{
-		"result":   "password deleted",
-		"password": password,
-		"branch":   branch,
-	}
-	c.Assert(buf.String(), qt.JSONEquals, res)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 }

--- a/internal/cmd/password/delete.go
+++ b/internal/cmd/password/delete.go
@@ -1,4 +1,4 @@
-package passwords
+package password
 
 import (
 	"errors"

--- a/internal/cmd/password/delete_test.go
+++ b/internal/cmd/password/delete_test.go
@@ -1,4 +1,4 @@
-package passwords
+package password
 
 import (
 	"bytes"
@@ -14,7 +14,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-func TestPassword_ListCmd(t *testing.T) {
+func TestPassword_DeleteCmd(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
@@ -25,19 +25,16 @@ func TestPassword_ListCmd(t *testing.T) {
 	org := "planetscale"
 	db := "planetscale"
 	branch := "development"
-
-	resp := []*ps.DatabaseBranchPassword{
-		{Name: "foo"},
-		{Name: "bar"},
-	}
+	password := "mypassword"
 
 	svc := &mock.PasswordsService{
-		ListFn: func(ctx context.Context, req *ps.ListDatabaseBranchPasswordRequest) ([]*ps.DatabaseBranchPassword, error) {
+		DeleteFn: func(ctx context.Context, req *ps.DeleteDatabaseBranchPasswordRequest) error {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.PasswordId, qt.Equals, password)
 
-			return resp, nil
+			return nil
 		},
 	}
 
@@ -54,23 +51,17 @@ func TestPassword_ListCmd(t *testing.T) {
 		},
 	}
 
-	cmd := ListCmd(ch)
-	cmd.SetArgs([]string{db, branch})
+	cmd := DeleteCmd(ch)
+	cmd.SetArgs([]string{db, branch, password, "--force"})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
 
-	passwords := []*Password{
-		{
-			Name: "foo",
-			orig: resp[0],
-		},
-		{
-			Name: "bar",
-			orig: resp[1],
-		},
+	res := map[string]string{
+		"result":   "password deleted",
+		"password": password,
+		"branch":   branch,
 	}
-
-	c.Assert(buf.String(), qt.JSONEquals, passwords)
+	c.Assert(buf.String(), qt.JSONEquals, res)
 }

--- a/internal/cmd/password/list.go
+++ b/internal/cmd/password/list.go
@@ -1,4 +1,4 @@
-package passwords
+package password
 
 import (
 	"fmt"
@@ -14,14 +14,13 @@ import (
 // ListCmd encapsulates the command for listing passwords for a branch.
 func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list <database> <branch>",
-		Short:   "List all passwords of a branch",
-		Args:    cmdutil.RequiredArgs("database", "branch"),
+		Use:     "list <database> [branch]",
+		Short:   "List all passwords of a database",
+		Args:    cmdutil.RequiredArgs("database"),
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database := args[0]
-			branch := args[1]
 
 			web, err := cmd.Flags().GetBool("web")
 			if err != nil {
@@ -35,6 +34,11 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 					return err
 				}
 				return nil
+			}
+
+			var branch string
+			if len(args) == 2 {
+				branch = args[1]
 			}
 
 			client, err := ch.Client()

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -1,4 +1,4 @@
-package passwords
+package password
 
 import (
 	"encoding/json"
@@ -35,6 +35,7 @@ type Passwords []*Password
 type Password struct {
 	PublicID  string `header:"id" json:"id"`
 	Name      string `header:"name" json:"name"`
+	Branch    string `header:"branch" json:"branch"`
 	UserName  string `header:"username" json:"username"`
 	Role      string `header:"role" json:"role"`
 	RoleDesc  string `header:"role description" json:"-"`
@@ -44,6 +45,7 @@ type Password struct {
 
 type PasswordWithPlainText struct {
 	Name              string               `header:"name" json:"name"`
+	Branch            string               `header:"branch" json:"branch"`
 	PublicID          string               `header:"username" json:"username"`
 	AccessHostUrl     string               `header:"access host url" json:"access_host_url"`
 	Role              string               `header:"role" json:"role"`
@@ -71,6 +73,7 @@ func (b Passwords) String() string {
 func toPassword(password *ps.DatabaseBranchPassword) *Password {
 	return &Password{
 		Name:      password.Name,
+		Branch:    password.Branch.Name,
 		PublicID:  password.PublicID,
 		UserName:  password.PublicID,
 		Role:      password.Role,
@@ -91,6 +94,7 @@ func toPasswords(passwords []*ps.DatabaseBranchPassword) []*Password {
 func toPasswordWithPlainText(password *ps.DatabaseBranchPassword) *PasswordWithPlainText {
 	return &PasswordWithPlainText{
 		Name:              password.Name,
+		Branch:            password.Branch.Name,
 		PublicID:          password.PublicID,
 		PlainText:         password.PlainText,
 		AccessHostUrl:     password.Branch.AccessHostURL,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -33,7 +33,7 @@ import (
 	"github.com/planetscale/cli/internal/cmd/database"
 	"github.com/planetscale/cli/internal/cmd/deployrequest"
 	"github.com/planetscale/cli/internal/cmd/org"
-	"github.com/planetscale/cli/internal/cmd/passwords"
+	"github.com/planetscale/cli/internal/cmd/password"
 	"github.com/planetscale/cli/internal/cmd/region"
 	"github.com/planetscale/cli/internal/cmd/shell"
 	"github.com/planetscale/cli/internal/cmd/signup"
@@ -174,7 +174,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.AddCommand(database.DatabaseCmd(ch))
 	rootCmd.AddCommand(deployrequest.DeployRequestCmd(ch))
 	rootCmd.AddCommand(org.OrgCmd(ch))
-	rootCmd.AddCommand(passwords.PasswordCmd(ch))
+	rootCmd.AddCommand(password.PasswordCmd(ch))
 	rootCmd.AddCommand(region.RegionCmd(ch))
 	rootCmd.AddCommand(shell.ShellCmd(ch))
 	rootCmd.AddCommand(signup.SignupCmd(ch))


### PR DESCRIPTION
This PR changes the `pscale password list` subcommand to list all branches. The following changes were made:

* Renamed the `passwords` package to `package` (packages in Go should be singular)
* Added a new header with the name `Branch` to the output, so the user can see which password belongs to which branch
* `pscale password list database` now lists all passwords from all branches. This is now the same behavior we see in the UI
* `pscale password list database branch` lists all passwords for the given `branch`.

Depends on https://github.com/planetscale/cli/pull/367