### PR TITLE
[service-tokens] Update show access with new format

### DIFF
--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -1,24 +1,90 @@
 {
   "entries": {
     "brew": {
-      "golang": null,
-      "golangci-lint": {
-        "version": "1.33.0",
+      "golang": {
+        "version": "1.19.5",
         "bottle": {
-          "cellar": ":any_skip_relocation",
-          "prefix": "/usr/local",
+          "rebuild": 0,
+          "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
+            "arm64_ventura": {
+              "cellar": "/opt/homebrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:9e45e8c058b38e85608717871c18e8a4236f7e8895938388081fc3b873e7da35",
+              "sha256": "9e45e8c058b38e85608717871c18e8a4236f7e8895938388081fc3b873e7da35"
+            },
+            "arm64_monterey": {
+              "cellar": "/opt/homebrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:e97b3a6221357290a48fba6bd88c39ccce5d0d48927a657a810f4932465ab62a",
+              "sha256": "e97b3a6221357290a48fba6bd88c39ccce5d0d48927a657a810f4932465ab62a"
+            },
+            "arm64_big_sur": {
+              "cellar": "/opt/homebrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:38d5820da5d75b9956e85edf5e85a386e3f39b585389ae5fcb118827b045dea6",
+              "sha256": "38d5820da5d75b9956e85edf5e85a386e3f39b585389ae5fcb118827b045dea6"
+            },
+            "ventura": {
+              "cellar": "/usr/local/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:8249f690a7898697a6c6c0a5bb21cd5b80739b65553c94ac0bb62348989aa3e9",
+              "sha256": "8249f690a7898697a6c6c0a5bb21cd5b80739b65553c94ac0bb62348989aa3e9"
+            },
+            "monterey": {
+              "cellar": "/usr/local/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:06020b3d11c2be4fc8318561203e7435c484773475b836496303cb1c6225ae0a",
+              "sha256": "06020b3d11c2be4fc8318561203e7435c484773475b836496303cb1c6225ae0a"
+            },
             "big_sur": {
-              "url": "https://homebrew.bintray.com/bottles/golangci-lint-1.33.0.big_sur.bottle.tar.gz",
-              "sha256": "3042277ec4e58631bc6cce5d643a77003ffd88a5f5a300dc850129f6aeb8462b"
+              "cellar": "/usr/local/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:1863c55cd86258e10ac6b7e3a3e3da12074d7783f81e864f3b43c5c288f59d8f",
+              "sha256": "1863c55cd86258e10ac6b7e3a3e3da12074d7783f81e864f3b43c5c288f59d8f"
             },
-            "catalina": {
-              "url": "https://homebrew.bintray.com/bottles/golangci-lint-1.33.0.catalina.bottle.tar.gz",
-              "sha256": "d9d8d30df68b927cf16979ccb327a0f764f0f722a74b1b8f40ff6be76c8b95b9"
+            "x86_64_linux": {
+              "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
+              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:4060878a09c55ce7bd3b1093829a5e01622be31816c368f8fcaf07e38bca1fb9",
+              "sha256": "4060878a09c55ce7bd3b1093829a5e01622be31816c368f8fcaf07e38bca1fb9"
+            }
+          }
+        }
+      },
+      "golangci-lint": {
+        "version": "1.50.1_1",
+        "bottle": {
+          "rebuild": 0,
+          "root_url": "https://ghcr.io/v2/homebrew/core",
+          "files": {
+            "arm64_ventura": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:b3d00d4719199fd7c376294e8b5d3cd83ca199abaa0a25d8e87847e174bb2aeb",
+              "sha256": "b3d00d4719199fd7c376294e8b5d3cd83ca199abaa0a25d8e87847e174bb2aeb"
             },
-            "mojave": {
-              "url": "https://homebrew.bintray.com/bottles/golangci-lint-1.33.0.mojave.bottle.tar.gz",
-              "sha256": "ea486d4398aebf87e5b2b9415e6bbd7f12b53d6149d3f487d2635b02d9942b10"
+            "arm64_monterey": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:00d0b1523c8d47f0372d85efc22c31ab2e40825e2b36de441d2bf3d4dec9277c",
+              "sha256": "00d0b1523c8d47f0372d85efc22c31ab2e40825e2b36de441d2bf3d4dec9277c"
+            },
+            "arm64_big_sur": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:132c057ec5d0f8a713055849cd4cf2a66d45133e44b60bb3a343b546b6154985",
+              "sha256": "132c057ec5d0f8a713055849cd4cf2a66d45133e44b60bb3a343b546b6154985"
+            },
+            "ventura": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:c07d3a7b134e10f465acb7728b3eb20c694ab02791cbe7feed64fadeb6875e46",
+              "sha256": "c07d3a7b134e10f465acb7728b3eb20c694ab02791cbe7feed64fadeb6875e46"
+            },
+            "monterey": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:e18d7d01fe317aba5bd80b4b9f87474251abcf6b6bc2d1b61d778bd172454184",
+              "sha256": "e18d7d01fe317aba5bd80b4b9f87474251abcf6b6bc2d1b61d778bd172454184"
+            },
+            "big_sur": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:645c684084e0e420f9a457e54234197625fb422c367c62b9b3de7f805908621f",
+              "sha256": "645c684084e0e420f9a457e54234197625fb422c367c62b9b3de7f805908621f"
+            },
+            "x86_64_linux": {
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:8645784e9d49f8fc7afbb5f1302e59fa8062a7c95a933ba9d8541abc24d3af30",
+              "sha256": "8645784e9d49f8fc7afbb5f1302e59fa8062a7c95a933ba9d8541abc24d3af30"
             }
           }
         }
