### PR TITLE
internal: remove unneeded errcheck annotations

### DIFF
--- a/internal/cmd/branch/diff.go
+++ b/internal/cmd/branch/diff.go
@@ -58,9 +58,9 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 				for scanner.Scan() {
 					txt := scanner.Text()
 					if strings.HasPrefix(txt, "+") {
-						ch.Printer.Println(color.New(color.FgGreen).Add(color.Bold).Sprint(txt)) //nolint: errcheck
+						ch.Printer.Println(color.New(color.FgGreen).Add(color.Bold).Sprint(txt))
 					} else if strings.HasPrefix(txt, "-") {
-						ch.Printer.Println(color.New(color.FgRed).Add(color.Bold).Sprint(txt)) //nolint: errcheck
+						ch.Printer.Println(color.New(color.FgRed).Add(color.Bold).Sprint(txt))
 					} else {
 						ch.Printer.Println(txt)
 					}

--- a/internal/cmd/branch/schema.go
+++ b/internal/cmd/branch/schema.go
@@ -64,9 +64,9 @@ func SchemaCmd(ch *cmdutil.Helper) *cobra.Command {
 				for scanner.Scan() {
 					txt := scanner.Text()
 					if strings.HasPrefix(txt, "+") {
-						ch.Printer.Println(color.New(color.FgGreen).Add(color.Bold).Sprint(txt)) //nolint: errcheck
+						ch.Printer.Println(color.New(color.FgGreen).Add(color.Bold).Sprint(txt))
 					} else if strings.HasPrefix(txt, "-") {
-						ch.Printer.Println(color.New(color.FgRed).Add(color.Bold).Sprint(txt)) //nolint: errcheck
+						ch.Printer.Println(color.New(color.FgRed).Add(color.Bold).Sprint(txt))
 					} else {
 						ch.Printer.Println(txt)
 					}

--- a/internal/cmd/deployrequest/diff.go
+++ b/internal/cmd/deployrequest/diff.go
@@ -71,9 +71,9 @@ func DiffCmd(ch *cmdutil.Helper) *cobra.Command {
 				for scanner.Scan() {
 					txt := scanner.Text()
 					if strings.HasPrefix(txt, "+") {
-						ch.Printer.Println(color.New(color.FgGreen).Add(color.Bold).Sprint(txt)) //nolint: errcheck
+						ch.Printer.Println(color.New(color.FgGreen).Add(color.Bold).Sprint(txt))
 					} else if strings.HasPrefix(txt, "-") {
-						ch.Printer.Println(color.New(color.FgRed).Add(color.Bold).Sprint(txt)) //nolint: errcheck
+						ch.Printer.Println(color.New(color.FgRed).Add(color.Bold).Sprint(txt))
 					} else {
 						ch.Printer.Println(txt)
 					}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -240,7 +240,7 @@ func initConfig() {
 	if rootDir, err := config.RootGitRepoDir(); err == nil && cfgFile == "" {
 		viper.AddConfigPath(rootDir)
 		viper.SetConfigName(config.ProjectConfigFile())
-		viper.MergeInConfig() // nolint:errcheck
+		_ = viper.MergeInConfig()
 	}
 
 	postInitCommands(rootCmd.Commands())

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -4,22 +4,19 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/adrg/xdg"
-	"github.com/mitchellh/go-homedir"
 	"net"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/adrg/xdg"
+	"github.com/mitchellh/go-homedir"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	"github.com/planetscale/cli/internal/promptutil"
 	"github.com/planetscale/cli/internal/proxyutil"
-
-	"github.com/planetscale/sql-proxy/proxy"
-
 	ps "github.com/planetscale/planetscale-go/planetscale"
-
+	"github.com/planetscale/sql-proxy/proxy"
 	"github.com/spf13/cobra"
 	exec "golang.org/x/sys/execabs"
 )
@@ -126,7 +123,7 @@ second argument:
 			proxyError := make(chan error, 1)
 
 			go func() {
-				proxyError <- runProxy(ctx, ch, proxyOpts, proxyAddr)
+				proxyError <- runProxy(ctx, proxyOpts, proxyAddr)
 			}()
 
 			dbBranch, err := client.DatabaseBranches.Get(ctx, &ps.GetDatabaseBranchRequest{
@@ -186,7 +183,6 @@ second argument:
 
 			err = m.Run(ctx, mysqlArgs...)
 			return err
-
 		},
 	}
 
@@ -203,7 +199,7 @@ second argument:
 }
 
 // runProxy runs the sql-proxy with the given options.
-func runProxy(ctx context.Context, ch *cmdutil.Helper, proxyOpts proxy.Options, ready chan string) error {
+func runProxy(ctx context.Context, proxyOpts proxy.Options, ready chan string) error {
 	p, err := proxy.NewClient(proxyOpts)
 	if err != nil {
 		return fmt.Errorf("couldn't create proxy client: %s", err)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -132,7 +132,7 @@ func (p *Printer) PrintProgress(message string) func() {
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(p.out()))
 	s.Suffix = fmt.Sprintf(" %s", message)
 
-	s.Color("bold", "green") // nolint:errcheck
+	_ = s.Color("bold", "green")
 	s.Start()
 	return func() {
 		s.Stop()
@@ -242,7 +242,6 @@ func (p *Printer) PrintJSON(v interface{}) error {
 
 	fmt.Fprintln(out, string(buf))
 	return nil
-
 }
 
 func (p *Printer) PrettyPrintJSON(b []byte) error {


### PR DESCRIPTION
Half of these methods don't return errors and were cargo culted. For the others, you can just explicitly ignore the error to more clearly indicate you don't care.