### PR TITLE
Add `role` parameter to shell & connect commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,5 +33,3 @@ require (
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
 	gopkg.in/yaml.v2 v2.4.0
 )
-
-replace github.com/planetscale/planetscale-go => /Users/phaniraj/ps/planetscale-go

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20201112035734-206646e67786
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.54.0
+	github.com/planetscale/planetscale-go v0.55.0
 	github.com/planetscale/sql-proxy v0.12.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,5 @@ require (
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+replace github.com/planetscale/planetscale-go => /Users/phaniraj/ps/planetscale-go

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,8 @@ github.com/planetscale/planetscale-go v0.53.0 h1:P9q4SgZPNaDvZQZVJ1sG2Pv65/XLqES
 github.com/planetscale/planetscale-go v0.53.0/go.mod h1:eJW9fqnZxyZSOEwHDgKvAYQhpij+P46FfLWTc2NS2q0=
 github.com/planetscale/planetscale-go v0.54.0 h1:k4IvdMv3GMFAgz671tf3ogus2oHJTjEgMCqdDyTFsPI=
 github.com/planetscale/planetscale-go v0.54.0/go.mod h1:eJW9fqnZxyZSOEwHDgKvAYQhpij+P46FfLWTc2NS2q0=
+github.com/planetscale/planetscale-go v0.55.0 h1:msx5t1uuRMevw5spvEHFwGyZ+D5Xk6Bjmr7J8aEcg7s=
+github.com/planetscale/planetscale-go v0.55.0/go.mod h1:eJW9fqnZxyZSOEwHDgKvAYQhpij+P46FfLWTc2NS2q0=
 github.com/planetscale/sql-proxy v0.12.0 h1:eFmpsI0xhhhMgSqxei1Z9BGoJ0iS4lcuFXpzz+JgmGk=
 github.com/planetscale/sql-proxy v0.12.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -74,7 +74,7 @@ argument:
 				}
 			}
 
-			role := cmdutil.Reader
+			role := cmdutil.ReaderRole
 			if flags.role != "" {
 				role, err = cmdutil.RoleFromString(flags.role)
 				if err != nil {

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -30,7 +30,7 @@ func ConnectCmd(ch *cmdutil.Helper) *cobra.Command {
 		execCommand         string
 		execCommandProtocol string
 		execCommandEnvURL   string
-		readOnly            bool
+		role                string
 	}
 
 	cmd := &cobra.Command{
@@ -97,7 +97,7 @@ argument:
 			localAddr := net.JoinHostPort(flags.host, flags.port)
 
 			proxyOpts := proxy.Options{
-				CertSource: proxyutil.NewRemoteCertSource(client, flags.readOnly),
+				CertSource: proxyutil.NewRemoteCertSource(client, flags.role),
 				LocalAddr:  localAddr,
 				RemoteAddr: flags.remoteAddr,
 				Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
@@ -159,10 +159,10 @@ argument:
 		"mysql2", "Protocol for the exposed URL (by default DATABASE_URL) value in execute")
 	cmd.PersistentFlags().StringVar(&flags.execCommandEnvURL, "execute-env-url", "DATABASE_URL",
 		"Environment variable name that contains the exposed Database URL.")
-	cmd.PersistentFlags().BoolVar(&flags.readOnly, "read-only",
-		false, "Connect to database in read only mode.")
+	cmd.PersistentFlags().StringVar(&flags.role, "role",
+		"reader", "allowed values are : reader, writer, readwriter, admin, default is reader")
 
-	cmd.PersistentFlags().MarkHidden("read-only")
+	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }
 

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -74,6 +74,14 @@ argument:
 				}
 			}
 
