### PR TITLE
Bump `goreleaser` version to support ARM macs properly

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -27,7 +27,7 @@ apt-get install -y docker-ce-cli
 
 echo "--- installing goreleaser"
 
-curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.173.2/goreleaser_Linux_x86_64.tar.gz
+curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.179.0/goreleaser_Linux_x86_64.tar.gz
 
 cd /tmp && tar -zxvf goreleaser_Linux_x86_64.tar.gz
 


### PR DESCRIPTION
Versions of `goreleaser` before https://github.com/goreleaser/goreleaser/pull/2407/files#diff-42bf43059238f9a44ded247b8c54c94a832da6fd89c2398b44682026b92a0e70L122 created Homebrew Taps that are invalid on M1 Macs, as they don't add the proper conditionals.

This means that the current `pscale` install on M1 Macs does not work. 