### PR TITLE
Database dump uses admin role

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -70,7 +70,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	}
 
 	proxyOpts := proxy.Options{
-		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.ReaderRole),
+		CertSource: proxyutil.NewRemoteCertSource(client, cmdutil.AdministratorRole),
 		LocalAddr:  localAddr,
 		Instance:   fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch),
 		Logger:     cmdutil.NewZapLogger(ch.Debug()),


### PR DESCRIPTION
Running `database dump` causes us to try and use the `reader` role which is not available to all of our customers.