### PR TITLE
Dump: support invisible columns

### DIFF
--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -408,9 +408,9 @@ func (d *Dumper) dumpableFieldNames(conn *Connection, table string) ([]string, e
 		name := t[0].String()
 		extra := t[5].String()
 
-		// Can be either "VIRTUAL GENERATED" or "VIRTUAL STORED"
+		// Can be either "VIRTUAL GENERATED" or "STORED GENERATED"
 		// https://dev.mysql.com/doc/refman/8.0/en/show-columns.html
-		if strings.Contains(extra, "VIRTUAL") {
+		if strings.Contains(extra, "GENERATED") {
 			// Skip generated columns
 			continue
 		} else {

--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -391,7 +391,7 @@ func (d *Dumper) filterDatabases(conn *Connection, filter *regexp.Regexp, invert
 	return databases, nil
 }
 
-// dumpableFieldNames returns a map that contains valid field names for the dump
+// dumpableFieldNames returns a slice that contains valid field names for the dump.
 func (d *Dumper) dumpableFieldNames(conn *Connection, table string) ([]string, error) {
 	qr, err := conn.Fetch(fmt.Sprintf("SHOW FIELDS FROM `%s`", table))
 	if err != nil {

--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -230,19 +230,19 @@ func (d *Dumper) dumpTable(conn *Connection, database string, table string) erro
 			return err
 		}
 
-		for _, fld := range flds {
-			d.log.Debug("dump", zap.Any("filters", d.cfg.Filters), zap.String("table", table), zap.String("field_name", fld))
+		for _, name := range flds {
+			d.log.Debug("dump", zap.Any("filters", d.cfg.Filters), zap.String("table", table), zap.String("field_name", name))
 
-			if _, ok := d.cfg.Filters[table][fld]; ok {
+			if _, ok := d.cfg.Filters[table][name]; ok {
 				continue
 			}
 
-			fields = append(fields, fmt.Sprintf("`%s`", fld))
-			replacement, ok := d.cfg.Selects[table][fld]
+			fields = append(fields, fmt.Sprintf("`%s`", name))
+			replacement, ok := d.cfg.Selects[table][name]
 			if ok {
-				selfields = append(selfields, fmt.Sprintf("%s AS `%s`", replacement, fld))
+				selfields = append(selfields, fmt.Sprintf("%s AS `%s`", replacement, name))
 			} else {
-				selfields = append(selfields, fmt.Sprintf("`%s`", fld))
+				selfields = append(selfields, fmt.Sprintf("`%s`", name))
 			}
 		}
 	}

--- a/internal/dumper/dumper_test.go
+++ b/internal/dumper/dumper_test.go
@@ -14,6 +14,17 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+func createFieldRow(name, extra string) []sqltypes.Value {
+	return []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(name)),
+		sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("varchar(255)")),
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
+		sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
+		sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(extra)),
+	}
+}
+
 func TestDumper(t *testing.T) {
 	c := qt.New(t)
 
@@ -114,14 +125,13 @@ func TestDumper(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("not_deleted")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("int")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
-				sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("VIRTUAL GENERATED")),
-			},
+			createFieldRow("id", ""),
+			createFieldRow("name", ""),
+			createFieldRow("namei1", ""),
+			createFieldRow("null", ""),
+			createFieldRow("decimal", ""),
+			createFieldRow("datetime", ""),
+			createFieldRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -261,14 +271,13 @@ func TestDumperGeneratedFields(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("name")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("varchar(255)")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
-				sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("VIRTUAL GENERATED")),
-			},
+			createFieldRow("id", ""),
+			createFieldRow("name", "VIRTUAL GENERATED"),
+			createFieldRow("namei1", ""),
+			createFieldRow("null", ""),
+			createFieldRow("decimal", ""),
+			createFieldRow("datetime", ""),
+			createFieldRow("not_deleted", "VIRTUAL GENERATED"),
 		},
 	}
 
@@ -442,14 +451,13 @@ func TestDumperAll(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("not_deleted")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("int")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
-				sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("VIRTUAL GENERATED")),
-			},
+			createFieldRow("id", ""),
+			createFieldRow("name", ""),
+			createFieldRow("namei1", ""),
+			createFieldRow("null", ""),
+			createFieldRow("decimal", ""),
+			createFieldRow("datetime", ""),
+			createFieldRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -630,14 +638,13 @@ func TestDumperMultiple(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("not_deleted")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("int")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
-				sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("VIRTUAL GENERATED")),
-			},
+			createFieldRow("id", ""),
+			createFieldRow("name", ""),
+			createFieldRow("namei1", ""),
+			createFieldRow("null", ""),
+			createFieldRow("decimal", ""),
+			createFieldRow("datetime", ""),
+			createFieldRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -828,14 +835,13 @@ func TestDumperSimpleRegexp(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("not_deleted")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("int")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
-				sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("VIRTUAL GENERATED")),
-			},
+			createFieldRow("id", ""),
+			createFieldRow("name", ""),
+			createFieldRow("namei1", ""),
+			createFieldRow("null", ""),
+			createFieldRow("decimal", ""),
+			createFieldRow("datetime", ""),
+			createFieldRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -1026,14 +1032,13 @@ func TestDumperComplexRegexp(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			{
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("not_deleted")),
-				sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("int")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("YES")),
-				sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("")),
-				sqltypes.MakeTrusted(querypb.Type_NULL_TYPE, []byte("NULL")),
-				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("VIRTUAL GENERATED")),
-			},
+			createFieldRow("id", ""),
+			createFieldRow("name", ""),
+			createFieldRow("namei1", ""),
+			createFieldRow("null", ""),
+			createFieldRow("decimal", ""),
+			createFieldRow("datetime", ""),
+			createFieldRow("not_deleted", "virtual generated"),
 		},
 	}
 

