### PR TITLE
cmd/branch: print newline after switching branches

### DIFF
--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -92,7 +92,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			ch.Printer.Printf(
-				"Successfully switched to branch %s on database %s",
+				"Successfully switched to branch %s on database %s\n",
 				printer.BoldBlue(branch),
 				printer.BoldBlue(ch.Config.Database),
 			)


### PR DESCRIPTION
Before:
```
✘-2 ~/src/github.com/planetscale/cli [main|✔] 
08:57 $ pscale branch switch --database planetscale main
!! WARNING: You are using a self-compiled binary which is not officially supported.
!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true

Finding branch main on database planetscale
Successfully switched to branch main on database planetscale✔ ~/src/github.com/planetscale/cli [main|…1]
```

After:
```
✔ ~/src/github.com/planetscale/cli [main|✚ 1…1] 
08:58 $ pscale branch switch --database planetscale main
!! WARNING: You are using a self-compiled binary which is not officially supported.
!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true

Finding branch main on database planetscale
Successfully switched to branch main on database planetscale
✔ ~/src/github.com/planetscale/cli [main|✚ 1…1] 
08:58 
```