### PR TITLE
branch: export `toDatabaseBranch` and remove one char package alias

### DIFF
--- a/internal/cmd/backup/restore.go
+++ b/internal/cmd/backup/restore.go
@@ -3,7 +3,7 @@ package backup
 import (
 	"fmt"
 
-	b "github.com/planetscale/cli/internal/cmd/branch"
+	"github.com/planetscale/cli/internal/cmd/branch"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 
@@ -20,7 +20,7 @@ func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database := args[0]
-			branch := args[1]
+			branchName := args[1]
 			backup := args[2]
 
 			client, err := ch.Client()
@@ -28,12 +28,12 @@ func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Restoring backup %s to %s", printer.BoldBlue(backup), printer.BoldBlue(branch)))
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Restoring backup %s to %s", printer.BoldBlue(backup), printer.BoldBlue(branchName)))
 			defer end()
 			newBranch, err := client.DatabaseBranches.Create(ctx, &planetscale.CreateDatabaseBranchRequest{
 				Organization: ch.Config.Organization,
 				Database:     database,
-				Name:         branch,
+				Name:         branchName,
 				BackupID:     backup,
 			})
 			if err != nil {
@@ -41,7 +41,7 @@ func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			end()
-			return ch.Printer.PrintResource(b.ToDatabaseBranch(newBranch))
+			return ch.Printer.PrintResource(branch.ToDatabaseBranch(newBranch))
 		},
 	}
 

--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -54,13 +54,9 @@ func (d *DatabaseBranch) MarshalCSVValue() interface{} {
 	return []*DatabaseBranch{d}
 }
 
-func ToDatabaseBranch(db *ps.DatabaseBranch) *DatabaseBranch {
-	return toDatabaseBranch(db)
-}
-
-// toDatabaseBranch returns a struct that prints out the various fields of a
+// ToDatabaseBranch returns a struct that prints out the various fields of a
 // database model.
-func toDatabaseBranch(db *ps.DatabaseBranch) *DatabaseBranch {
+func ToDatabaseBranch(db *ps.DatabaseBranch) *DatabaseBranch {
 	return &DatabaseBranch{
 		Name:         db.Name,
 		Status:       db.Status,
@@ -76,7 +72,7 @@ func toDatabaseBranches(branches []*ps.DatabaseBranch) []*DatabaseBranch {
 	bs := make([]*DatabaseBranch, 0, len(branches))
 
 	for _, db := range branches {
-		bs = append(bs, toDatabaseBranch(db))
+		bs = append(bs, ToDatabaseBranch(db))
 	}
 
 	return bs

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -103,7 +103,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toDatabaseBranch(dbBranch))
+			return ch.Printer.PrintResource(ToDatabaseBranch(dbBranch))
 		},
 	}
 

--- a/internal/cmd/branch/promote.go
+++ b/internal/cmd/branch/promote.go
@@ -85,7 +85,7 @@ func PromoteCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toDatabaseBranch(dbBranch))
+			return ch.Printer.PrintResource(ToDatabaseBranch(dbBranch))
 		},
 	}
 

--- a/internal/cmd/branch/show.go
+++ b/internal/cmd/branch/show.go
@@ -60,7 +60,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			end()
 
-			return ch.Printer.PrintResource(toDatabaseBranch(b))
+			return ch.Printer.PrintResource(ToDatabaseBranch(b))
 		},
 	}
 


### PR DESCRIPTION
Instead of creating a new exported method, we can export the existing
`toDatabaseBranch` method. 

I also removed the import alias `b`, because
one character identifier is rarely used for naming packages.
