### PR TITLE
Add ssl-mode to imports support

### DIFF
--- a/internal/cmd/dataimports/lint.go
+++ b/internal/cmd/dataimports/lint.go
@@ -17,6 +17,7 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 		password string
 		database string
 		port     int
+		sslMode  string
 	}
 
 	testRequest := &ps.TestDataImportSourceRequest{}
@@ -27,7 +28,7 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 		Aliases: []string{"l"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-
+			sslMode := cmdutil.ParseSSLMode(flags.sslMode)
 			testRequest.Organization = ch.Config.Organization
 			testRequest.Database = flags.database
 			testRequest.Connection = ps.DataImportSource{
@@ -36,7 +37,7 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 				Password:            flags.password,
 				HostName:            flags.host,
 				Port:                flags.port,
-				SSLVerificationMode: ps.SSLModeDisabled,
+				SSLVerificationMode: sslMode,
 			}
 
 			client, err := ch.Client()
@@ -44,6 +45,9 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
+			switch flags.sslMode {
+
+			}
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Testing Compatibility of database %s with user %s...", printer.BoldBlue(flags.database), printer.BoldBlue(flags.username)))
 			defer end()
 
@@ -86,12 +90,14 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.database, "database", "", "Name of the external database")
 	cmd.PersistentFlags().StringVar(&flags.username, "username", "", "Username to connect to external database.")
 	cmd.PersistentFlags().StringVar(&flags.password, "password", "", "Password to connect to external database.")
+	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values : disabled, preferred, required, verify_ca, verify_identity")
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 
 	cmd.MarkPersistentFlagRequired("host")
 	cmd.MarkPersistentFlagRequired("database")
 	cmd.MarkPersistentFlagRequired("username")
 	cmd.MarkPersistentFlagRequired("password")
+	cmd.MarkPersistentFlagRequired("ssl-mode")
 
 	return cmd
 }

--- a/internal/cmd/dataimports/lint.go
+++ b/internal/cmd/dataimports/lint.go
@@ -87,7 +87,7 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.database, "database", "", "Name of the external database")
 	cmd.PersistentFlags().StringVar(&flags.username, "username", "", "Username to connect to external database.")
 	cmd.PersistentFlags().StringVar(&flags.password, "password", "", "Password to connect to external database.")
-	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values : disabled, preferred, required, verify_ca, verify_identity")
+	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values: disabled, preferred, required, verify_ca, verify_identity")
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 
 	cmd.MarkPersistentFlagRequired("host")

--- a/internal/cmd/dataimports/lint.go
+++ b/internal/cmd/dataimports/lint.go
@@ -45,9 +45,6 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			switch flags.sslMode {
-
-			}
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Testing Compatibility of database %s with user %s...", printer.BoldBlue(flags.database), printer.BoldBlue(flags.username)))
 			defer end()
 

