### PR TITLE
Fix error handling for `switch` command

### DIFF
--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -40,7 +40,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 				Branch:       branch,
 			})
 			if err != nil && !errorIsNotFound(err) {
-				return err
+				return cmdutil.HandleError(err)
 			}
 
 			if errorIsNotFound(err) {


### PR DESCRIPTION
Fixes: https://github.com/planetscale/cli/issues/607

**Before:**
```
Error: internal error, response body doesn't match error type signature
```

**After:**
```
Error: the access token has expired. Please run 'pscale auth login'
```