@@ -34,6 +100,30 @@
         "CLT": "12.0.32.27",
         "Xcode": "12.0",
         "macOS": "10.15.7"
+      },
+      "big_sur": {
+        "HOMEBREW_VERSION": "2.6.2",
+        "HOMEBREW_PREFIX": "/usr/local",
+        "Homebrew/homebrew-core": "9087b7573b6bb25aed15ab24b0d596b216157713",
+        "CLT": "12.2.0.0.1.1604076827",
+        "Xcode": "12.0",
+        "macOS": "11.0.1"
+      },
+      "monterey": {
+        "HOMEBREW_VERSION": "3.6.5-22-g77311e4",
+        "HOMEBREW_PREFIX": "/usr/local",
+        "Homebrew/homebrew-core": "7a9c050fbbb6f52c37b82fd7b0050a2843cdf113",
+        "CLT": "14.0.0.0.1.1661618636",
+        "Xcode": "14.0.1",
+        "macOS": "12.6"
+      },
+      "ventura": {
+        "HOMEBREW_VERSION": "3.6.20-189-g3af2f0e",
+        "HOMEBREW_PREFIX": "/usr/local",
+        "Homebrew/homebrew-core": "c7c38c40e91994ba2b59fa8570f836df0178d064",
+        "CLT": "14.2.0.0.1.1668646533",
+        "Xcode": "14.1",
+        "macOS": "13.1"
       }
     }
   }

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -1,90 +1,24 @@
 {
   "entries": {
     "brew": {
-      "golang": {
-        "version": "1.19.5",
-        "bottle": {
-          "rebuild": 0,
-          "root_url": "https://ghcr.io/v2/homebrew/core",
-          "files": {
-            "arm64_ventura": {
-              "cellar": "/opt/homebrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:9e45e8c058b38e85608717871c18e8a4236f7e8895938388081fc3b873e7da35",
-              "sha256": "9e45e8c058b38e85608717871c18e8a4236f7e8895938388081fc3b873e7da35"
-            },
-            "arm64_monterey": {
-              "cellar": "/opt/homebrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:e97b3a6221357290a48fba6bd88c39ccce5d0d48927a657a810f4932465ab62a",
-              "sha256": "e97b3a6221357290a48fba6bd88c39ccce5d0d48927a657a810f4932465ab62a"
-            },
-            "arm64_big_sur": {
-              "cellar": "/opt/homebrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:38d5820da5d75b9956e85edf5e85a386e3f39b585389ae5fcb118827b045dea6",
-              "sha256": "38d5820da5d75b9956e85edf5e85a386e3f39b585389ae5fcb118827b045dea6"
-            },
-            "ventura": {
-              "cellar": "/usr/local/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:8249f690a7898697a6c6c0a5bb21cd5b80739b65553c94ac0bb62348989aa3e9",
-              "sha256": "8249f690a7898697a6c6c0a5bb21cd5b80739b65553c94ac0bb62348989aa3e9"
-            },
-            "monterey": {
-              "cellar": "/usr/local/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:06020b3d11c2be4fc8318561203e7435c484773475b836496303cb1c6225ae0a",
-              "sha256": "06020b3d11c2be4fc8318561203e7435c484773475b836496303cb1c6225ae0a"
-            },
-            "big_sur": {
-              "cellar": "/usr/local/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:1863c55cd86258e10ac6b7e3a3e3da12074d7783f81e864f3b43c5c288f59d8f",
-              "sha256": "1863c55cd86258e10ac6b7e3a3e3da12074d7783f81e864f3b43c5c288f59d8f"
-            },
-            "x86_64_linux": {
-              "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/go/blobs/sha256:4060878a09c55ce7bd3b1093829a5e01622be31816c368f8fcaf07e38bca1fb9",
-              "sha256": "4060878a09c55ce7bd3b1093829a5e01622be31816c368f8fcaf07e38bca1fb9"
-            }
-          }
-        }
-      },
+      "golang": null,
       "golangci-lint": {
-        "version": "1.50.1_1",
+        "version": "1.33.0",
         "bottle": {
-          "rebuild": 0,
-          "root_url": "https://ghcr.io/v2/homebrew/core",
+          "cellar": ":any_skip_relocation",
+          "prefix": "/usr/local",
           "files": {
-            "arm64_ventura": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:b3d00d4719199fd7c376294e8b5d3cd83ca199abaa0a25d8e87847e174bb2aeb",
-              "sha256": "b3d00d4719199fd7c376294e8b5d3cd83ca199abaa0a25d8e87847e174bb2aeb"
-            },
-            "arm64_monterey": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:00d0b1523c8d47f0372d85efc22c31ab2e40825e2b36de441d2bf3d4dec9277c",
-              "sha256": "00d0b1523c8d47f0372d85efc22c31ab2e40825e2b36de441d2bf3d4dec9277c"
-            },
-            "arm64_big_sur": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:132c057ec5d0f8a713055849cd4cf2a66d45133e44b60bb3a343b546b6154985",
-              "sha256": "132c057ec5d0f8a713055849cd4cf2a66d45133e44b60bb3a343b546b6154985"
-            },
-            "ventura": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:c07d3a7b134e10f465acb7728b3eb20c694ab02791cbe7feed64fadeb6875e46",
-              "sha256": "c07d3a7b134e10f465acb7728b3eb20c694ab02791cbe7feed64fadeb6875e46"
-            },
-            "monterey": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:e18d7d01fe317aba5bd80b4b9f87474251abcf6b6bc2d1b61d778bd172454184",
-              "sha256": "e18d7d01fe317aba5bd80b4b9f87474251abcf6b6bc2d1b61d778bd172454184"
-            },
             "big_sur": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:645c684084e0e420f9a457e54234197625fb422c367c62b9b3de7f805908621f",
-              "sha256": "645c684084e0e420f9a457e54234197625fb422c367c62b9b3de7f805908621f"
+              "url": "https://homebrew.bintray.com/bottles/golangci-lint-1.33.0.big_sur.bottle.tar.gz",
+              "sha256": "3042277ec4e58631bc6cce5d643a77003ffd88a5f5a300dc850129f6aeb8462b"
             },