--- a/internal/cmd/dataimports/lint_test.go
+++ b/internal/cmd/dataimports/lint_test.go
@@ -19,11 +19,13 @@ func TestImports_LintDatabase_Success(t *testing.T) {
 
 	org := "planetscale"
 	externalDataSource := ps.DataImportSource{
-		Database: "aws-upstream-database",
-		Port:     3306,
-		HostName: "rds.amazonaws.com",
-		UserName: "aws-user",
-		Password: "aws-password",
+		Database:            "aws-upstream-database",
+		Port:                3306,
+		HostName:            "rds.amazonaws.com",
+		UserName:            "aws-user",
+		Password:            "aws-password",
+		SSLVerificationMode: ps.SSLModePreferred,
+		SSLMode:             ps.SSLModePreferred.String(),
 	}
 	res := &ps.TestDataImportSourceResponse{
 		CanConnect: true,
@@ -44,11 +46,13 @@ func TestImports_LintDatabase_CannotConnect(t *testing.T) {
 
 	org := "planetscale"
 	externalDataSource := ps.DataImportSource{
-		Database: "aws-upstream-database",
-		Port:     3306,
-		HostName: "rds.amazonaws.com",
-		UserName: "aws-user",
-		Password: "aws-password",
+		Database:            "aws-upstream-database",
+		Port:                3306,
+		HostName:            "rds.amazonaws.com",
+		UserName:            "aws-user",
+		Password:            "aws-password",
+		SSLVerificationMode: ps.SSLModePreferred,
+		SSLMode:             ps.SSLModePreferred.String(),
 	}
 
 	res := &ps.TestDataImportSourceResponse{
@@ -71,11 +75,13 @@ func TestImports_LintDatabase_SchemaIncompatible(t *testing.T) {
 
 	org := "planetscale"
 	externalDataSource := ps.DataImportSource{
-		Database: "aws-upstream-database",
-		Port:     3306,
-		HostName: "rds.amazonaws.com",
-		UserName: "aws-user",
-		Password: "aws-password",
+		Database:            "aws-upstream-database",
+		Port:                3306,
+		HostName:            "rds.amazonaws.com",
+		UserName:            "aws-user",
+		Password:            "aws-password",
+		SSLVerificationMode: ps.SSLModePreferred,
+		SSLMode:             ps.SSLModePreferred.String(),
 	}
 
 	res := &ps.TestDataImportSourceResponse{
@@ -110,6 +116,7 @@ Please fix the following errors and then try again:
 func invokeLintDatabase(externalDataSource *ps.DataImportSource, org string, c *qt.C, response *ps.TestDataImportSourceResponse) (string, error) {
 	svc := &mock.DataImportsService{
 		TestDataImportSourceFn: func(ctx context.Context, req *ps.TestDataImportSourceRequest) (*ps.TestDataImportSourceResponse, error) {
+			req.Connection.SSLMode = req.Connection.SSLVerificationMode.String()
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Connection, qt.Equals, *externalDataSource)
 			return response, nil
@@ -142,6 +149,7 @@ func invokeLintDatabase(externalDataSource *ps.DataImportSource, org string, c *
 		"--host", externalDataSource.HostName,
 		"--username", externalDataSource.UserName,
 		"--password", externalDataSource.Password,
+		"--ssl-mode", "preferred",
 	})
 	cmd.SilenceUsage = true
 	err := cmd.Execute()

--- a/internal/cmd/dataimports/start.go
+++ b/internal/cmd/dataimports/start.go
@@ -122,7 +122,7 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.password, "password", "", "Password to connect to external database.")
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 	cmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", true, "Only run compatibility check, do not start import")
-	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values : disabled, preferred, required, verify_ca, verify_identity")
+	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values: disabled, preferred, required, verify_ca, verify_identity")
 
 	cmd.MarkPersistentFlagRequired("name")
 	cmd.MarkPersistentFlagRequired("host")

--- a/internal/cmd/dataimports/start.go
+++ b/internal/cmd/dataimports/start.go
@@ -19,6 +19,7 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 		database string
 		port     int
 		dryRun   bool
+		sslMode  string
 	}
 
 	startImportRequest := &ps.StartDataImportRequest{}
@@ -30,13 +31,15 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			ctx := cmd.Context()
+			sslMode := cmdutil.ParseSSLMode(flags.sslMode)
+
 			dataSource := ps.DataImportSource{
 				Database:            flags.database,
 				UserName:            flags.username,
 				Password:            flags.password,
 				HostName:            flags.host,
 				Port:                flags.port,
-				SSLVerificationMode: ps.SSLModeDisabled,
+				SSLVerificationMode: sslMode,
 			}
 			startImportRequest.Organization = ch.Config.Organization
 			startImportRequest.Database = flags.name
@@ -119,12 +122,14 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.password, "password", "", "Password to connect to external database.")
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 	cmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", true, "Only run compatibility check, do not start import")
+	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values : disabled, preferred, required, verify_ca, verify_identity")
 
 	cmd.MarkPersistentFlagRequired("name")
 	cmd.MarkPersistentFlagRequired("host")
 	cmd.MarkPersistentFlagRequired("database")
 	cmd.MarkPersistentFlagRequired("username")
 	cmd.MarkPersistentFlagRequired("password")
+	cmd.MarkPersistentFlagRequired("ssl-mode")
 
 	return cmd
 }

--- a/internal/cmd/dataimports/start_test.go
+++ b/internal/cmd/dataimports/start_test.go
@@ -19,11 +19,13 @@ func TestStart_LintDatabase_Success(t *testing.T) {
 
 	org := "planetscale"
 	externalDataSource := ps.DataImportSource{
-		Database: "aws-upstream-database",
-		Port:     3306,
-		HostName: "rds.amazonaws.com",
-		UserName: "aws-user",
-		Password: "aws-password",
+		Database:            "aws-upstream-database",
+		Port:                3306,
+		HostName:            "rds.amazonaws.com",
+		UserName:            "aws-user",
+		Password:            "aws-password",
+		SSLVerificationMode: ps.SSLModePreferred,
+		SSLMode:             ps.SSLModePreferred.String(),
 	}
 	res := &ps.TestDataImportSourceResponse{
 		CanConnect: true,
@@ -45,11 +47,13 @@ func TestStart_LintDatabase_CannotConnect(t *testing.T) {
 
 	org := "planetscale"
 	externalDataSource := ps.DataImportSource{
-		Database: "aws-upstream-database",
-		Port:     3306,
-		HostName: "rds.amazonaws.com",
-		UserName: "aws-user",
-		Password: "aws-password",
+		Database:            "aws-upstream-database",
+		Port:                3306,
+		HostName:            "rds.amazonaws.com",
+		UserName:            "aws-user",
+		Password:            "aws-password",
+		SSLVerificationMode: ps.SSLModePreferred,
+		SSLMode:             ps.SSLModePreferred.String(),
 	}
 
 	res := &ps.TestDataImportSourceResponse{
@@ -72,11 +76,13 @@ func TestStart_LintDatabase_SchemaIncompatible(t *testing.T) {
 
 	org := "planetscale"
 	externalDataSource := ps.DataImportSource{
-		Database: "aws-upstream-database",
-		Port:     3306,
-		HostName: "rds.amazonaws.com",
-		UserName: "aws-user",
-		Password: "aws-password",
+		Database:            "aws-upstream-database",
+		Port:                3306,
+		HostName:            "rds.amazonaws.com",
+		UserName:            "aws-user",
+		Password:            "aws-password",
+		SSLVerificationMode: ps.SSLModePreferred,
+		SSLMode:             ps.SSLModePreferred.String(),
 	}
 
 	res := &ps.TestDataImportSourceResponse{
@@ -111,6 +117,7 @@ func TestStart_LintDatabase_SchemaIncompatible(t *testing.T) {
 func invokeStartDatabase(externalDataSource *ps.DataImportSource, psdbName, org string, c *qt.C, response *ps.TestDataImportSourceResponse) (string, error) {
 	svc := &mock.DataImportsService{
 		TestDataImportSourceFn: func(ctx context.Context, req *ps.TestDataImportSourceRequest) (*ps.TestDataImportSourceResponse, error) {
+			req.Connection.SSLMode = req.Connection.SSLVerificationMode.String()
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Connection, qt.Equals, *externalDataSource)
 			return response, nil
@@ -142,6 +149,7 @@ func invokeStartDatabase(externalDataSource *ps.DataImportSource, psdbName, org 
 		"--host", externalDataSource.HostName,
 		"--username", externalDataSource.UserName,
 		"--password", externalDataSource.Password,
+		"--ssl-mode", "preferred",
 	})
 	cmd.SilenceUsage = true
 	err := cmd.Execute()

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -217,3 +217,18 @@ func MySQLClientPath() (string, error) {
 
 	return "", fmt.Errorf("%s\nTo install, follow the instructions: %s", msg, installURL)
 }
+
+func ParseSSLMode(sslMode string) ps.ExternalDataSourceSSLVerificationMode {
+	switch sslMode {
+	case "disabled":
+		return ps.SSLModeDisabled
+	case "preferred":
+		return ps.SSLModePreferred
+	case "required":
+		return ps.SSLModeRequired
+	case "verify_ca":
+		return ps.SSLModeVerifyCA
+	default:
+		return ps.SSLModeVerifyIdentity
+	}
+}


### PR DESCRIPTION
Adds `ssl-mode` to `Lint` and `Start` command in the Imports sub-command.

``` bash
go run cmd/pscale/main.go data-imports lint --help | grep ssl
      --ssl-mode string   SSL verification mode, allowed values : disabled, preferred, required, verify_ca, verify_identity

 go run cmd/pscale/main.go data-imports start --help | grep ssl
      --ssl-mode string   SSL verification mode, allowed values : disabled, preferred, required, verify_ca, verify_identity
```