### PR TITLE
Restore backup to new branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.44.0
+	github.com/planetscale/planetscale-go v0.45.0
 	github.com/planetscale/sql-proxy v0.11.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,9 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/planetscale/planetscale-go v0.44.0 h1:m8Kvfnu0ObcCZxGgj/LAcoogEjHHMkYVF9lukkwD740=
 github.com/planetscale/planetscale-go v0.44.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
+github.com/planetscale/planetscale-go v0.45.0 h1:6EVvttWZ7lvVGRFDXycL4YmTiWWvScZuHP1XS/yKwGM=
+github.com/planetscale/planetscale-go v0.45.0/go.mod h1:99n+tnrvJaaUako3UZNCiC1dTtSPKr81GqAUNibw5pc=
 github.com/planetscale/sql-proxy v0.11.0 h1:wZEYbrXZP64QaLruisdjB+0UjIFTvksyS7NuPWipdtg=
 github.com/planetscale/sql-proxy v0.11.0/go.mod h1:n9gsHgJhOxlqJyaE2G50LgTgLepSdc7w6pbb7M8tl3E=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/backup/backup.go
+++ b/internal/cmd/backup/backup.go
@@ -34,6 +34,7 @@ func BackupCmd(ch *cmdutil.Helper) *cobra.Command {
 type Backups []*Backup
 
 type Backup struct {
+	PublicID    string `header:"id" json:"id"`
 	Name        string `header:"name" json:"name"`
 	State       string `header:"state" json:"state"`
 	Size        int64  `header:"size" json:"size"`
@@ -63,6 +64,7 @@ func (b Backups) String() string {
 // toBackup Returns a struct that prints out the various fields of a branch model.
 func toBackup(backup *ps.Backup) *Backup {
 	return &Backup{
+		PublicID:    backup.PublicID,
 		Name:        backup.Name,
 		State:       backup.State,
 		Size:        backup.Size,

--- a/internal/cmd/backup/backup.go
+++ b/internal/cmd/backup/backup.go
@@ -27,6 +27,7 @@ func BackupCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ListCmd(ch))
 	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
+	cmd.AddCommand(RestoreCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/backup/restore.go
+++ b/internal/cmd/backup/restore.go
@@ -1,0 +1,49 @@
+package backup
+
+import (
+	"fmt"
+
+	b "github.com/planetscale/cli/internal/cmd/branch"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/planetscale/planetscale-go/planetscale"
+
+	"github.com/spf13/cobra"
+)
+
+func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore <database> <branch> <backup>",
+		Short: "Restore a backup to a new branch",
+		Args:  cmdutil.RequiredArgs("database", "branch", "backup"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+			backup := args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Restoring backup %s to %s", printer.BoldBlue(backup), printer.BoldBlue(branch)))
+			defer end()
+			newBranch, err := client.DatabaseBranches.Create(ctx, &planetscale.CreateDatabaseBranchRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Name:         branch,
+				BackupID:     backup,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+
+			end()
+			return ch.Printer.PrintResource(b.ToDatabaseBranch(newBranch))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/backup/restore_test.go
+++ b/internal/cmd/backup/restore_test.go
@@ -1,0 +1,62 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackup_RestoreCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "restore-branch"
+	backup := "mybackup"
+
+	res := &ps.DatabaseBranch{Name: "restore-branch"}
+
+	svc := &mock.DatabaseBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Name, qt.Equals, branch)
+			c.Assert(req.BackupID, qt.Equals, backup)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := RestoreCmd(ch)
+	cmd.SetArgs([]string{db, branch, backup})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -54,6 +54,10 @@ func (d *DatabaseBranch) MarshalCSVValue() interface{} {
 	return []*DatabaseBranch{d}
 }
 
+func ToDatabaseBranch(db *ps.DatabaseBranch) *DatabaseBranch {
+	return toDatabaseBranch(db)
+}
+
 // toDatabaseBranch returns a struct that prints out the various fields of a
 // database model.
 func toDatabaseBranch(db *ps.DatabaseBranch) *DatabaseBranch {

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -109,6 +109,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
+	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "backup to restore into the branch")
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := cmd.Context()
 		client, err := ch.Client()


### PR DESCRIPTION
Add two commands to restore a backup to a new branch. Requires https://github.com/planetscale/planetscale-go/pull/94.

    pscale branch create <db> <name> --restore <backup>
    pscale backup restore <db> <name> <backup>