### PR TITLE
dr: add `--wait` flag to `deploy-request deploy` subcommand

### DIFF
--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -84,7 +84,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is ready")
+	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is deployed")
 
 	return cmd
 }
@@ -109,7 +109,7 @@ func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *pr
 				continue
 			}
 
-			if resp.State == "complete" {
+			if resp.State == "complete_pending_revert" {
 				return nil
 			}
 		}

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -119,7 +119,7 @@ func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *pr
 				continue
 			}
 
-			if resp.Deployment.State == "complete_pending_revert" || resp.Deployment.State == "pending_cutover" {
+			if resp.Deployment.State == "complete" || resp.Deployment.State == "complete_pending_revert" || resp.Deployment.State == "pending_cutover" {
 				return resp.Deployment.State, nil
 			}
 		}

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -1,8 +1,11 @@
 package deployrequest
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
@@ -13,6 +16,10 @@ import (
 
 // DeployCmd is the command for deploying deploy requests.
 func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		wait bool
+	}
+
 	cmd := &cobra.Command{
 		Use:   "deploy <database> <number>",
 		Short: "Deploy a specific deploy request",
@@ -47,15 +54,64 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
-			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Successfully queued %s from %s for deployment to %s.\n",
-					dr.ID, dr.Branch, dr.IntoBranch)
-				return nil
+			// wait and check until the deploy request is deployed
+			if flags.wait {
+				end := ch.Printer.PrintProgress(fmt.Sprintf("Waiting until deploy request %s/%s is deployed...",
+					printer.BoldBlue(database), printer.BoldBlue(number)))
+				defer end()
+				getReq := &planetscale.GetDeployRequestRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+					Number:       n,
+				}
+				if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+					return err
+				}
+				end()
+
+				ch.Printer.Printf("Deploy request %s/%s is successfully deployed.",
+					printer.BoldBlue(database), printer.BoldBlue(number))
+
+			} else {
+				if ch.Printer.Format() == printer.Human {
+					ch.Printer.Printf("Successfully queued %s from %s for deployment to %s.\n",
+						dr.ID, dr.Branch, dr.IntoBranch)
+					return nil
+				}
 			}
 
 			return ch.Printer.PrintResource(toDeployRequest(dr))
 		},
 	}
 
+	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is ready")
+
 	return cmd
+}
+
+// waitUntilReady waits until the given deploy request has been deployed. It times out after 3 minutes.
+func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *printer.Printer, debug bool, getReq *planetscale.GetDeployRequestRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("deploy request queueing timed out")
+		case <-ticker.C:
+			resp, err := client.DeployRequests.Get(ctx, getReq)
+			if err != nil {
+				if debug {
+					printer.Printf("fetching deploy request %s/%d failed: %s", getReq.Database, getReq.Number, err)
+				}
+				continue
+			}
+
+			if resp.State == "complete" {
+				return nil
+			}
+		}
+	}
 }


### PR DESCRIPTION
Similar to https://github.com/planetscale/cli/pull/510, this PR adds a
new `--wait` flag that blocks the `dr deploy` subcommand. This allows
the user to wait on this command and makes scripting easier as they can
chain commands without polling the deployment action's status.

- [ ] needs testing

fixes: https://github.com/planetscale/cli/issues/518
