### PR TITLE
Update to latest Go 1.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.2 as build
+FROM golang:1.19.4 as build
 WORKDIR /app
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.19.2
+GORELEASE_CROSS_VERSION ?= v1.19.4
 
 .PHONY: all
 all: build test lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: golang:1.19.2
+    image: golang:1.19.4
     volumes:
       - .:/work
     working_dir: /work

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,4 +1,4 @@
-FROM golang:1.19.2-bullseye
+FROM golang:1.19.4-bullseye
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev


### PR DESCRIPTION
Depends on https://github.com/goreleaser/goreleaser-cross/pull/18 to be released first so we have a new `goreleaser-cross` base image. 