+			role := cmdutil.Reader
+			if flags.role != "" {
+				role, err = cmdutil.RoleFromString(flags.role)
+				if err != nil {
+					return err
+				}
+			}
+
 			// check whether database and branch exist
 			dbBranch, err := client.DatabaseBranches.Get(ctx, &planetscale.GetDatabaseBranchRequest{
 				Organization: ch.Config.Organization,
@@ -97,7 +105,7 @@ argument:
 			localAddr := net.JoinHostPort(flags.host, flags.port)
 
 			proxyOpts := proxy.Options{
-				CertSource: proxyutil.NewRemoteCertSource(client, flags.role),
+				CertSource: proxyutil.NewRemoteCertSource(client, role),
 				LocalAddr:  localAddr,
 				RemoteAddr: flags.remoteAddr,
 				Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),

--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -168,7 +168,7 @@ argument:
 	cmd.PersistentFlags().StringVar(&flags.execCommandEnvURL, "execute-env-url", "DATABASE_URL",
 		"Environment variable name that contains the exposed Database URL.")
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"reader", "allowed values are : reader, writer, readwriter, admin, default is reader")
+		"reader", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
 
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -66,7 +66,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.Reader),
+		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.ReaderRole),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -66,7 +66,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, "reader"),
+		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.Reader),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -66,7 +66,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, true),
+		CertSource: proxyutil.NewRemoteCertSource(client, "reader"),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -62,7 +62,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, "admin"),
+		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.Administrator),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -62,7 +62,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.Administrator),
+		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.AdministratorRole),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -62,7 +62,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, false),
+		CertSource: proxyutil.NewRemoteCertSource(client, "admin"),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -62,7 +62,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return ch.Printer.PrintResource(toPasswordWithPlainText(pass))
 		},
 	}
-	cmd.PersistentFlags().StringVar(&flags.role, "role", "", "Role for the password, allowed values are : reader, writer, readwriter, admin")
+	cmd.PersistentFlags().StringVar(&flags.role, "role",
+		"reader", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -62,7 +62,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return ch.Printer.PrintResource(toPasswordWithPlainText(pass))
 		},
 	}
-	cmd.PersistentFlags().StringVar(&flags.role, "role", "", "Role for the password, allowed values are : reader, writer, admin")
+	cmd.PersistentFlags().StringVar(&flags.role, "role", "", "Role for the password, allowed values are : reader, writer, readwriter, admin")
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -27,6 +27,13 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			branch := args[1]
 			name := args[2]
 
+			if flags.role != "" {
+				_, err := cmdutil.RoleFromString(flags.role)
+				if err != nil {
+					return err
+				}
+			}
+
 			createReq.Database = database
 			createReq.Branch = branch
 			createReq.Organization = ch.Config.Organization
@@ -63,7 +70,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"reader", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
+		"", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -63,6 +63,54 @@ func TestPassword_CreateCmd(t *testing.T) {
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 }
 
+func TestPassword_CreateCmd_InvalidRole(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	name := "production-password"
+	res := &ps.DatabaseBranchPassword{Name: "foo"}
+
+	svc := &mock.PasswordsService{
+		CreateFn: func(ctx context.Context, req *ps.DatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.DisplayName, qt.Equals, name)
+			c.Assert(req.Role, qt.Equals, "")
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Passwords: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, name})
+	cmd.Flag("role").Value.Set("random")
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsFalse)
+
+}
+
 func TestPassword_CreateCmd_DefaultRoleEmpty(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -118,9 +118,11 @@ func toRoleDesc(role string) string {
 	case "reader":
 		return "Can Read"
 	case "writer":
+		return "Can Write"
+	case "readwriter":
 		return "Can Read & Write"
 	case "admin":
 		return "Can Read, Write & Administer"
 	}
-	return "no idea"
+	return "Can Read"
 }

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -83,6 +83,14 @@ second argument:
 				}
 			}
 
