### PR TITLE
Error when half of a service token is passed

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,11 +78,11 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 	}
 
 	if c.ServiceToken == "" && c.ServiceTokenID != "" {
-		return nil, errors.New("service token ID was passed, but service token was not")
+		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
 	if c.ServiceToken != "" && c.ServiceTokenID == "" {
-		return nil, errors.New("service token was passed, but service token ID was not")
+		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
 	if c.ServiceToken != "" && c.ServiceTokenID != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,11 +77,7 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 		ps.WithBaseURL(c.BaseURL),
 	}
 
-	if c.ServiceToken == "" && c.ServiceTokenID != "" {
-		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
-	}
-
-	if c.ServiceToken != "" && c.ServiceTokenID == "" {
+	if (c.ServiceToken == "" && c.ServiceTokenID != "") || (c.ServiceToken != "" && c.ServiceTokenID == "") {
 		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,14 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 		ps.WithBaseURL(c.BaseURL),
 	}
 
+	if c.ServiceToken == "" && c.ServiceTokenID != "" {
+		return nil, errors.New("service token ID was passed, but service token was not")
+	}
+
+	if c.ServiceToken != "" && c.ServiceTokenID == "" {
+		return nil, errors.New("service token was passed, but service token ID was not")
+	}
+
 	if c.ServiceToken != "" && c.ServiceTokenID != "" {
 		opts = append(opts, ps.WithServiceToken(c.ServiceTokenID, c.ServiceToken))
 	} else {


### PR DESCRIPTION
In order to use authentication with a Service Token, you have to pass both the Token ID and the Token. If you also have a local session as a user, it will fall back to using that if you pass one of the two.

Instead, we should error if you've passed one or the other, which is significantly less confusing. 