### PR TITLE
Enable -trimpath for all builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,8 @@ builds:
     main: ./cmd/pscale/main.go
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    flags:
+      - -trimpath
     binary: "pscale"
   - id: darwin-arm64
     goos:
@@ -31,6 +33,8 @@ builds:
     main: ./cmd/pscale/main.go
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    flags:
+      - -trimpath
     binary: "pscale"
   - env:
       - CGO_ENABLED=0
@@ -45,6 +49,8 @@ builds:
     main: ./cmd/pscale/main.go
     ldflags:
      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+    flags:
+      - -trimpath
     binary: "pscale"   
 dockers:
   - image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ builds:
       - CGO_ENABLED=1
     main: ./cmd/pscale/main.go
     ldflags:
-     - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     flags:
       - -trimpath
     binary: "pscale"
@@ -32,7 +32,7 @@ builds:
       - CGO_ENABLED=1
     main: ./cmd/pscale/main.go
     ldflags:
-     - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     flags:
       - -trimpath
     binary: "pscale"
@@ -48,7 +48,7 @@ builds:
       - arm64
     main: ./cmd/pscale/main.go
     ldflags:
-     - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     flags:
       - -trimpath
     binary: "pscale"   

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION
 ARG COMMIT
 ARG DATE
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates mysql-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION
 ARG COMMIT
 ARG DATE
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates mysql-client

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 
 .PHONY: build
 build:
-	@go build ./... 
+	@go build -trimpath ./...
 
 .PHONY: lint
 lint: 


### PR DESCRIPTION
Generates paths independent from the build location. 