### PR TITLE
Refer to service token grant list in the API docs

### DIFF
--- a/internal/cmd/token/addaccess.go
+++ b/internal/cmd/token/addaccess.go
@@ -21,7 +21,7 @@ For example, to give a service token the ability to create, read and delete bran
 
   pscale service-token add-access <token id> read_branch delete_branch create_branch --database <database name>
 
-For a complete list of the access permissions that can be granted to a token, see: https://planetscale.com/docs/reference/planetscale-cli#service-tokens-in-organizations.`,
+For a complete list of the access permissions that can be granted to a token, see: https://api-docs.planetscale.com/reference/service-tokens#access-permissions.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := ch.Client()


### PR DESCRIPTION
The token access list on the main docs site was often out of date. We should refer to the automated list in the API docs instead.

I've already updated original page to point to the API docs.