### PR TITLE
Add revert deploy requests command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.63.0
+	github.com/planetscale/planetscale-go v0.64.0
 	github.com/planetscale/sql-proxy v0.12.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.62.0
+	github.com/planetscale/planetscale-go v0.63.0
 	github.com/planetscale/sql-proxy v0.12.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/planetscale/planetscale-go v0.61.0 h1:5ifxFnKJhomE1IXfunZDZeSX7g0O7uN
 github.com/planetscale/planetscale-go v0.61.0/go.mod h1:T9yNcF+t12+GCxgH7ehIi9Qx36zRSrE5i3PP98etWTA=
 github.com/planetscale/planetscale-go v0.62.0 h1:7s1S4MupNk7t5pZ4FI9TdyCTj36w1KBO2J+tJcg0iQ0=
 github.com/planetscale/planetscale-go v0.62.0/go.mod h1:T9yNcF+t12+GCxgH7ehIi9Qx36zRSrE5i3PP98etWTA=
+github.com/planetscale/planetscale-go v0.63.0 h1:e8mizQIkGIlOGXoUynz4I7ZALENmbd73gG5pGZx7Y90=
+github.com/planetscale/planetscale-go v0.63.0/go.mod h1:T9yNcF+t12+GCxgH7ehIi9Qx36zRSrE5i3PP98etWTA=
 github.com/planetscale/sql-proxy v0.12.0 h1:eFmpsI0xhhhMgSqxei1Z9BGoJ0iS4lcuFXpzz+JgmGk=
 github.com/planetscale/sql-proxy v0.12.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/planetscale/planetscale-go v0.62.0 h1:7s1S4MupNk7t5pZ4FI9TdyCTj36w1KB
 github.com/planetscale/planetscale-go v0.62.0/go.mod h1:T9yNcF+t12+GCxgH7ehIi9Qx36zRSrE5i3PP98etWTA=
 github.com/planetscale/planetscale-go v0.63.0 h1:e8mizQIkGIlOGXoUynz4I7ZALENmbd73gG5pGZx7Y90=
 github.com/planetscale/planetscale-go v0.63.0/go.mod h1:T9yNcF+t12+GCxgH7ehIi9Qx36zRSrE5i3PP98etWTA=
+github.com/planetscale/planetscale-go v0.64.0 h1:+9gmZXlMHDda9tgw2OyeOEhdZlrxqgAzU2QdgRpWbhM=
+github.com/planetscale/planetscale-go v0.64.0/go.mod h1:T9yNcF+t12+GCxgH7ehIi9Qx36zRSrE5i3PP98etWTA=
 github.com/planetscale/sql-proxy v0.12.0 h1:eFmpsI0xhhhMgSqxei1Z9BGoJ0iS4lcuFXpzz+JgmGk=
 github.com/planetscale/sql-proxy v0.12.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/deployrequest/dr.go
