### PR TITLE
Add locations to region output.

### DIFF
--- a/internal/cmd/region/region.go
+++ b/internal/cmd/region/region.go
@@ -40,7 +40,7 @@ type Region struct {
 // toRegion returns a struct that prints out various fields of a region.
 func toRegion(region *ps.Region) *Region {
 	return &Region{
-		Name:    fmt.Sprintf("%s (%s)", region.Name, region.Location),
+		Name:    fmt.Sprintf("%s - %s", region.Name, region.Location),
 		Slug:    region.Slug,
 		Enabled: region.Enabled,
 		orig:    region,

--- a/internal/cmd/region/region.go
+++ b/internal/cmd/region/region.go
@@ -2,6 +2,7 @@ package region
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	ps "github.com/planetscale/planetscale-go/planetscale"
@@ -39,7 +40,7 @@ type Region struct {
 // toRegion returns a struct that prints out various fields of a region.
 func toRegion(region *ps.Region) *Region {
 	return &Region{
-		Name:    region.Name,
+		Name:    fmt.Sprintf("%s (%s)", region.Name, region.Location),
 		Slug:    region.Slug,
 		Enabled: region.Enabled,
 		orig:    region,


### PR DESCRIPTION
Given that we're adding more locations in the same regions, this adds the geographical location to the output for a region. This allows users to disambiguate where the the regions are actually located.

### Before
```
  NAME (6)       SLUG           ENABLED
 -------------- -------------- ---------
  US East        us-east        Yes
  US West        us-west        Yes
  EU West        eu-west        Yes
  Asia Pacific   ap-south       Yes
  Asia Pacific   ap-southeast   Yes
  Asia Pacific   ap-northeast   Yes
```

### After
```
  NAME (6)                      SLUG           ENABLED
 ----------------------------- -------------- ---------
  US East - Northern Virginia   us-east        Yes
  US West - Oregon              us-west        Yes
  EU West - Dublin              eu-west        Yes
  Asia Pacific - Mumbai         ap-south       Yes
  Asia Pacific - Singapore      ap-southeast   Yes
  Asia Pacific - Tokyo          ap-northeast   Yes
```