### PR TITLE
restore: set workload=olap

### DIFF
--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -110,6 +110,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 	cfg.Debug = ch.Debug()
 	cfg.IntervalMs = 10 * 1000
 	cfg.Outdir = flags.dir
+	cfg.SessionVars = "set workload=olap;"
 
 	loader, err := dumper.NewLoader(cfg)
 	if err != nil {


### PR DESCRIPTION
We do this in the dump command (https://github.com/planetscale/cli/blob/12faa1658517b2677877c9cf5821c1550c7b2c3f/internal/cmd/database/dump.go#L143), I think we probably want to in the restore command as well. 

This should make imports more smooth for more users, I believe. 