--- a/internal/dumper/dumper_test.go
+++ b/internal/dumper/dumper_test.go
@@ -14,7 +14,7 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-func createFieldRow(name, extra string) []sqltypes.Value {
+func testRow(name, extra string) []sqltypes.Value {
 	return []sqltypes.Value{
 		sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(name)),
 		sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("varchar(255)")),
@@ -125,13 +125,13 @@ func TestDumper(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			createFieldRow("id", ""),
-			createFieldRow("name", ""),
-			createFieldRow("namei1", ""),
-			createFieldRow("null", ""),
-			createFieldRow("decimal", ""),
-			createFieldRow("datetime", ""),
-			createFieldRow("not_deleted", "virtual generated"),
+			testRow("id", ""),
+			testRow("name", ""),
+			testRow("namei1", ""),
+			testRow("null", ""),
+			testRow("decimal", ""),
+			testRow("datetime", ""),
+			testRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -271,13 +271,13 @@ func TestDumperGeneratedFields(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			createFieldRow("id", ""),
-			createFieldRow("name", "VIRTUAL GENERATED"),
-			createFieldRow("namei1", ""),
-			createFieldRow("null", ""),
-			createFieldRow("decimal", ""),
-			createFieldRow("datetime", ""),
-			createFieldRow("not_deleted", "VIRTUAL GENERATED"),
+			testRow("id", ""),
+			testRow("name", "VIRTUAL GENERATED"),
+			testRow("namei1", ""),
+			testRow("null", ""),
+			testRow("decimal", ""),
+			testRow("datetime", ""),
+			testRow("not_deleted", "VIRTUAL GENERATED"),
 		},
 	}
 
@@ -451,13 +451,13 @@ func TestDumperAll(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			createFieldRow("id", ""),
-			createFieldRow("name", ""),
-			createFieldRow("namei1", ""),
-			createFieldRow("null", ""),
-			createFieldRow("decimal", ""),
-			createFieldRow("datetime", ""),
-			createFieldRow("not_deleted", "virtual generated"),
+			testRow("id", ""),
+			testRow("name", ""),
+			testRow("namei1", ""),
+			testRow("null", ""),
+			testRow("decimal", ""),
+			testRow("datetime", ""),
+			testRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -638,13 +638,13 @@ func TestDumperMultiple(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			createFieldRow("id", ""),
-			createFieldRow("name", ""),
-			createFieldRow("namei1", ""),
-			createFieldRow("null", ""),
-			createFieldRow("decimal", ""),
-			createFieldRow("datetime", ""),
-			createFieldRow("not_deleted", "virtual generated"),
+			testRow("id", ""),
+			testRow("name", ""),
+			testRow("namei1", ""),
+			testRow("null", ""),
+			testRow("decimal", ""),
+			testRow("datetime", ""),
+			testRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -835,13 +835,13 @@ func TestDumperSimpleRegexp(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			createFieldRow("id", ""),
-			createFieldRow("name", ""),
-			createFieldRow("namei1", ""),
-			createFieldRow("null", ""),
-			createFieldRow("decimal", ""),
-			createFieldRow("datetime", ""),
-			createFieldRow("not_deleted", "virtual generated"),
+			testRow("id", ""),
+			testRow("name", ""),
+			testRow("namei1", ""),
+			testRow("null", ""),
+			testRow("decimal", ""),
+			testRow("datetime", ""),
+			testRow("not_deleted", "virtual generated"),
 		},
 	}
 
@@ -1032,13 +1032,13 @@ func TestDumperComplexRegexp(t *testing.T) {
 			{Name: "Extra", Type: querypb.Type_VARCHAR},
 		},
 		Rows: [][]sqltypes.Value{
-			createFieldRow("id", ""),
-			createFieldRow("name", ""),
-			createFieldRow("namei1", ""),
-			createFieldRow("null", ""),
-			createFieldRow("decimal", ""),
-			createFieldRow("datetime", ""),
-			createFieldRow("not_deleted", "virtual generated"),
+			testRow("id", ""),
+			testRow("name", ""),
+			testRow("namei1", ""),
+			testRow("null", ""),
+			testRow("decimal", ""),
+			testRow("datetime", ""),
+			testRow("not_deleted", "virtual generated"),
 		},
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/planetscale/cli/issues/652
Fixes: https://github.com/planetscale/cli/issues/645

Originally, the dump command grabbed the column names by running `select *`.

This does not work with invisible columns, since `select *` will only return visible columns.

This PR updates `dump` to use `SHOW FIELDS` which returns invisible columns.

```
invisible/main> show fields from mike;
+-------+------+------+-----+---------+-----------+
| Field | Type | Null | Key | Default | Extra     |
+-------+------+------+-----+---------+-----------+
| id    | int  | NO   | PRI | NULL    |           |
| test  | int  | YES  |     | NULL    | INVISIBLE |
+-------+------+------+-----+---------+-----------+
```

We then use that list to generate the dump.