### PR TITLE
Add ARMv7 Linux builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,17 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
+        goarm: 7
     main: ./cmd/pscale/main.go
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}


### PR DESCRIPTION
A user asked for ARMv7 Linux builds, this config adds only that build,

Not sure if there's a better way to check this but currently running `goreleaser build` on main locally builds these targets:

```sh
 • building binaries
      • building                  binary=dist/pscale_darwin_amd64/pscale
      • building                  binary=dist/pscale_darwin_arm64/pscale
      • building                  binary=dist/pscale_linux_386/pscale
      • building                  binary=dist/pscale_linux_amd64/pscale
      • building                  binary=dist/pscale_linux_arm64/pscale
      • building                  binary=dist/pscale_windows_386/pscale.exe
      • building                  binary=dist/pscale_windows_amd64/pscale.exe
      • building                  binary=dist/pscale_windows_arm64/pscale.exe
```

And for this branch, we add exactly one more:
```sh
      • building                  binary=dist/pscale_darwin_amd64/pscale
      • building                  binary=dist/pscale_darwin_arm64/pscale
      • building                  binary=dist/pscale_linux_386/pscale
      • building                  binary=dist/pscale_linux_amd64/pscale
      • building                  binary=dist/pscale_linux_arm64/pscale
+     • building                  binary=dist/pscale_linux_arm_7/pscale
      • building                  binary=dist/pscale_windows_386/pscale.exe
      • building                  binary=dist/pscale_windows_amd64/pscale.exe
      • building                  binary=dist/pscale_windows_arm64/pscale.exe
```

Followed https://goreleaser.com/customization/build/