+++ b/internal/cmd/deployrequest/dr.go
@@ -12,7 +12,7 @@ import (
 func DeployRequestCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "deploy-request <command>",
-		Short:             "Create, review, diff, and manage deploy requests",
+		Short:             "Create, review, diff, revert, and manage deploy requests",
 		Aliases:           []string{"dr"},
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
@@ -27,6 +27,7 @@ func DeployRequestCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ListCmd(ch))
 	cmd.AddCommand(ReviewCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
+	cmd.AddCommand(RevertCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/deployrequest/dr.go
+++ b/internal/cmd/deployrequest/dr.go
@@ -28,6 +28,7 @@ func DeployRequestCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ReviewCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(RevertCmd(ch))
+	cmd.AddCommand(SkipRevertCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/deployrequest/revert.go
+++ b/internal/cmd/deployrequest/revert.go
@@ -29,7 +29,7 @@ func RevertCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("the argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> %q is invalid: %s", number, err)
 			}
 
 			dr, err := client.DeployRequests.RevertDeploy(ctx, &planetscale.RevertDeployRequestRequest{

--- a/internal/cmd/deployrequest/revert.go
+++ b/internal/cmd/deployrequest/revert.go
@@ -1,0 +1,62 @@
+package deployrequest
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/planetscale-go/planetscale"
+
+	"github.com/spf13/cobra"
+)
+
+// RevertCmd is the command for reverting a successfully deployed deploy request.
+func RevertCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "revert <database> <number>",
+		Short: "Revert a deployed deploy request",
+		Args:  cmdutil.RequiredArgs("database", "number"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			number := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			n, err := strconv.ParseUint(number, 10, 64)
+			if err != nil {
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
+			}
+
+			dr, err := client.DeployRequests.RevertDeploy(ctx, &planetscale.RevertDeployRequestRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Number:       n,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Successfully started deploy request revert for '%s/%s'.\n",
+					printer.BoldBlue(database),
+					printer.BoldBlue(dr.Number))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toDeployRequest(dr))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/deployrequest/revert_test.go
+++ b/internal/cmd/deployrequest/revert_test.go
@@ -1,0 +1,62 @@
+package deployrequest
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestDeployRequest_RevertCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	var number uint64 = 10
+
+	svc := &mock.DeployRequestsService{
+		RevertDeployFn: func(ctx context.Context, req *ps.RevertDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Number, qt.Equals, number)
+
+			return &ps.DeployRequest{Number: number}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DeployRequests: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := RevertCmd(ch)
+	cmd.SetArgs([]string{db, strconv.FormatUint(number, 10)})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.RevertDeployFnInvoked, qt.IsTrue)
+
+	res := &DeployRequest{Number: number}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/cmd/deployrequest/skiprevert.go
+++ b/internal/cmd/deployrequest/skiprevert.go
@@ -29,7 +29,7 @@ func SkipRevertCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			n, err := strconv.ParseUint(number, 10, 64)
 			if err != nil {
-				return fmt.Errorf("the argument <number> is invalid: %s", err)
+				return fmt.Errorf("the argument <number> %q is invalid: %s", number, err)
 			}
 
 			dr, err := client.DeployRequests.SkipRevertDeploy(ctx, &planetscale.SkipRevertDeployRequestRequest{

--- a/internal/cmd/deployrequest/skiprevert.go
+++ b/internal/cmd/deployrequest/skiprevert.go
@@ -1,0 +1,62 @@
+package deployrequest
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/planetscale-go/planetscale"
+
+	"github.com/spf13/cobra"
+)
+
+// SkipRevertCmd is the command for skipping a pending deploy request revert
+func SkipRevertCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skip-revert <database> <number>",
+		Short: "Skip and close a pending deploy request revert",
+		Args:  cmdutil.RequiredArgs("database", "number"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			number := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			n, err := strconv.ParseUint(number, 10, 64)
+			if err != nil {
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
+			}
+
+			dr, err := client.DeployRequests.SkipRevertDeploy(ctx, &planetscale.SkipRevertDeployRequestRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Number:       n,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Successfully skipped the deploy request started deploy request revert for '%s/%s'.\n",
+					printer.BoldBlue(database),
+					printer.BoldBlue(dr.Number))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toDeployRequest(dr))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/deployrequest/skiprevert.go
+++ b/internal/cmd/deployrequest/skiprevert.go
@@ -48,7 +48,7 @@ func SkipRevertCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Successfully skipped the deploy request started deploy request revert for '%s/%s'.\n",
+				ch.Printer.Printf("Successfully skipped the pending revert for deploy request '%s/%s'.\n",
 					printer.BoldBlue(database),
 					printer.BoldBlue(dr.Number))
 				return nil

--- a/internal/cmd/deployrequest/skiprevert_test.go
+++ b/internal/cmd/deployrequest/skiprevert_test.go
@@ -1,0 +1,62 @@
+package deployrequest
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestDeployRequest_SkipRevertCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	var number uint64 = 10
+
+	svc := &mock.DeployRequestsService{
+		SkipRevertDeployFn: func(ctx context.Context, req *ps.SkipRevertDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Number, qt.Equals, number)
+
+			return &ps.DeployRequest{Number: number}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DeployRequests: svc,
+			}, nil
+
+		},
+	}
+
+	cmd := SkipRevertCmd(ch)
+	cmd.SetArgs([]string{db, strconv.FormatUint(number, 10)})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.SkipRevertDeployFnInvoked, qt.IsTrue)
+
+	res := &DeployRequest{Number: number}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/mock/dr.go
+++ b/internal/mock/dr.go
@@ -30,6 +30,12 @@ type DeployRequestsService struct {
 
 	ListFn        func(context.Context, *ps.ListDeployRequestsRequest) ([]*ps.DeployRequest, error)
 	ListFnInvoked bool
+
+	RevertDeployFn        func(context.Context, *ps.RevertDeployRequestRequest) (*ps.DeployRequest, error)
+	RevertDeployFnInvoked bool
+
+	SkipRevertDeployFn        func(context.Context, *ps.SkipRevertDeployRequestRequest) (*ps.DeployRequest, error)
+	SkipRevertDeployFnInvoked bool
 }
 
 func (d *DeployRequestsService) CancelDeploy(ctx context.Context, req *ps.CancelDeployRequestRequest) (*ps.DeployRequest, error) {
@@ -70,4 +76,14 @@ func (d *DeployRequestsService) Get(ctx context.Context, req *ps.GetDeployReques
 func (d *DeployRequestsService) List(ctx context.Context, req *ps.ListDeployRequestsRequest) ([]*ps.DeployRequest, error) {
 	d.ListFnInvoked = true
 	return d.ListFn(ctx, req)
+}
+
+func (d *DeployRequestsService) RevertDeploy(ctx context.Context, req *ps.RevertDeployRequestRequest) (*ps.DeployRequest, error) {
+	d.RevertDeployFnInvoked = true
+	return d.RevertDeployFn(ctx, req)
+}
+
+func (d *DeployRequestsService) SkipRevertDeploy(ctx context.Context, req *ps.SkipRevertDeployRequestRequest) (*ps.DeployRequest, error) {
+	d.SkipRevertDeployFnInvoked = true
+	return d.SkipRevertDeployFn(ctx, req)
 }


### PR DESCRIPTION
Closes: https://github.com/planetscale/cli/issues/480

This PR adds the following commands to help with reverting a completed deploy request and skipping a pending deploy request revert.
#### Revert deploy request
```shell
pscale deploy-request revert <database> <number> [flags]
```

#### Skip revert deploy request
```shell
pscale deploy-request skip-revert <database> <number> [flags]
```