### PR TITLE
dump-restore: add a placeholder password to fix EOF error

### DIFF
--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -106,6 +106,8 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 
 	cfg := dumper.NewDefaultConfig()
 	cfg.User = "root"
+	// NOTE: the password is a placeholder, replace once we get rid of the proxy
+	cfg.Password = "root"
 	cfg.Address = addr.String()
 	cfg.Debug = ch.Debug()
 	cfg.IntervalMs = 10 * 1000


### PR DESCRIPTION
Applies the temporary fix from https://github.com/planetscale/cli/pull/392 to the `dump-restore` command.