### PR TITLE
Add missing space

### DIFF
--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -19,7 +19,7 @@ import (
 	exec "golang.org/x/sys/execabs"
 )
 
-const WarnAuthMessage = "not authenticated yet. Please run 'pscale auth login'" +
+const WarnAuthMessage = "not authenticated yet. Please run 'pscale auth login' " +
 	"or create a service token with 'pscale service-token create'"
 
 // Helper is passed to every single command and is used by individual


### PR DESCRIPTION
The `not authenticated yet` error has a missing space:
![CleanShot 2021-10-10 at 23 30 10](https://user-images.githubusercontent.com/4721750/136725132-7bc266d4-b596-4e21-bc0a-26d6ed0c7b1b.png)

This PR adds it ✅ 