### PR TITLE
Show `--role` flag on password create, connect & shell commands

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -170,7 +170,6 @@ argument:
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
 
-	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }
 

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -71,6 +71,5 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
-	cmd.PersistentFlags().MarkHidden("role")
 	return cmd
 }

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -200,7 +200,7 @@ second argument:
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
-	cmd.PersistentFlags().MarkHidden("role")
+
 	return cmd
 }
 


### PR DESCRIPTION
Now that we've shipped ACLs, we can show this flag in help documents.