### PR TITLE
Remove hidden flag from safe migrations command.

### DIFF
--- a/internal/cmd/branch/safe_migrations.go
+++ b/internal/cmd/branch/safe_migrations.go
@@ -14,9 +14,8 @@ import (
 
 func SafeMigrationsCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "safe-migrations <command>",
-		Short:  "Enable or disable safe migrations on a branch",
-		Hidden: true,
+		Use:   "safe-migrations <command>",
+		Short: "Enable or disable safe migrations on a branch",
 	}
 
 	cmd.AddCommand(EnableSafeMigrationsCmd(ch))


### PR DESCRIPTION
Now that this is released, we can make this CLI command visible.