### PR TITLE
fix(ci): try empty string for docker hub addr

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -14,7 +14,7 @@ cat >"$tmpdir/docker.json" <<EOF
     {
       "user" : "$DOCKER_USERNAME",
       "pass" : "$DOCKER_PASSWORD",
-      "registry" : "hub.docker.io"
+      "registry" : ""
     }
   ]
 }


### PR DESCRIPTION
This should be similar to the previous method of authenticating that did not provide a $registry addr: https://github.com/goreleaser/goreleaser-cross/commit/b5b9b7cccea89d31d07ebe4113b4991536c229ed