### PR TITLE
fix(ci): try hub.docker.io for registry addr

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -14,7 +14,7 @@ cat >"$tmpdir/docker.json" <<EOF
     {
       "user" : "$DOCKER_USERNAME",
       "pass" : "$DOCKER_PASSWORD",
-      "registry" : "index.docker.io"
+      "registry" : "hub.docker.io"
     }
   ]
 }


### PR DESCRIPTION
followup to #571, attempting to figure out new way to pass docker registry creds

This might be the correct addr judging from the prior upstream docs - https://github.com/goreleaser/goreleaser-cross/commit/6ee68a94f140791df2bfea54f91a1529a0d106d9