-            "x86_64_linux": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/golangci-lint/blobs/sha256:8645784e9d49f8fc7afbb5f1302e59fa8062a7c95a933ba9d8541abc24d3af30",
-              "sha256": "8645784e9d49f8fc7afbb5f1302e59fa8062a7c95a933ba9d8541abc24d3af30"
+            "catalina": {
+              "url": "https://homebrew.bintray.com/bottles/golangci-lint-1.33.0.catalina.bottle.tar.gz",
+              "sha256": "d9d8d30df68b927cf16979ccb327a0f764f0f722a74b1b8f40ff6be76c8b95b9"
+            },
+            "mojave": {
+              "url": "https://homebrew.bintray.com/bottles/golangci-lint-1.33.0.mojave.bottle.tar.gz",
+              "sha256": "ea486d4398aebf87e5b2b9415e6bbd7f12b53d6149d3f487d2635b02d9942b10"
             }
           }
         }
@@ -100,30 +34,6 @@
         "CLT": "12.0.32.27",
         "Xcode": "12.0",
         "macOS": "10.15.7"
-      },
-      "big_sur": {
-        "HOMEBREW_VERSION": "2.6.2",
-        "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "9087b7573b6bb25aed15ab24b0d596b216157713",
-        "CLT": "12.2.0.0.1.1604076827",
-        "Xcode": "12.0",
-        "macOS": "11.0.1"
-      },
-      "monterey": {
-        "HOMEBREW_VERSION": "3.6.5-22-g77311e4",
-        "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "7a9c050fbbb6f52c37b82fd7b0050a2843cdf113",
-        "CLT": "14.0.0.0.1.1661618636",
-        "Xcode": "14.0.1",
-        "macOS": "12.6"
-      },
-      "ventura": {
-        "HOMEBREW_VERSION": "3.6.20-189-g3af2f0e",
-        "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "c7c38c40e91994ba2b59fa8570f836df0178d064",
-        "CLT": "14.2.0.0.1.1668646533",
-        "Xcode": "14.1",
-        "macOS": "13.1"
       }
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.80.0
+	github.com/planetscale/planetscale-go v0.81.0
 	github.com/planetscale/sql-proxy v0.13.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
 github.com/planetscale/planetscale-go v0.80.0 h1:JjqitoiuBVMuDwO8ZMlnP71ApkVpNqNeRa7GktJXf5k=
 github.com/planetscale/planetscale-go v0.80.0/go.mod h1:zCYbPZu3s99BEePAFortKfLJwxKd5HgP53wRFq5r0m4=
