### PR TITLE
Update to Go 1.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.5 as build
+FROM golang:1.20.1 as build
 WORKDIR /app
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.19.5
+GORELEASE_CROSS_VERSION ?= v1.20.1
 
 .PHONY: all
 all: build test lint
@@ -67,5 +67,5 @@ release:
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v `pwd`:/go/src/${REPO}/${NAME} \
 		-w /go/src/${REPO}/${NAME} \
-		goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION} \
+		ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION} \
 		release --rm-dist ${GORELEASER_EXTRA_ARGS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: golang:1.19.5
+    image: golang:1.20.1
     volumes:
       - .:/work
     working_dir: /work

--- a/docker/Dockerfile.licensed
+++ b/docker/Dockerfile.licensed
@@ -1,4 +1,4 @@
-FROM golang:1.19.5-bullseye
+FROM golang:1.20.1-bullseye
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y ruby-dev rubygems ruby cmake pkg-config git-core libgit2-dev


### PR DESCRIPTION
Latest and greatest that also fixes some upstream CVEs. 