### PR TITLE
cmd/pscale: os.Kill cannot be caught

### DIFF
--- a/cmd/pscale/main.go
+++ b/cmd/pscale/main.go
@@ -19,7 +19,7 @@ func main() {
 }
 
 func realMain() int {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
 	return cmd.Execute(ctx, version, commit, date)


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@planetscale.com>

According to https://pkg.go.dev/os/signal#hdr-Types_of_signals and https://staticcheck.io/docs/checks/#SA1016, os.Kill cannot be caught. staticcheck should catch this but I'm unsure why it is not at the moment. I'll follow up later on.

/cc @dominikh