### PR TITLE
Switch service token name to be service token ID

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -152,9 +152,9 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	ch.SetDebug(debug)
 
 	// service token flags. they are hidden for now.
-	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenName,
-		"service-token-name", "", "The Service Token name for authenticating. (deprecated)")
-	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenID, "The Service Token ID for authenticating.")
+	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenID,
+		"service-token-name", "", "The Service Token name for authenticating.")
+	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenID, "service-token-id", "", "The Service Token ID for authenticating.")
 	rootCmd.PersistentFlags().StringVar(&cfg.ServiceToken,
 		"service-token", "", "Service Token for authenticating.")
 
@@ -162,6 +162,9 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	if err := viper.BindPFlag("no-color", rootCmd.PersistentFlags().Lookup("no-color")); err != nil {
 		return err
 	}
+
+	rootCmd.PersistentFlags().MarkDeprecated("service-token-name", "use --service-token-id instead")
+	rootCmd.PersistentFlags().MarkHidden("service-token-name")
 
 	// We don't want to show the default value
 	rootCmd.PersistentFlags().Lookup("api-token").DefValue = ""

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -153,7 +153,8 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 
 	// service token flags. they are hidden for now.
 	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenName,
-		"service-token-name", "", "The Service Token name for authenticating.")
+		"service-token-name", "", "The Service Token name for authenticating. (deprecated)")
+	rootCmd.PersistentFlags().StringVar(&cfg.ServiceTokenID, "The Service Token ID for authenticating.")
 	rootCmd.PersistentFlags().StringVar(&cfg.ServiceToken,
 		"service-token", "", "Service Token for authenticating.")
 

--- a/internal/cmd/token/token.go
+++ b/internal/cmd/token/token.go
@@ -30,7 +30,7 @@ func TokenCmd(ch *cmdutil.Helper) *cobra.Command {
 
 // ServiceToken returns a table and json serializable schema snapshot.
 type ServiceToken struct {
-	Name  string `header:"name" json:"name"`
+	ID    string `header:"id" json:"id"`
 	Token string `header:"token" json:"token"`
 
 	orig *ps.ServiceToken
@@ -44,7 +44,7 @@ func (s *ServiceToken) MarshalJSON() ([]byte, error) {
 // of a schema snapshot model.
 func toServiceToken(st *ps.ServiceToken) *ServiceToken {
 	return &ServiceToken{
-		Name:  st.ID,
+		ID:    st.ID,
 		Token: st.Token,
 		orig:  st,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Organization string
 
 	ServiceTokenName string
+	ServiceTokenID   string
 	ServiceToken     string
 
 	// Project Configuration
@@ -68,7 +69,7 @@ func New() (*Config, error) {
 }
 
 func (c *Config) IsAuthenticated() bool {
-	return ((c.ServiceToken != "" && c.ServiceTokenName != "") || (c.AccessToken != ""))
+	return (c.ServiceToken != "" && c.GetServiceTokenID() != "") || c.AccessToken != ""
 }
 
 // NewClientFromConfig creates a PlaentScale API client from our configuration
@@ -76,14 +77,27 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 	opts := []ps.ClientOption{
 		ps.WithBaseURL(c.BaseURL),
 	}
-	if c.ServiceToken != "" && c.ServiceTokenName != "" {
-		opts = append(opts, ps.WithServiceToken(c.ServiceTokenName, c.ServiceToken))
+
+	if c.ServiceToken != "" && (c.GetServiceTokenID() != "") {
+		opts = append(opts, ps.WithServiceToken(c.GetServiceTokenID(), c.ServiceToken))
 	} else {
 		opts = append(opts, ps.WithAccessToken(c.AccessToken))
 	}
 	opts = append(opts, clientOpts...)
 
 	return ps.NewClient(opts...)
+}
+
+// GetServiceTokenID gets the service token either from the ServiceTokenName or
+// the ServiceTokenID flag
+func (c *Config) GetServiceTokenID() string {
+	id := c.ServiceTokenID
+
+	if id == "" {
+		id = c.ServiceTokenName
+	}
+
+	return id
 }
 
 // ConfigDir is the directory for PlanetScale config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,9 +28,8 @@ type Config struct {
 	BaseURL      string
 	Organization string
 
-	ServiceTokenName string
-	ServiceTokenID   string
-	ServiceToken     string
+	ServiceTokenID string
+	ServiceToken   string
 
 	// Project Configuration
 	Database string
@@ -69,7 +68,7 @@ func New() (*Config, error) {
 }
 
 func (c *Config) IsAuthenticated() bool {
-	return (c.ServiceToken != "" && c.GetServiceTokenID() != "") || c.AccessToken != ""
+	return (c.ServiceToken != "" && c.ServiceTokenID != "") || c.AccessToken != ""
 }
 
 // NewClientFromConfig creates a PlaentScale API client from our configuration
@@ -78,26 +77,14 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 		ps.WithBaseURL(c.BaseURL),
 	}
 
-	if c.ServiceToken != "" && (c.GetServiceTokenID() != "") {
-		opts = append(opts, ps.WithServiceToken(c.GetServiceTokenID(), c.ServiceToken))
+	if c.ServiceToken != "" && c.ServiceTokenID != "" {
+		opts = append(opts, ps.WithServiceToken(c.ServiceTokenID, c.ServiceToken))
 	} else {
 		opts = append(opts, ps.WithAccessToken(c.AccessToken))
 	}
 	opts = append(opts, clientOpts...)
 
 	return ps.NewClient(opts...)
-}
-
-// GetServiceTokenID gets the service token either from the ServiceTokenName or
-// the ServiceTokenID flag
-func (c *Config) GetServiceTokenID() string {
-	id := c.ServiceTokenID
-
-	if id == "" {
-		id = c.ServiceTokenName
-	}
-
-	return id
 }
 
 // ConfigDir is the directory for PlanetScale config.


### PR DESCRIPTION
Before, we were showing the ID of a service token as a name, when in reality, we should just keep it as the `ID` in the output. This makes a couple of changes. First, it changes the header for a service token to be `ID` instead of `Name`. Secondly, it changes the flag to be `--service-token-id` instead of `--service-token-name`, with the last one being deprecated and hidden. Users will get warned when using the deprecated flag to use the new format, so this gives our users ample time to switch over. 