### PR TITLE
internal/auth: simplify HTTP test construction, panic in handlers

### DIFF
--- a/internal/auth/authenticator.go
+++ b/internal/auth/authenticator.go
@@ -99,7 +99,7 @@ type DeviceAuthenticator struct {
 }
 
 // New returns an instance of the DeviceAuthenticator
-func New(client *http.Client, clientID string, clientSecret string, opts ...AuthenticatorOption) (*DeviceAuthenticator, error) {
+func New(client *http.Client, clientID, clientSecret string, opts ...AuthenticatorOption) (*DeviceAuthenticator, error) {
 	if client == nil {
 		client = cleanhttp.DefaultClient()
 	}


### PR DESCRIPTION
Signed-off-by: Matt Layher <mdlayher@planetscale.com>

The test setup function wasn't doing much and we can simplify things by putting the mux and server construction right in the test. Also remove the uses of t.Fatal in goroutines and replace with panics, which should ultimately result in HTTP 500s anyway.