### PR TITLE
Add CLI parameters for region, ssl authentication to data imports.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.85.0
+	github.com/planetscale/planetscale-go v0.86.0
 	github.com/planetscale/sql-proxy v0.13.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
 github.com/planetscale/planetscale-go v0.85.0 h1:G8YQ8bKyEZq0c2QOqQI95tHBrLIUVUexOfiHqsqp7bA=
 github.com/planetscale/planetscale-go v0.85.0/go.mod h1:Mnv8ntn4x1qO6f5FS+uMKZji4oWjG9PZqdTx/3uYAxM=
+github.com/planetscale/planetscale-go v0.86.0 h1:vJvL4BYIVupbx36TtP7AlHWhhcoI0SQYR8faimXqpYo=
+github.com/planetscale/planetscale-go v0.86.0/go.mod h1:Mnv8ntn4x1qO6f5FS+uMKZji4oWjG9PZqdTx/3uYAxM=
 github.com/planetscale/sql-proxy v0.13.0 h1:NDjcdqgoNzwbZQTyoIDEoI+K7keC5RRKvdML2roAMn4=
 github.com/planetscale/sql-proxy v0.13.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/dataimports/lint.go
+++ b/internal/cmd/dataimports/lint.go
@@ -12,12 +12,16 @@ import (
 
 func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		host     string
-		username string
-		password string
-		database string
-		port     int
-		sslMode  string
+		host           string
+		username       string
+		password       string
+		database       string
+		port           int
+		sslMode        string
+		sslCA          string
+		sslKey         string
+		sslCertificate string
+		sslServerName  string
 	}
 
 	testRequest := &ps.TestDataImportSourceRequest{}
@@ -38,6 +42,10 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 				HostName:            flags.host,
 				Port:                flags.port,
 				SSLVerificationMode: sslMode,
+				SSLKey:              flags.sslKey,
+				SSLCertificate:      flags.sslCertificate,
+				SSLCA:               flags.sslCA,
+				SSLServerName:       flags.sslServerName,
 			}
 
 			client, err := ch.Client()
@@ -88,6 +96,10 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.username, "username", "", "Username to connect to external database.")
 	cmd.PersistentFlags().StringVar(&flags.password, "password", "", "Password to connect to external database.")
 	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values: disabled, preferred, required, verify_ca, verify_identity")
+	cmd.PersistentFlags().StringVar(&flags.sslServerName, "ssl-server-name", "", "SSL server name override")
+	cmd.PersistentFlags().StringVar(&flags.sslCA, "ssl-certificate-authority", "", "Provide the full CA certificate chain here")
+	cmd.PersistentFlags().StringVar(&flags.sslKey, "ssl-client-key", "", "Private key for the client certificate")
+	cmd.PersistentFlags().StringVar(&flags.sslKey, "ssl-client-certificate", "", "Client Certificate to authenticate PlanetScale with your database server")
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 
 	cmd.MarkPersistentFlagRequired("host")

--- a/internal/cmd/dataimports/start.go
+++ b/internal/cmd/dataimports/start.go
@@ -14,6 +14,7 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		name     string
 		host     string
+		region   string
 		username string
 		password string
 		database string
@@ -44,6 +45,7 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 			startImportRequest.Organization = ch.Config.Organization
 			startImportRequest.Database = flags.name
 			startImportRequest.Connection = dataSource
+			startImportRequest.Region = flags.region
 
 			testRequest.Organization = ch.Config.Organization
 			testRequest.Database = flags.database
@@ -116,6 +118,7 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&flags.name, "name", "", "")
+	cmd.PersistentFlags().StringVar(&flags.region, "region", "", "region for the PlanetScale database.")
 	cmd.PersistentFlags().StringVar(&flags.host, "host", "", "Host name of the external database.")
 	cmd.PersistentFlags().StringVar(&flags.database, "database", "", "Name of the external database")
 	cmd.PersistentFlags().StringVar(&flags.username, "username", "", "Username to connect to external database.")

