### PR TITLE
Bump `goreleaser` to latest (0.183.0)

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -27,7 +27,7 @@ apt-get install -y docker-ce-cli
 
 echo "--- installing goreleaser"
 
-curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.179.0/goreleaser_Linux_x86_64.tar.gz
+curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.183.0/goreleaser_Linux_x86_64.tar.gz
 
 cd /tmp && tar -zxvf goreleaser_Linux_x86_64.tar.gz
 


### PR DESCRIPTION
This will fix the Homebrew deprecation warnings: https://github.com/goreleaser/goreleaser/pull/2591