### PR TITLE
Respect users XDG directory setting for history file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.3 h1:g+rSsSaAzhHJYcIQE78hJ3AhyjjtQvleKDjlhdBnIhc=
 github.com/benbjohnson/clock v1.3.3/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -430,6 +432,7 @@ golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/adrg/xdg"
 	"net"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -18,7 +18,6 @@ import (
 
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	exec "golang.org/x/sys/execabs"
 )
@@ -267,23 +266,12 @@ func formatMySQLBranch(database string, branch *ps.DatabaseBranch) string {
 }
 
 func historyFilePath(org, db, branch string) (string, error) {
-	dir, err := homedir.Dir()
+	historyFilePath := fmt.Sprintf(".pscale/history/%s.%s.%s", org, db, branch)
+
+	historyFile, err := xdg.DataFile(historyFilePath)
 	if err != nil {
 		return "", err
 	}
-
-	historyDir := filepath.Join(dir, ".pscale", "history")
-
-	_, err = os.Stat(historyDir)
-	if os.IsNotExist(err) {
-		err := os.MkdirAll(historyDir, 0771)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	historyFilename := fmt.Sprintf("%s.%s.%s", org, db, branch)
-	historyFile := filepath.Join(historyDir, historyFilename)
 
 	return historyFile, nil
 }

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -173,11 +173,7 @@ second argument:
 				"-D", database,
 			}
 
-			historyFile, err := historyFilePath(ch.Config.Organization, database, branch)
-			if err != nil {
-				return err
-			}
-
+			historyFile := historyFilePath(ch.Config.Organization, database, branch)
 			styledBranch := formatMySQLBranch(database, dbBranch)
 
 			m := &mysql{
@@ -287,18 +283,18 @@ func legacyHistoryFilePath(org, db, branch string) string {
 	return historyFile
 }
 
-func historyFilePath(org, db, branch string) (string, error) {
+func historyFilePath(org, db, branch string) string {
 	legacyHistoryFile := legacyHistoryFilePath(org, db, branch)
 	if legacyHistoryFile != "" {
-		return legacyHistoryFile, nil
+		return legacyHistoryFile
 	}
 
 	historyFilePath := fmt.Sprintf(".pscale/history/%s.%s.%s", org, db, branch)
 
 	historyFile, err := xdg.DataFile(historyFilePath)
 	if err != nil {
-		return "", err
+		return ""
 	}
 
-	return historyFile, nil
+	return historyFile
 }


### PR DESCRIPTION
Closes: https://github.com/planetscale/cli/issues/429

This updates the CLI to use XDG_DATA_HOME for the location of the users shell history file.

The [xdg package](https://github.com/adrg/xdg) takes care of returning the path based on the operating system and creating the directory if it is not present.

## Legacy history files

For anyone with an existing `~/.pscale/history` directory, it will continue to use it. To avoid wiping out all of a person's history