### PR TITLE
Improve error message when connecting to not found DB

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -70,7 +70,13 @@ argument:
 			if branch == "" {
 				branch, err = promptutil.GetBranch(ctx, client, ch.Config.Organization, database)
 				if err != nil {
-					return err
+					switch cmdutil.ErrCode(err) {
+					case planetscale.ErrNotFound:
+						return fmt.Errorf("database %s does not exist in organization %s",
+							printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+					default:
+						return cmdutil.HandleError(err)
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/planetscale/cli/issues/500

**Before:**
```
pscale connect mike
Error: Not found
```

**After:**
```
pscale connect mike
Error: database mike does not exist in organization mike
```