### PR TITLE
Shell: fix conflict with DB name

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -169,6 +169,7 @@ second argument:
 				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,
 				"-P", port,
+				"-D", database,
 			}
 
 			historyFile, err := historyFilePath(ch.Config.Organization, database, branch)


### PR DESCRIPTION
Fixes: https://github.com/planetscale/cli/issues/453

When a user has `~/.my.cnf` configured with a database name. For example:
```
[client]
database=databasename
```

pscale shell errors with the following:
```
ERROR 1105 (HY000): unknown database 'databasename'
```

This is easily fixed by passing the database name.