### PR TITLE
dump: add a placeholder password to fix `EOF` error

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -134,6 +134,8 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 
 	cfg := dumper.NewDefaultConfig()
 	cfg.User = "root"
+	// NOTE(fatih): the password is a placeholder, replace once we get rid of the proxy
+	cfg.Password = "root"
 	cfg.Address = addr.String()
 	cfg.Database = dbName
 	cfg.Debug = ch.Debug()


### PR DESCRIPTION
After the changes in https://github.com/planetscale/cli/commit/98c6fd0f3357afb94633d08d3e509ed531828b10, the `pscale database dump` command started throwing an `EOF` error. The reason for that is, the `github.com/xelabs/go-mysqlstack` package expects the password to be non-empty. Adding a placeholder value (with no meaning) fixes it.

This change is temporary and we're going to remove it once we remove the `proxy` and move using connection strings.