+			role := cmdutil.Reader
+			if flags.role != "" {
+				role, err = cmdutil.RoleFromString(flags.role)
+				if err != nil {
+					return err
+				}
+			}
+
 			// check whether database and branch exist
 			_, err = client.DatabaseBranches.Get(ctx, &ps.GetDatabaseBranchRequest{
 				Organization: ch.Config.Organization,
@@ -106,7 +114,7 @@ second argument:
 			}
 
 			proxyOpts := proxy.Options{
-				CertSource: proxyutil.NewRemoteCertSource(client, flags.role),
+				CertSource: proxyutil.NewRemoteCertSource(client, role),
 				LocalAddr:  localAddr,
 				RemoteAddr: flags.remoteAddr,
 				Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -197,7 +197,7 @@ second argument:
 	cmd.PersistentFlags().StringVar(&flags.remoteAddr, "remote-addr", "",
 		"PlanetScale Database remote network address. By default the remote address is populated automatically from the PlanetScale API.")
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"reader", "allowed values are : reader, writer, readwriter, admin, default is reader")
+		"reader", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -27,7 +27,7 @@ func ShellCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		localAddr  string
 		remoteAddr string
-		readOnly   bool
+		role       string
 	}
 
 	cmd := &cobra.Command{
@@ -106,7 +106,7 @@ second argument:
 			}
 
 			proxyOpts := proxy.Options{
-				CertSource: proxyutil.NewRemoteCertSource(client, flags.readOnly),
+				CertSource: proxyutil.NewRemoteCertSource(client, flags.role),
 				LocalAddr:  localAddr,
 				RemoteAddr: flags.remoteAddr,
 				Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
@@ -188,10 +188,10 @@ second argument:
 		"", "Local address to bind and listen for connections. By default the proxy binds to 127.0.0.1 with a random port.")
 	cmd.PersistentFlags().StringVar(&flags.remoteAddr, "remote-addr", "",
 		"PlanetScale Database remote network address. By default the remote address is populated automatically from the PlanetScale API.")
-	cmd.PersistentFlags().BoolVar(&flags.readOnly, "read-only",
-		false, "Connect to database in read only mode.")
+	cmd.PersistentFlags().StringVar(&flags.role, "role",
+		"reader", "allowed values are : reader, writer, readwriter, admin, default is reader")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
-	cmd.PersistentFlags().MarkHidden("read-only")
+	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }
 

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -83,7 +83,7 @@ second argument:
 				}
 			}
 
