### PR TITLE
bump licensed container to use bullseye

### DIFF
--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,4 +1,4 @@
-FROM golang:1.17-buster
+FROM golang:1.17-bullseye
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev


### PR DESCRIPTION
The root of this issue is actually that `gem install licensed` tries to install `nokogiri-1.13.1` which doesn't support Ruby 2.5, which is the version of Ruby that comes with `buster`:

```
# ruby -v
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux-gnu]
# cat /etc/issue
Debian GNU/Linux 10 \n \l
```

This fails with a cryptic error: 

```
ERROR:  While executing gem ... (Gem::RemoteFetcher::FetchError)
--
  | bad response Forbidden 403 (https://api.rubygems.org/quick/Marshal.4.8/nokogiri-1.13.1-x64-unknown.gemspec.rz)
```

This just bumps us to using `bullseye`, which installs a newer version of Ruby, which should work. 

ref https://github.com/sparklemotion/nokogiri/issues/2415