### PR TITLE
dump/restore: set number of threads to be configurable

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -48,7 +48,7 @@ func DumpCmd(ch *cmdutil.Helper) *cobra.Command {
 		"Comma separated string of WHERE clauses to filter the tables to dump. Only used when you specify tables to dump. Default is not to filter dumped tables.")
 	cmd.PersistentFlags().StringVar(&f.output, "output", "",
 		"Output directory of the dump. By default the dump is saved to a folder in the current directory.")
-	cmd.PersistentFlags().IntVar(&f.threads, "threads", 16, "Number of concurrent threads to use to restore the database.")
+	cmd.PersistentFlags().IntVar(&f.threads, "threads", 16, "Number of concurrent threads to use to dump the database.")
 
 	return cmd
 }

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -27,6 +27,7 @@ type dumpFlags struct {
 	tables    string
 	wheres    string
 	output    string
+	threads   int
 }
 
 // DumpCmd encapsulates the commands for dumping a database
@@ -47,6 +48,7 @@ func DumpCmd(ch *cmdutil.Helper) *cobra.Command {
 		"Comma separated string of WHERE clauses to filter the tables to dump. Only used when you specify tables to dump. Default is not to filter dumped tables.")
 	cmd.PersistentFlags().StringVar(&f.output, "output", "",
 		"Output directory of the dump. By default the dump is saved to a folder in the current directory.")
+	cmd.PersistentFlags().IntVar(&f.threads, "threads", 16, "Number of concurrent threads to use to restore the database.")
 
 	return cmd
 }
@@ -137,6 +139,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	}
 
 	cfg := dumper.NewDefaultConfig()
+	cfg.Threads = flags.threads
 	cfg.User = "root"
 	// NOTE(fatih): the password is a placeholder, replace once we get rid of the proxy
 	cfg.Password = "root"

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -20,6 +20,7 @@ type restoreFlags struct {
 	localAddr string
 	dir       string
 	overwrite bool
+	threads   int
 }
 
 // RestoreCmd encapsulates the commands for restore a database
@@ -38,6 +39,7 @@ func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
 		"Directory containing the files to be used for the restore (required)")
 	cmd.PersistentFlags().BoolVar(&f.overwrite, "overwrite-tables", false, "If true, will attempt to DROP TABLE before restoring.")
 
+	cmd.PersistentFlags().IntVar(&f.threads, "threads", 1, "Number of concurrent threads to use to restore the database.")
 	return cmd
 }
 
@@ -107,6 +109,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 	}
 
 	cfg := dumper.NewDefaultConfig()
+	cfg.Threads = flags.threads
 	cfg.User = "root"
 	// NOTE: the password is a placeholder, replace once we get rid of the proxy
 	cfg.Password = "root"

--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -51,7 +51,7 @@ type Config struct {
 
 func NewDefaultConfig() *Config {
 	return &Config{
-		Threads: 16,
+		Threads: 1,
 	}
 }
 


### PR DESCRIPTION
This allows a user to pick the number of threads to use when dumping and restoring. Defaults are unchanged for dump, but are set low (1) for restoring, to ensure that we don't overwhelm a small database. Users can configure that to be higher if they happen to want higher concurrency.

```
$ pscale db restore-dump --help

Restore your database from a local dump directory

Usage:
  pscale database restore-dump <database> <branch> [options] [flags]

Flags:
      --dir string          Directory containing the files to be used for the restore (required)
  -h, --help                help for restore-dump
      --local-addr string   Local address to bind and listen for connections. By default the proxy binds to 127.0.0.1 with a random port.
      --overwrite-tables    If true, will attempt to DROP TABLE before restoring.
      --threads int         Number of concurrent threads to use to restore the database. (default 1)
```