### PR TITLE
auth: report better error messages

### DIFF
--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -1,7 +1,6 @@
 package cmdutil
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -107,11 +106,11 @@ func RequiredArgs(reqArgs ...string) cobra.PositionalArgs {
 // actionable error message.
 func CheckAuthentication(cfg *config.Config) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		if cfg.IsAuthenticated() {
-			return nil
+		if err := cfg.IsAuthenticated(); err != nil {
+			return fmt.Errorf("%s\nError: %s", WarnAuthMessage, err.Error())
 		}
 
-		return errors.New(WarnAuthMessage)
+		return nil
 	}
 }
 


### PR DESCRIPTION
We don't tell the user what's wrong if their service tokens are missing or if the service tokens are not set, but they forgot to authenticate via access tokens.

With service tokens misconfigured:

```
$ PLANETSCALE_SERVICE_TOKEN_ID="" PLANETSCALE_SERVICE_TOKEN="bar" go run cmd/pscale/main.go connect planetscale main

Error: not authenticated yet. Please run 'pscale auth login'
Error: both --service-token and --service-token-id are required for service token authentication
exit status 2
```

No service tokens are configured, access token is also missing :

```
$ go run cmd/pscale/main.go connect planetscale main

Error: not authenticated yet. Please run 'pscale auth login'
Error: --access-token is required for access token authentication
```
