### PR TITLE
Clarify success message of deploy command

### DIFF
--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -48,7 +48,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Successfully deployed %s from %s to %s.\n",
+				ch.Printer.Printf("Successfully queued %s from %s for deployment to %s.\n",
 					dr.ID, dr.Branch, dr.IntoBranch)
 				return nil
 			}


### PR DESCRIPTION
`pscale deploy-request deploy <db> <deploy-request-id>` actually adds the deploy-request to the queue to be deployed, but the current success message tells you that the deploy-request has *been* deployed already.

This modifies the success message for clarity. Ideally, it'd also print the URL to view the deploy request on the Planetscale Dashboard.