### PR TITLE
Add bin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ scoop update pscale
 
 Download the pre-compiled binaries from the [releases](https://github.com/planetscale/cli/releases/latest) page and copy to the desired location.
 
+Alternatively, you can install [bin](https://github.com/marcosnils/bin) which works on all `macOS`, `Windows`, and `Linux` platforms:
+
+```
+bin install https://github.com/planetscale/cli
+```
+
+To upgrade to the latest version
+
+```
+bin upgrade pscale
+```
 
 #### Container images 
 


### PR DESCRIPTION
:wave: there! bin creator here and long time planetscale fan. 

Just adding another convenient way to manually keep your `pscale` CLI updated in all platforms. Been using this approach for quite some time and I find it extremely convenient. 

Hopefully you find this interesting enough to get it merged :crossed_fingers: 


