### PR TITLE
bump-version: install `svu` manually

### DIFF
--- a/script/bump-version.sh
+++ b/script/bump-version.sh
@@ -3,14 +3,15 @@
 set -eu
 
 WORKDIR=$(pwd)
-SVU_BIN="${WORKDIR}/svu"
 
 echo "+++ :construction:  Installing 'svu' tool"
-curl -sfL https://install.goreleaser.com/github.com/caarlos0/svu.sh | bash -s -- -b $WORKDIR
+curl -L -o /tmp/svu_linux_x86_64.tar.gz https://github.com/caarlos0/svu/releases/download/v1.8.0/svu_1.8.0_linux_amd64.tar.gz
+cd /tmp && tar -zxvf svu_linux_x86_64.tar.gz
+cd $WORKDIR
 
 git fetch --tags 
 
-RELEASE_VERSION=$($SVU_BIN minor)
+RELEASE_VERSION=$(/tmp/svu minor)
 
 echo "+++ :boom: Bumping to version $RELEASE_VERSION"
 


### PR DESCRIPTION
The install shell script is deprecated and not maintained: https://github.com/goreleaser/godownloader/issues/207 and https://github.com/goreleaser/goinstall/commit/195bf32149e3a555a3dd827e8ba843f83b48602f#diff-dd4069fbb32850fcb99cb3ab6ce106ae8bfc92098f53931c109bc89c3befb6a7R373

We're now directly downloadign the asset and installing it ourselves.
