### PR TITLE
Pin to 3.4.0 for licensed.

### DIFF
--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,5 +1,5 @@
 FROM golang:1.17-buster
 
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev
+RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev apt-utils
 RUN gem install licensed -v 3.4.0

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -5,4 +5,4 @@ ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y apt-utils
 RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev
-RUN gem install licensed -v 3.4.0
+RUN gem install licensed -v 3.3.1

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,5 +1,8 @@
 FROM golang:1.17-buster
 
+ENV DEBIAN_FRONTEND="noninteractive"
+
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev apt-utils
+RUN apt-get install -y apt-utils
+RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev
 RUN gem install licensed -v 3.4.0

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -2,4 +2,4 @@ FROM golang:1.17-buster
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev
-RUN gem install licensed
+RUN gem install licensed -v 3.4.0


### PR DESCRIPTION
3.4.1 seems to be causing issues, so let's see if using 3.4.0 fixes us up.