### PR TITLE
cmd/branch: wait until new branch is ready

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -1,8 +1,11 @@
 package branch
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/pkg/browser"
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -13,6 +16,10 @@ import (
 
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	createReq := &ps.CreateDatabaseBranchRequest{}
+
+	var flags struct {
+		wait bool
+	}
 
 	cmd := &cobra.Command{
 		Use:     "create <source-database> <branch> [options]",
@@ -54,6 +61,9 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			return candidates, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
 			source := args[0]
 			branch := args[1]
 
@@ -98,6 +108,21 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			end()
 
+			// wait and check until the DB is ready
+			if flags.wait {
+				end := ch.Printer.PrintProgress(fmt.Sprintf("Waiting until branch %s is ready...", printer.BoldBlue(branch)))
+				defer end()
+				getReq := &ps.GetDatabaseBranchRequest{
+					Organization: ch.Config.Organization,
+					Database:     source,
+					Branch:       branch,
+				}
+				if err := waitUntilReady(ctx, client, getReq); err != nil {
+					return err
+				}
+				end()
+			}
+
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Branch %s was successfully created.\n\nView this branch in the browser: %s\n", printer.BoldBlue(dbBranch.Name), printer.BoldBlue(dbBranch.HtmlURL))
 				return nil
@@ -110,6 +135,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
 	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "backup to restore into the branch")
+	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is ready")
+
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := cmd.Context()
 		client, err := ch.Client()
@@ -135,4 +162,28 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().BoolP("web", "w", false, "Create a branch in your web browser")
 
 	return cmd
+}
+
+// waitUntilReady waits until the given database branch is ready. It times out after 3 minutes.
+func waitUntilReady(ctx context.Context, client *ps.Client, getReq *ps.GetDatabaseBranchRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("branch creation timed out")
+		case <-ticker.C:
+			resp, err := client.DatabaseBranches.Get(ctx, getReq)
+			if err != nil {
+				return err
+			}
+
+			if resp.Ready {
+				return nil
+			}
+		}
+	}
 }


### PR DESCRIPTION
A common frustration with new branches is that it's not ready yet. The `pscale branch create` command creates a new branch immediately however it takes time until the branch is `ready`. This confusion leads to various issues, where the users think they can connect to the DB, but it's not possible yet.

We add a new `--wait` flag that blocks on a `pscale branch create` command. It's backwards compatible and people can decide whether they want to wait until the Branch is ready, or they want to create branches without a wait (and do other things meanwhile with the CLI) 

```
$ pscale branch create testdb test-branch --wait

⠧ Waiting until branch test-branch is ready...
```
```
$ pscale branch create testdb test-branch --wait
Branch test-branch was successfully created.

View this branch in the browser: https://app.planetscale.com/damp-dew-9934/testdb/test-branch
```

Fixes:

https://github.com/planetscale/cli/issues/477
https://github.com/planetscale/cli/issues/439
