### PR TITLE
releases: add `scoop` support for Windows users

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,6 +45,13 @@ nfpms:
     - rpm
     replacements:
       darwin: macOS
+scoop:
+  bucket:
+    owner: planetscale
+    name: scoop-bucket
+  homepage: "https://github.com/planetscale/cli"
+  description: "The PlanetScale CLI"
+  license: Apache 2.0
 brews:
   - homepage: "https://planetscale.com/"
     description: "The PlanetScale CLI"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,18 @@ brew upgrade pscale
 
 #### Windows
 
-`pscale` is available as downloadable binary from the [releases](https://github.com/planetscale/cli/releases/latest) page.
+On Windows, `pscale` is available via [scoop](https://scoop.sh/), and as a downloadable binarty from the [releases](https://github.com/planetscale/cli/releases/latest) page:
+
+```
+scoop bucket add pscale https://github.com/planetscale/scoop-bucket.git
+scoop install pscale
+```
+
+To upgrade to the latest version:
+
+```
+scoop update pscale
+```
 
 #### Manually
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew upgrade pscale
 
 #### Windows
 
-On Windows, `pscale` is available via [scoop](https://scoop.sh/), and as a downloadable binarty from the [releases](https://github.com/planetscale/cli/releases/latest) page:
+On Windows, `pscale` is available via [scoop](https://scoop.sh/), and as a downloadable binary from the [releases](https://github.com/planetscale/cli/releases/latest) page:
 
 ```
 scoop bucket add pscale https://github.com/planetscale/scoop-bucket.git


### PR DESCRIPTION
This PR includes the support for https://scoop.sh/, which allows Windows users to install `pscale` in an easy way (similar to macOS Homebrew).

We created the appropriate https://github.com/planetscale/scoop-bucket repository which holds the scoop related manifests (similar to https://github.com/planetscale/homebrew-tap for macOS).

Once we merge this PR and release a new version of the CLI, Windows users will be able to install via the following commands:

```
scoop bucket add pscale https://github.com/planetscale/scoop-bucket.git
scoop install pscale
```
