### PR TITLE
internal/dumper: fix restore panic

### DIFF
--- a/internal/dumper/loader.go
+++ b/internal/dumper/loader.go
@@ -239,9 +239,15 @@ func (l *Loader) restoreTable(table string, conn *Connection) (int, error) {
 	part := "0"
 	base := filepath.Base(table)
 	name := strings.TrimSuffix(base, tableSuffix)
+
 	splits := strings.Split(name, ".")
+	if len(splits) < 2 {
+		return 0, fmt.Errorf("expected database.table, but got: %q", name)
+	}
+
 	db := splits[0]
 	tbl := splits[1]
+
 	if len(splits) > 2 {
 		part = splits[2]
 	}


### PR DESCRIPTION
For https://github.com/planetscale/cli/issues/697. All slice index accesses must have a bounds check beforehand.