### PR TITLE
README: Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mkdir -p $HOME/.config/planetscale
 alias pscale="docker run -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale --user $(id -u):$(id -g) --rm -it -p 3306:3306/tcp planetscale/pscale:latest"
 ```
 
-If you need a more advanced example that works with service tokens and differentiates between commands that need a pseudo terminal or non-interactive mode, [have a look at this shell function](https://github.com/jonico/pscale-cli-helper-scripts/blob/main/use-pscale-docker-image.sh).
+If you need a more advanced example that works with service tokens and differentiates between commands that need a pseudo terminal or non-interactive mode, [have a look at this shell function](https://github.com/jonico/pscale-cli-helper-scripts/blob/main/.pscale/cli-helper-scripts/use-pscale-docker-image.sh).
 
 ## Documentation
 


### PR DESCRIPTION
The link that points to an advanced example for Docker usage has changed.
This PR points to a correct link.