### PR TITLE
Provide example how to run pscale from docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ To pull a specific version:
 docker pull planetscale/pscale:v0.63.0
 ```
 
+If you like to have a shell alias that runs the latest version of pscale from docker whenever you type `pscale`:
+
+```
+mkdir -p $HOME/.config/planetscale
+alias pscale="docker run -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale --user $(id -u):$(id -g) --rm -it -p 3306:3306/tcp planetscale/pscale:latest"
+```
+
+If you need a more advanced example that works with service tokens and differentiates between commands that need a pseudo terminal or non-interactive mode, [have a look at this shell function](https://github.com/jonico/pscale-cli-helper-scripts/blob/main/use-pscale-docker-image.sh).
+
 ## Documentation
 
 Please checkout our Documentation page: [docs.planetscale.com](https://docs.planetscale.com/reference/planetscale-cli/)


### PR DESCRIPTION
* example how to create a shell alias pscale that runs pscale from latest docker image
* supports port forwarding and reading/writing to local PlanetScale configuration/auth files
* needs to have $HOME/.config/planetscale folder pre-created so that it can be properly mounted by docker image
* added pointer to more advanced shell function