### PR TITLE
Improve error message for `db list` when org missing or not authed

### DIFF
--- a/internal/cmd/database/list.go
+++ b/internal/cmd/database/list.go
@@ -52,7 +52,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(ch.Config.Organization))
+					return fmt.Errorf("organization %s does not exist or your account is not authorized to access it", printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}


### PR DESCRIPTION
Fixes: https://github.com/planetscale/cli/issues/556

Improves the error message for cases where the user doesn't have permission to access it.

We can't get more specific than this since we do not give more detailed info via the API.