### PR TITLE
password/create: specify a default role

### DIFF
--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -70,7 +70,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"reader", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
+		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -70,7 +70,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
+		"reader", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is reader.")
 	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -111,7 +111,7 @@ func TestPassword_CreateCmd_InvalidRole(t *testing.T) {
 
 }
 
-func TestPassword_CreateCmd_DefaultRoleEmpty(t *testing.T) {
+func TestPassword_CreateCmd_DefaultRoleAdmin(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
@@ -131,7 +131,7 @@ func TestPassword_CreateCmd_DefaultRoleEmpty(t *testing.T) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.DisplayName, qt.Equals, name)
-			c.Assert(req.Role, qt.Equals, "")
+			c.Assert(req.Role, qt.Equals, "admin")
 
 			return res, nil
 		},


### PR DESCRIPTION
The docstring says we provide a default, but we don't actually provide a default. Let's do that. 