### PR TITLE
fix(ci): update docker creds for latest goreleaser-cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build:
 	@go build -trimpath ./...
 
 .PHONY: lint
-lint: 
+lint:
 	@go install honnef.co/go/tools/cmd/staticcheck@HEAD
 	@staticcheck ./...
 
@@ -35,7 +35,7 @@ licensed:
 	licensed status
 
 .PHONY: build-image
-build-image: 
+build-image:
 	@echo "==> Building docker image ${REPO}/${NAME}:$(VERSION)"
 	@# Permit building only if the Git tree is clean
 	@echo "${GIT_TREE_STATE}" | grep -Eq "^clean" || ( echo "Git tree state is not clean"; exit 1 )
@@ -61,11 +61,11 @@ release:
 	@docker run \
 		--rm \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		-e DOCKER_USERNAME=${DOCKER_USERNAME} \
-		-e DOCKER_PASSWORD=${DOCKER_PASSWORD} \
 		-e GORELEASER_CURRENT_TAG=${GORELEASER_CURRENT_TAG} \
+		-e DOCKER_CREDS_FILE=${DOCKER_CREDS_FILE} \
+		-v ${DOCKER_CREDS_FILE}:${DOCKER_CREDS_FILE} \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/${REPO}/${NAME} \
 		-w /go/src/${REPO}/${NAME} \
 		goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION} \
-		release --rm-dist
+		release --rm-dist ${GORELEASER_EXTRA_ARGS}

--- a/script/release.sh
+++ b/script/release.sh
@@ -4,7 +4,22 @@ set -eu
 
 WORKDIR=$(pwd)
 
-export GORELEASER_CURRENT_TAG=$(buildkite-agent meta-data get "release-version")
+GORELEASER_CURRENT_TAG=$(buildkite-agent meta-data get "release-version")
+export GORELEASER_CURRENT_TAG
 
-cd $WORKDIR
-make release
+tmpdir=$(mktemp -d)
+cat >"$tmpdir/docker.json" <<EOF
+{
+  "registries": [
+    {
+      "user" : "$DOCKER_USERNAME",
+      "pass" : "$DOCKER_PASSWORD",
+      "registry" : "index.docker.io"
+    }
+  ]
+}
+EOF
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+cd "$WORKDIR"
+make release DOCKER_CREDS_FILE="$tmpdir/docker.json"


### PR DESCRIPTION
goreleaser-cross now requires docker creds provided in a JSON file.

We could also add a new CI job that runs on non-main branches that execs goreleaser with the `--snapshot` flag. That will run goreleaser but not publish a release. I've found this helpful on other projects since goreleaser has a tendency to change config options frequently. I added the `GORELEASER_EXTRA_ARGS` to help facilitate this with local testing