### PR TITLE
Confirm when creating Scaler databases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.86.0
+	github.com/planetscale/planetscale-go v0.87.0
 	github.com/planetscale/sql-proxy v0.13.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
 github.com/planetscale/planetscale-go v0.86.0 h1:vJvL4BYIVupbx36TtP7AlHWhhcoI0SQYR8faimXqpYo=
 github.com/planetscale/planetscale-go v0.86.0/go.mod h1:Mnv8ntn4x1qO6f5FS+uMKZji4oWjG9PZqdTx/3uYAxM=
+github.com/planetscale/planetscale-go v0.87.0 h1:pkp0jg0QlnyO2zB5DpVCq8rzX7fEu4oLiwvrusQwUHA=
+github.com/planetscale/planetscale-go v0.87.0/go.mod h1:Mnv8ntn4x1qO6f5FS+uMKZji4oWjG9PZqdTx/3uYAxM=
 github.com/planetscale/sql-proxy v0.13.0 h1:NDjcdqgoNzwbZQTyoIDEoI+K7keC5RRKvdML2roAMn4=
 github.com/planetscale/sql-proxy v0.13.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -45,6 +45,24 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
+			org, err := client.Organizations.Get(cmd.Context(), &ps.GetOrganizationRequest{
+				Organization: ch.Config.Organization,
+			})
+
+			if err != nil {
+				return err
+			}
+
+			if org.RemainingFreeDatabases == 0 {
+				ch.Printer.Printf("Organization [%s] does not have any free databases remaining\n", org.Name)
+				ch.Printer.Printf("If you choose to continue, this  database will be created on Scaler plan. The monthly cost is %v.\n", printer.BoldYellow("$29"))
+				confirmationName := "$29"
+				confirmError := ch.Printer.ConfirmCommand(confirmationName, "create", "create this branch")
+				if confirmError != nil {
+					return confirmError
+				}
+			}
+
 			end := ch.Printer.PrintProgress("Creating database...")
 			defer end()
 			database, err := client.Databases.Create(ctx, createReq)

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -55,7 +55,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if org.RemainingFreeDatabases == 0 {
 				ch.Printer.Printf("Organization [%s] does not have any free databases remaining\n", org.Name)
-				ch.Printer.Printf("If you choose to continue, this  database will be created on Scaler plan. The monthly cost is %v.\n", printer.BoldYellow("$29"))
+				ch.Printer.Printf("If you choose to continue, this database will be created on the Scaler plan. The monthly cost is %v.\n", printer.BoldYellow("$29"))
 				confirmationName := "Y"
 				confirmError := ch.Printer.ConfirmCommand(confirmationName, "create", "create this branch")
 				if confirmError != nil {

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -56,7 +56,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if org.RemainingFreeDatabases == 0 {
 				ch.Printer.Printf("Organization [%s] does not have any free databases remaining\n", org.Name)
 				ch.Printer.Printf("If you choose to continue, this  database will be created on Scaler plan. The monthly cost is %v.\n", printer.BoldYellow("$29"))
-				confirmationName := "$29"
+				confirmationName := "Y"
 				confirmError := ch.Printer.ConfirmCommand(confirmationName, "create", "create this branch")
 				if confirmError != nil {
 					return confirmError

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -45,6 +45,14 @@ func TestDatabase_CreateCmd(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				Databases: svc,
+				Organizations: &mock.OrganizationsService{
+					GetFn: func(ctx context.Context, request *ps.GetOrganizationRequest) (*ps.Organization, error) {
+						return &ps.Organization{
+							RemainingFreeDatabases: 1,
+							Name:                   request.Organization,
+						}, nil
+					},
+				},
 			}, nil
 
 		},


### PR DESCRIPTION
This PR adds a confirmation dialog when a user creates a database and there are no more free databases available in the organization, creating a scaler database. 

``` bash
$ pscale database create paid-database --org Phani

Organization [phani] does not have any free databases remaining.
If you choose to continue, this  database will be created on Scaler plan. The monthly cost is $29.
? Please type $29 to confirm:
```