+github.com/planetscale/planetscale-go v0.81.0 h1:CpAhyCoOm6sOPVBiclG845xIpcCF/0tGKv/JbIRQOjI=
+github.com/planetscale/planetscale-go v0.81.0/go.mod h1:zCYbPZu3s99BEePAFortKfLJwxKd5HgP53wRFq5r0m4=
 github.com/planetscale/sql-proxy v0.13.0 h1:NDjcdqgoNzwbZQTyoIDEoI+K7keC5RRKvdML2roAMn4=
 github.com/planetscale/sql-proxy v0.13.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/token/showaccess_test.go
+++ b/internal/cmd/token/showaccess_test.go
@@ -26,13 +26,17 @@ func TestServiceToken_ShowAccess(t *testing.T) {
 
 	orig := []*ps.ServiceTokenGrant{
 		{
-			ID:           "id-1",
-			Accesses:     []string{"read_branch"},
+			ID: "id-1",
+			Accesses: []*ps.ServiceTokenGrantAccess{
+				{Access: "read_branch", Description: "Read database branch info"},
+			},
 			ResourceName: "db1",
 		},
 		{
-			ID:           "id-2",
-			Accesses:     []string{"delete_branch"},
+			ID: "id-2",
+			Accesses: []*ps.ServiceTokenGrantAccess{
+				{Access: "delete_branch", Description: "Delete a database branch"},
+			},
 			ResourceName: "db2",
 		},
 	}
@@ -70,12 +74,14 @@ func TestServiceToken_ShowAccess(t *testing.T) {
 
 	res := []*ServiceTokenGrant{
 		{
-			Database: "db1",
-			Accesses: []string{"read_branch"},
+			ResourceName: "db1",
+			ResourceType: "Database",
+			Accesses:     []string{"read_branch"},
 		},
 		{
-			Database: "db2",
-			Accesses: []string{"delete_branch"},
+			ResourceName: "db2",
+			ResourceType: "Database",
+			Accesses:     []string{"delete_branch"},
 		},
 	}
 	c.Assert(buf.String(), qt.JSONEquals, res)

--- a/internal/cmd/token/showaccess_test.go
+++ b/internal/cmd/token/showaccess_test.go
@@ -30,6 +30,7 @@ func TestServiceToken_ShowAccess(t *testing.T) {
 			Accesses: []*ps.ServiceTokenGrantAccess{
 				{Access: "read_branch", Description: "Read database branch info"},
 			},
+			ResourceType: "Database",
 			ResourceName: "db1",
 		},
 		{
@@ -37,6 +38,7 @@ func TestServiceToken_ShowAccess(t *testing.T) {
 			Accesses: []*ps.ServiceTokenGrantAccess{
 				{Access: "delete_branch", Description: "Delete a database branch"},
 			},
+			ResourceType: "Database",
 			ResourceName: "db2",
 		},
 	}

--- a/internal/cmd/token/token.go
+++ b/internal/cmd/token/token.go
@@ -87,16 +87,22 @@ func toServiceTokenAccesses(st []*ps.ServiceTokenAccess) []*ServiceTokenAccess {
 
 // ServiceTokenGrant erturns a table and json serializable service token grant
 type ServiceTokenGrant struct {
-	Database string   `header:"database" json:"database"`
-	Accesses []string `header:"accesses" json:"accesses"`
+	ResourceName string   `header:"resource_name" json:"resource_name"`
+	ResourceType string   `header:"resource_type" json:"resource_type"`
+	Accesses     []string `header:"accesses" json:"accesses"`
 }
 
 func toServiceTokenGrants(st []*ps.ServiceTokenGrant) []*ServiceTokenGrant {
 	out := make([]*ServiceTokenGrant, 0, len(st))
 	for _, v := range st {
+		accesses := make([]string, 0, len(v.Accesses))
+		for _, a := range v.Accesses {
+			accesses = append(accesses, a.Access)
+		}
 		out = append(out, &ServiceTokenGrant{
-			Database: v.ResourceName,
-			Accesses: v.Accesses,
+			ResourceName: v.ResourceName,
+			ResourceType: v.ResourceType,
+			Accesses:     accesses,
 		})
 	}
 


### PR DESCRIPTION
This PR updates the `pscale service-token show-access` cmd with a new format:

```
➜  cli git:(frances/fix-service-tokens) ✗ go run ./cmd/pscale/main.go service-token show-access irc25xa5f5hk --api-url http://api.pscaledev.com:3000
!! WARNING: You are using a self-compiled binary which is not officially supported.
!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true

  RESOURCE NAME   RESOURCE TYPE   ACCESSES
 --------------- --------------- ---------------------------------------------------------
  test            Database        restore_branch_backup, restore_production_branch_backup
```

This should fix: https://github.com/planetscale/surfaces/issues/912