-			role := cmdutil.Reader
+			role := cmdutil.ReaderRole
 			if flags.role != "" {
 				role, err = cmdutil.RoleFromString(flags.role)
 				if err != nil {

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -22,6 +22,45 @@ import (
 const WarnAuthMessage = "not authenticated yet. Please run 'pscale auth login' " +
 	"or create a service token with 'pscale service-token create'"
 
+type PasswordRole int
+
+const (
+	Reader PasswordRole = iota
+	Writer
+	ReadWriter
+	Administrator
+)
+
+func (r PasswordRole) ToString() string {
+	switch r {
+	case Reader:
+		return "reader"
+	case Writer:
+		return "writer"
+	case ReadWriter:
+		return "readwriter"
+	case Administrator:
+		return "admin"
+	}
+	return ""
+}
+
+func RoleFromString(r string) (PasswordRole, error) {
+	role := strings.ToLower(r)
+	switch role {
+	case "reader":
+		return Reader, nil
+	case "writer":
+		return Writer, nil
+	case "readwriter":
+		return ReadWriter, nil
+	case "admin":
+		return Administrator, nil
+	}
+
+	return 0, fmt.Errorf("Invalid role [%v] requested", r)
+}
+
 // Helper is passed to every single command and is used by individual
 // subcommands.
 type Helper struct {

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -25,10 +25,10 @@ const WarnAuthMessage = "not authenticated yet. Please run 'pscale auth login' "
 type PasswordRole int
 
 const (
-	Reader PasswordRole = iota
-	Writer
-	ReadWriter
-	Administrator
+	ReaderRole PasswordRole = iota
+	WriterRole
+	ReadWriterRole
+	AdministratorRole
 )
 
 func (r PasswordRole) ToString() string {

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -33,13 +33,13 @@ const (
 
 func (r PasswordRole) ToString() string {
 	switch r {
-	case Reader:
+	case ReaderRole:
 		return "reader"
-	case Writer:
+	case WriterRole:
 		return "writer"
-	case ReadWriter:
+	case ReadWriterRole:
 		return "readwriter"
-	case Administrator:
+	case AdministratorRole:
 		return "admin"
 	}
 	return ""
@@ -49,13 +49,13 @@ func RoleFromString(r string) (PasswordRole, error) {
 	role := strings.ToLower(r)
 	switch role {
 	case "reader":
-		return Reader, nil
+		return ReaderRole, nil
 	case "writer":
-		return Writer, nil
+		return WriterRole, nil
 	case "readwriter":
-		return ReadWriter, nil
+		return ReadWriterRole, nil
 	case "admin":
-		return Administrator, nil
+		return AdministratorRole, nil
 	}
 
 	return 0, fmt.Errorf("invalid role [%v] requested", r)

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -58,7 +58,7 @@ func RoleFromString(r string) (PasswordRole, error) {
 		return Administrator, nil
 	}
 
-	return 0, fmt.Errorf("Invalid role [%v] requested", r)
+	return 0, fmt.Errorf("invalid role [%v] requested", r)
 }
 
 // Helper is passed to every single command and is used by individual

--- a/internal/proxyutil/remotesource.go
+++ b/internal/proxyutil/remotesource.go
@@ -6,8 +6,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
-	"github.com/planetscale/cli/internal/cmdutil"
 	"time"
+
+	"github.com/planetscale/cli/internal/cmdutil"
 
 	nanoid "github.com/matoous/go-nanoid/v2"
 

--- a/internal/proxyutil/remotesource.go
+++ b/internal/proxyutil/remotesource.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
+	"github.com/planetscale/cli/internal/cmdutil"
 	"time"
 
 	nanoid "github.com/matoous/go-nanoid/v2"
@@ -19,10 +20,10 @@ type RemoteCertSource struct {
 	role   string
 }
 
-func NewRemoteCertSource(client *ps.Client, role string) *RemoteCertSource {
+func NewRemoteCertSource(client *ps.Client, role cmdutil.PasswordRole) *RemoteCertSource {
 	return &RemoteCertSource{
 		client: client,
-		role:   role,
+		role:   role.ToString(),
 	}
 }
 

--- a/internal/proxyutil/remotesource.go
+++ b/internal/proxyutil/remotesource.go
@@ -15,14 +15,14 @@ import (
 )
 
 type RemoteCertSource struct {
-	client   *ps.Client
-	readOnly bool
+	client *ps.Client
+	role   string
 }
 
-func NewRemoteCertSource(client *ps.Client, readOnly bool) *RemoteCertSource {
+func NewRemoteCertSource(client *ps.Client, role string) *RemoteCertSource {
 	return &RemoteCertSource{
-		client:   client,
-		readOnly: readOnly,
+		client: client,
+		role:   role,
 	}
 }
 
@@ -35,15 +35,10 @@ func (r *RemoteCertSource) Cert(ctx context.Context, org, db, branch string) (*p
 		return nil, fmt.Errorf("couldn't generate private key: %s", err)
 	}
 
-	role := "admin"
-	if r.readOnly {
-		role = "reader"
-	}
-
 	request := &ps.DatabaseBranchCertificateRequest{
 		Organization: org,
 		Database:     db,
-		Role:         role,
+		Role:         r.role,
 		Branch:       branch,
 		DisplayName:  fmt.Sprintf("pscale-cli-%s-%s", time.Now().Format("2006-01-02"), nanoid.MustGenerate(publicIdAlphabet, publicIdLength)),
 		PrivateKey:   pkey,


### PR DESCRIPTION
This PR adds a `--role` parameter as a hidden flag to the `pscale shell` and `pscale connect` commands. 

We can now prevent accidental inserts & deletes from a database when using shell for read only queries.

``` bash
 go run cmd/pscale/main.go shell  withacls main --org phani --role reader
withacls/main> show tables;
+--------------------+
| Tables_in_withacls |
+--------------------+
| Customers          |
+--------------------+
withacls/main> select count(*) from Customers;
+----------+
| count(*) |
+----------+
|        0 |
+----------+
withacls/main> Insert into Customers(ID) values (12);
ERROR 1045 (28000): target: withacls.-.primary: vttablet: rpc error: code = PermissionDenied desc = Insert command denied to user 'planetscale-reader' for table 'Customers' (ACL check error) (CallerID: planetscale-reader)

withacls/main> Delete from Customers;
ERROR 1045 (28000): target: withacls.-.primary: vttablet: rpc error: code = PermissionDenied desc = DeleteLimit command denied to user 'planetscale-reader' for table 'Customers' (ACL check error) (CallerID: planetscale-reader)
withacls/main>
```