### PR TITLE
Attempt `os.MkdirAll` for the config-file if we fallback from Keychain

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,9 +290,21 @@ func deleteAccessTokenPath() error {
 	return nil
 }
 
-func writeAccessTokenPath(accessToken string) error {	
+func writeAccessTokenPath(accessToken string) error {
 	tokenPath, err := accessTokenPath()
 	if err != nil {
+		return err
+	}
+
+	configDir := filepath.Dir(tokenPath)
+
+	_, err = os.Stat(configDir)
+	if os.IsNotExist(err) {
+		err := os.MkdirAll(configDir, 0771)
+		if err != nil {
+			return errors.New("error creating config directory")
+		}
+	} else if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The switch to using Keychain reordered some of the token creation code, which means that we tried to write the token before we tried to make the folder. This adds code in that codepath as well to look at the `filepath.Dir` we're trying to write that token to, and does an `os.MkdirAll`. 

This should work fine with the rest of the codebase, as this is all atomic and only done once. 

Fixes: https://github.com/planetscale/cli/issues/667