### PR TITLE
cmd: show a warning for self compiled binaries

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -70,6 +70,12 @@ func Execute(ctx context.Context, ver, commit, buildDate string) int {
 	var format printer.Format
 	var debug bool
 
+	if _, ok := os.LookupEnv("PSCALE_DISABLE_DEV_WARNING"); !ok {
+		if commit == "" || ver == "" || buildDate == "" {
+			fmt.Fprintf(os.Stderr, "!! WARNING: You are using a self-compiled binary which is not officially supported.\n!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true\n\n")
+		}
+	}
+
 	err := runCmd(ctx, ver, commit, buildDate, &format, &debug)
 	if err == nil {
 		return 0


### PR DESCRIPTION
Let's make sure users don't use a compiled version accidentally. For us devs, it doesn't matter because we can set the environment variable so everything would be the same as previously. People who have compiled it themselves wouldn't realize later that they use an old version.  If `pscale` is compiled from the source, it also can't do a version check, so we don't have a way to prompt the user for an update and they will be stuck with an old version. 
