### PR TITLE
Add override to allow non-interactive use of `pscale shell`

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -54,7 +54,9 @@ second argument:
 			database := args[0]
 
 			if !printer.IsTTY || ch.Printer.Format() != printer.Human {
-				return errors.New("pscale shell only works in interactive mode")
+				if !(os.Getenv("PSCALE_ALLOW_NONINTERACTIVE_SHELL") == "true") {
+					return errors.New("pscale shell only works in interactive mode")
+				}
 			}
 
 			mysqlPath, err := cmdutil.MySQLClientPath()

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -54,7 +54,7 @@ second argument:
 			database := args[0]
 
 			if !printer.IsTTY || ch.Printer.Format() != printer.Human {
-				if _, ok := os.LookupEnv("PSCALE_ALLOW_NONINTERACTIVE_SHELL"); !ok {
+				if _, exists := os.LookupEnv("PSCALE_ALLOW_NONINTERACTIVE_SHELL"); !exists {
 					return errors.New("pscale shell only works in interactive mode")
 				}
 			}

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -54,7 +54,7 @@ second argument:
 			database := args[0]
 
 			if !printer.IsTTY || ch.Printer.Format() != printer.Human {
-				if !(os.Getenv("PSCALE_ALLOW_NONINTERACTIVE_SHELL") == "true") {
+				if _, ok := os.LookupEnv("PSCALE_ALLOW_NONINTERACTIVE_SHELL"); !ok {
 					return errors.New("pscale shell only works in interactive mode")
 				}
 			}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -93,7 +93,7 @@ func checkVersion(
 	buildVersion, path string,
 	latestVersionFn func(ctx context.Context, addr string) (*ReleaseInfo, error),
 ) (*UpdateInfo, error) {
-	if os.Getenv("PSCALE_NO_UPDATE_NOTIFIER") != "" {
+	if _, ok := os.LookupEnv("PSCALE_NO_UPDATE_NOTIFIER"); ok {
 		return &UpdateInfo{
 			Update: false,
 			Reason: "PSCALE_NO_UPDATE_NOTIFIER is set",

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -93,7 +93,7 @@ func checkVersion(
 	buildVersion, path string,
 	latestVersionFn func(ctx context.Context, addr string) (*ReleaseInfo, error),
 ) (*UpdateInfo, error) {
-	if _, ok := os.LookupEnv("PSCALE_NO_UPDATE_NOTIFIER"); ok {
+	if _, exists := os.LookupEnv("PSCALE_NO_UPDATE_NOTIFIER"); exists {
 		return &UpdateInfo{
 			Update: false,
 			Reason: "PSCALE_NO_UPDATE_NOTIFIER is set",


### PR DESCRIPTION
This makes it possible to use `pscale shell` to run small SQL scripts
against a database branch from shell scripts.

This is behind an environment variable for now, while we make sure there
aren't unintended consequences. We may remove the check entirely at a
later time.