### PR TITLE
Add role parameter to Password Create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.51.0
+	github.com/planetscale/planetscale-go v0.53.0
 	github.com/planetscale/sql-proxy v0.12.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/planetscale/planetscale-go v0.51.0 h1:R7/7ngtpZxT9y+PBXobRycAmPppl5n15roXwD4vteJk=
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
+github.com/planetscale/planetscale-go v0.52.0 h1:64U6Cbd7RfJM6dPQinos3hYdTHoxyH+C/GHIAB/K7do=
+github.com/planetscale/planetscale-go v0.52.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
+github.com/planetscale/planetscale-go v0.53.0 h1:P9q4SgZPNaDvZQZVJ1sG2Pv65/XLqESnYZy6cZEwuTs=
+github.com/planetscale/planetscale-go v0.53.0/go.mod h1:eJW9fqnZxyZSOEwHDgKvAYQhpij+P46FfLWTc2NS2q0=
 github.com/planetscale/sql-proxy v0.12.0 h1:eFmpsI0xhhhMgSqxei1Z9BGoJ0iS4lcuFXpzz+JgmGk=
 github.com/planetscale/sql-proxy v0.12.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -22,7 +22,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			database := args[0]
 			branch := args[1]
 			name := args[2]
-			role := "reader"
+			role := ""
 			if len(args) > 3 {
 				role = args[3]
 			}

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -11,9 +11,13 @@ import (
 )
 
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		role string
+	}
+
 	createReq := &ps.DatabaseBranchPasswordRequest{}
 	cmd := &cobra.Command{
-		Use:     "create <database> <branch> <name> [<role>]",
+		Use:     "create <database> <branch> <name>",
 		Short:   "Create password to access a branch's data",
 		Args:    cmdutil.RequiredArgs("database", "branch", "name"),
 		Aliases: []string{"p"},
@@ -22,16 +26,12 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			database := args[0]
 			branch := args[1]
 			name := args[2]
-			role := ""
-			if len(args) > 3 {
-				role = args[3]
-			}
 
 			createReq.Database = database
 			createReq.Branch = branch
 			createReq.Organization = ch.Config.Organization
 			createReq.DisplayName = name
-			createReq.Role = role
+			createReq.Role = flags.role
 
 			client, err := ch.Client()
 			if err != nil {
@@ -62,6 +62,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return ch.Printer.PrintResource(toPasswordWithPlainText(pass))
 		},
 	}
+	cmd.PersistentFlags().StringVar(&flags.role, "role", "", "Role for the password, allowed values are : reader, writer, admin")
 
 	return cmd
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -63,6 +63,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role", "", "Role for the password, allowed values are : reader, writer, admin")
-
+	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -13,7 +13,7 @@ import (
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	createReq := &ps.DatabaseBranchPasswordRequest{}
 	cmd := &cobra.Command{
-		Use:     "create <database> <branch> <name>",
+		Use:     "create <database> <branch> <name> [<role>]",
 		Short:   "Create password to access a branch's data",
 		Args:    cmdutil.RequiredArgs("database", "branch", "name"),
 		Aliases: []string{"p"},
@@ -22,11 +22,16 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			database := args[0]
 			branch := args[1]
 			name := args[2]
+			role := "reader"
+			if len(args) > 3 {
+				role = args[3]
+			}
 
 			createReq.Database = database
 			createReq.Branch = branch
 			createReq.Organization = ch.Config.Organization
 			createReq.DisplayName = name
+			createReq.Role = role
 
 			client, err := ch.Client()
 			if err != nil {

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -25,6 +25,7 @@ func TestPassword_CreateCmd(t *testing.T) {
 	org := "planetscale"
 	db := "planetscale"
 	branch := "development"
+	role := "reader"
 	name := "production-password"
 	res := &ps.DatabaseBranchPassword{Name: "foo"}
 
@@ -34,6 +35,54 @@ func TestPassword_CreateCmd(t *testing.T) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.DisplayName, qt.Equals, name)
+			c.Assert(req.Role, qt.Equals, role)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Passwords: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, name, role})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+}
+
+func TestPassword_CreateCmd_DefaultRoleReader(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	name := "production-password"
+	res := &ps.DatabaseBranchPassword{Name: "foo"}
+
+	svc := &mock.PasswordsService{
+		CreateFn: func(ctx context.Context, req *ps.DatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.DisplayName, qt.Equals, name)
+			c.Assert(req.Role, qt.Equals, "reader")
 
 			return res, nil
 		},

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -62,7 +62,7 @@ func TestPassword_CreateCmd(t *testing.T) {
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 }
 
-func TestPassword_CreateCmd_DefaultRoleReader(t *testing.T) {
+func TestPassword_CreateCmd_DefaultRoleEmpty(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
@@ -82,7 +82,7 @@ func TestPassword_CreateCmd_DefaultRoleReader(t *testing.T) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.DisplayName, qt.Equals, name)
-			c.Assert(req.Role, qt.Equals, "reader")
+			c.Assert(req.Role, qt.Equals, "")
 
 			return res, nil
 		},

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -55,7 +55,8 @@ func TestPassword_CreateCmd(t *testing.T) {
 	}
 
 	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db, branch, name, role})
+	cmd.SetArgs([]string{db, branch, name})
+	cmd.Flag("role").Value.Set(role)
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -115,6 +115,8 @@ func toPasswordWithPlainText(password *ps.DatabaseBranchPassword) *PasswordWithP
 
 func toRoleDesc(role string) string {
 	switch role {
+	case "reader":
+		return "Can Read"
 	case "writer":
 		return "Can Read & Write"
 	case "admin":


### PR DESCRIPTION
This doesn't work for everyone yet, only for users who've been flagged in to the ACLs feature.

### Usage
``` bash
pscale password create aclstest main read-only-password --role reader

Password read-only-password was successfully created in aclstest/main.
Please save the values below as they will not be shown again

  NAME                 BRANCH   USERNAME       ACCESS HOST URL                     ROLE     ROLE DESCRIPTION   PASSWORD
 -------------------- -------- -------------- ----------------------------------- -------- ------------------ -------------------------------------------------------
  read-only-password   main     x3koc4nh3scq   66ve87c9rsvw.us-east-2.psdb.cloud   reader   Can Read            pscale_pw_no_idea
```