### PR TITLE
fix bug skipping "DEFAULT_GENERATED" columns in dump

### DIFF
--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -410,7 +410,7 @@ func (d *Dumper) dumpableFieldNames(conn *Connection, table string) ([]string, e
 
 		// Can be either "VIRTUAL GENERATED" or "STORED GENERATED"
 		// https://dev.mysql.com/doc/refman/8.0/en/show-columns.html
-		if strings.Contains(extra, "GENERATED") {
+		if strings.Contains(extra, "VIRTUAL GENERATED") || strings.Contains(extra, "STORED GENERATED") {
 			// Skip generated columns
 			continue
 		} else {


### PR DESCRIPTION
Closes #676.

Was considering just adding a space before `"GENERATED"` in the if-clause, but this more verbose solution is hopefully more future-proof.

Looked into adding a test for it, but the testing setup looked too complicated for me, sorry.