### PR TITLE
Add -c to mysql CLI args for shell;  allow SQL comments to pass thru

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -156,6 +156,7 @@ second argument:
 			mysqlArgs := []string{
 				"-u",
 				"root",
+				"-c", // allow comments to pass to the server
 				"-s",
 				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,


### PR DESCRIPTION
By default the MySQL CLI will strip comments.  Since MySQL (and Vitess) allows certain SQL comments to alter behavior, if you were using `pscale shell`, this might cause consternation. 