--- a/internal/cmd/dataimports/start.go
+++ b/internal/cmd/dataimports/start.go
@@ -12,15 +12,19 @@ import (
 
 func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		name     string
-		host     string
-		region   string
-		username string
-		password string
-		database string
-		port     int
-		dryRun   bool
-		sslMode  string
+		name           string
+		host           string
+		region         string
+		username       string
+		password       string
+		database       string
+		port           int
+		dryRun         bool
+		sslMode        string
+		sslCA          string
+		sslKey         string
+		sslCertificate string
+		sslServerName  string
 	}
 
 	startImportRequest := &ps.StartDataImportRequest{}
@@ -41,6 +45,10 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 				HostName:            flags.host,
 				Port:                flags.port,
 				SSLVerificationMode: sslMode,
+				SSLKey:              flags.sslKey,
+				SSLCertificate:      flags.sslCertificate,
+				SSLCA:               flags.sslCA,
+				SSLServerName:       flags.sslServerName,
 			}
 			startImportRequest.Organization = ch.Config.Organization
 			startImportRequest.Database = flags.name
@@ -98,6 +106,7 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			startImportRequest.Plan = resp.SuggestedPlan
+			startImportRequest.MaxPoolSize = resp.MaxPoolSize
 
 			ch.Printer.Println(fmt.Sprintf("starting import of schema and data from external database %s to PlanetScale database %s", printer.BoldBlue(flags.database), printer.BoldGreen(flags.name)))
 			dataImport, err := client.DataImports.StartDataImport(ctx, startImportRequest)
@@ -126,6 +135,10 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 	cmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", true, "Only run compatibility check, do not start import")
 	cmd.PersistentFlags().StringVar(&flags.sslMode, "ssl-mode", "", "SSL verification mode, allowed values: disabled, preferred, required, verify_ca, verify_identity")
+	cmd.PersistentFlags().StringVar(&flags.sslServerName, "ssl-server-name", "", "SSL server name override")
+	cmd.PersistentFlags().StringVar(&flags.sslCA, "ssl-certificate-authority", "", "Provide the full CA certificate chain here")
+	cmd.PersistentFlags().StringVar(&flags.sslKey, "ssl-client-key", "", "Private key for the client certificate")
+	cmd.PersistentFlags().StringVar(&flags.sslKey, "ssl-client-certificate", "", "Client Certificate to authenticate PlanetScale with your database server")
 
 	cmd.MarkPersistentFlagRequired("name")
 	cmd.MarkPersistentFlagRequired("host")


### PR DESCRIPTION
Help documents for `lint` and `start` commands  for data imports:

Needs https://github.com/planetscale/planetscale-go/pull/160 

### Lint external datasource
``` bash
./pcli data-imports lint -h

lint external database for compatibility with PlanetScale

Usage:
  pscale data-imports lint [options] [flags]

Aliases:
  lint, l

Flags:
      --database string                    Name of the external database
  -h, --help                               help for lint
      --host string                        Host name of the external database.
      --password string                    Password to connect to external database.
      --port int                           Port number to connect to external database (default 3306)
      --ssl-certificate-authority string   Provide the full CA certificate chain here
      --ssl-client-certificate string      Client Certificate to authenticate PlanetScale with your database server
      --ssl-client-key string              Private key for the client certificate
      --ssl-mode string                    SSL verification mode, allowed values: disabled, preferred, required, verify_ca, verify_identity
      --ssl-server-name string             SSL server name override
      --username string                    Username to connect to external database.
```

### Start Data Import

``` bash
./pcli data-imports start -h
start importing data from an external database

Usage:
  pscale data-imports start [options] [flags]

Aliases:
  start, s

Flags:
      --database string                    Name of the external database
      --dry-run                            Only run compatibility check, do not start import (default true)
  -h, --help                               help for start
      --host string                        Host name of the external database.
      --name string
      --password string                    Password to connect to external database.
      --port int                           Port number to connect to external database (default 3306)
      --region string                      region for the PlanetScale database.
      --ssl-certificate-authority string   Provide the full CA certificate chain here
      --ssl-client-certificate string      Client Certificate to authenticate PlanetScale with your database server
      --ssl-client-key string              Private key for the client certificate
      --ssl-mode string                    SSL verification mode, allowed values: disabled, preferred, required, verify_ca, verify_identity
      --ssl-server-name string             SSL server name override
      --username string                    Username to connect to external database.
```