### PR TITLE
Change ssl client certificate to set correct flag

### DIFF
--- a/internal/cmd/dataimports/lint.go
+++ b/internal/cmd/dataimports/lint.go
@@ -99,7 +99,7 @@ func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.sslServerName, "ssl-server-name", "", "SSL server name override")
 	cmd.PersistentFlags().StringVar(&flags.sslCA, "ssl-certificate-authority", "", "Provide the full CA certificate chain here")
 	cmd.PersistentFlags().StringVar(&flags.sslKey, "ssl-client-key", "", "Private key for the client certificate")
-	cmd.PersistentFlags().StringVar(&flags.sslKey, "ssl-client-certificate", "", "Client Certificate to authenticate PlanetScale with your database server")
+	cmd.PersistentFlags().StringVar(&flags.sslCertificate, "ssl-client-certificate", "", "Client Certificate to authenticate PlanetScale with your database server")
 	cmd.PersistentFlags().IntVar(&flags.port, "port", 3306, "Port number to connect to external database")
 
 	cmd.MarkPersistentFlagRequired("host")


### PR DESCRIPTION
The `data-imports lint` command accepts ssl cert info, but was overwriting `sslKey` with the client cert.