### PR TITLE
internal/*: apply gofumpt

### DIFF
--- a/internal/cmd/auditlog/list_test.go
+++ b/internal/cmd/auditlog/list_test.go
@@ -53,7 +53,6 @@ func TestAuditLog_List(t *testing.T) {
 			return &ps.Client{
 				AuditLogs: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/backup/create_test.go
+++ b/internal/cmd/backup/create_test.go
@@ -47,7 +47,6 @@ func TestBackup_CreateCmd(t *testing.T) {
 			return &ps.Client{
 				Backups: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/backup/delete_test.go
+++ b/internal/cmd/backup/delete_test.go
@@ -47,7 +47,6 @@ func TestBackup_DeleteCmd(t *testing.T) {
 			return &ps.Client{
 				Backups: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/backup/list_test.go
+++ b/internal/cmd/backup/list_test.go
@@ -50,7 +50,6 @@ func TestBackup_ListCmd(t *testing.T) {
 			return &ps.Client{
 				Backups: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/backup/restore_test.go
+++ b/internal/cmd/backup/restore_test.go
@@ -48,7 +48,6 @@ func TestBackup_RestoreCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/backup/show_test.go
+++ b/internal/cmd/backup/show_test.go
@@ -49,7 +49,6 @@ func TestBackup_ShowCmd(t *testing.T) {
 			return &ps.Client{
 				Backups: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -48,7 +48,6 @@ func TestBranch_CreateCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/delete_test.go
+++ b/internal/cmd/branch/delete_test.go
@@ -44,7 +44,6 @@ func TestBranch_DeleteCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/demote_test.go
+++ b/internal/cmd/branch/demote_test.go
@@ -55,7 +55,6 @@ func TestBranch_DemoteCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 
@@ -108,7 +107,6 @@ func TestBranch_DemoteCmdWithDemotionRequest(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/diff_test.go
+++ b/internal/cmd/branch/diff_test.go
@@ -50,7 +50,6 @@ func TestBranchDiffCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/keyspaces_test.go
+++ b/internal/cmd/branch/keyspaces_test.go
@@ -53,7 +53,6 @@ func TestBranchKeyspacesCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/lint_test.go
+++ b/internal/cmd/branch/lint_test.go
@@ -46,7 +46,6 @@ func TestBranch_LintCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/list_test.go
+++ b/internal/cmd/branch/list_test.go
@@ -49,7 +49,6 @@ func TestBranch_ListCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/promote_test.go
+++ b/internal/cmd/branch/promote_test.go
@@ -50,7 +50,6 @@ func TestBranch_PromoteCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/refresh_schema_test.go
+++ b/internal/cmd/branch/refresh_schema_test.go
@@ -43,7 +43,6 @@ func TestSnapshot_CreateCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/safe_migrations.go
+++ b/internal/cmd/branch/safe_migrations.go
@@ -79,7 +79,6 @@ func EnableSafeMigrationsCmd(ch *cmdutil.Helper) *cobra.Command {
 				default:
 					return cmdutil.HandleError(err)
 				}
-
 			}
 
 			end()

--- a/internal/cmd/branch/safe_migrations_test.go
+++ b/internal/cmd/branch/safe_migrations_test.go
@@ -50,7 +50,6 @@ func TestBranch_EnableSafeMigrationsCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 
@@ -114,7 +113,6 @@ func TestBranch_EnableSafeMigrationsCmdWithLintingErrors(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 
@@ -165,7 +163,6 @@ func TestBranch_DisableSafeMigrationsCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/schema_test.go
+++ b/internal/cmd/branch/schema_test.go
@@ -50,7 +50,6 @@ func TestBranchSchemaCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/show_test.go
+++ b/internal/cmd/branch/show_test.go
@@ -47,7 +47,6 @@ func TestBranch_ShowCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/branch/vschema_test.go
+++ b/internal/cmd/branch/vschema_test.go
@@ -49,7 +49,6 @@ func TestBranchVSchemaCmd(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -48,7 +48,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			org, err := client.Organizations.Get(cmd.Context(), &ps.GetOrganizationRequest{
 				Organization: ch.Config.Organization,
 			})
-
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -54,7 +54,6 @@ func TestDatabase_CreateCmd(t *testing.T) {
 					},
 				},
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/database/delete_test.go
+++ b/internal/cmd/database/delete_test.go
@@ -47,7 +47,6 @@ func TestDatabase_DeleteCmd(t *testing.T) {
 			return &ps.Client{
 				Databases: svc,
 			}, nil
-
 		},
 	}
 
@@ -90,7 +89,6 @@ func TestDatabase_DeleteCmdWithDeletionRequest(t *testing.T) {
 			return &ps.Client{
 				Databases: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -170,7 +170,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 		return fmt.Errorf("backup directory already exists: %s", dir)
 	}
 
-	err = os.MkdirAll(dir, 0755)
+	err = os.MkdirAll(dir, 0o755)
 	if err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func getDatabaseName(name, addr string) (string, error) {
 		return "", fmt.Errorf("failed getting database names: %s", err)
 	}
 
-	var hasDatabaseName = map[string]bool{
+	hasDatabaseName := map[string]bool{
 		"onboarding-demo": true,
 	}
 

--- a/internal/cmd/database/list_test.go
+++ b/internal/cmd/database/list_test.go
@@ -45,7 +45,6 @@ func TestDatabase_ListCmd(t *testing.T) {
 			return &ps.Client{
 				Databases: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/database/show_test.go
+++ b/internal/cmd/database/show_test.go
@@ -45,7 +45,6 @@ func TestDatabase_ShowCmd(t *testing.T) {
 			return &ps.Client{
 				Databases: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/dataimports/cancel.go
+++ b/internal/cmd/dataimports/cancel.go
@@ -2,6 +2,7 @@ package dataimports
 
 import (
 	"fmt"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"

--- a/internal/cmd/dataimports/cancel_test.go
+++ b/internal/cmd/dataimports/cancel_test.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
-	"strings"
-	"testing"
 )
 
 func TestImports_Cancel_FailsIfNoImport(t *testing.T) {
@@ -98,7 +99,6 @@ func invokeCancel(org, dbName string, c *qt.C, shouldInvokeCancel bool, svc *moc
 			return &ps.Client{
 				DataImports: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/dataimports/detach.go
+++ b/internal/cmd/dataimports/detach.go
@@ -2,6 +2,7 @@ package dataimports
 
 import (
 	"fmt"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"

--- a/internal/cmd/dataimports/get.go
+++ b/internal/cmd/dataimports/get.go
@@ -2,6 +2,7 @@ package dataimports
 
 import (
 	"fmt"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"

--- a/internal/cmd/dataimports/lint.go
+++ b/internal/cmd/dataimports/lint.go
@@ -3,11 +3,12 @@ package dataimports
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 func LintExternalDataSourceCmd(ch *cmdutil.Helper) *cobra.Command {

--- a/internal/cmd/dataimports/lint_test.go
+++ b/internal/cmd/dataimports/lint_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
-	"strings"
-	"testing"
 )
 
 func TestImports_LintDatabase_Success(t *testing.T) {
@@ -87,11 +88,11 @@ func TestImports_LintDatabase_SchemaIncompatible(t *testing.T) {
 	res := &ps.TestDataImportSourceResponse{
 		CanConnect: true,
 		Errors: []*ps.DataSourceIncompatibilityError{
-			&ps.DataSourceIncompatibilityError{
+			{
 				LintError:        "NO_PRIMARY_KEY",
 				ErrorDescription: "Table \"employees\" has no primary key",
 			},
-			&ps.DataSourceIncompatibilityError{
+			{
 				LintError:        "NO_PRIMARY_KEY",
 				ErrorDescription: "Table \"departments\" has no primary key",
 			},
@@ -138,7 +139,6 @@ func invokeLintDatabase(externalDataSource *ps.DataImportSource, org string, c *
 			return &ps.Client{
 				DataImports: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/dataimports/makeplanetscaleprimary.go
+++ b/internal/cmd/dataimports/makeplanetscaleprimary.go
@@ -2,6 +2,7 @@ package dataimports
 
 import (
 	"fmt"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"

--- a/internal/cmd/dataimports/makeplanetscaleprimary_test.go
+++ b/internal/cmd/dataimports/makeplanetscaleprimary_test.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
-	"strings"
-	"testing"
 )
 
 func TestImports_MakePrimary_FailsIfNoImport(t *testing.T) {
@@ -148,7 +149,6 @@ func invokeMakePrimary(org, dbName string, c *qt.C, shouldInvokeMakePrimary bool
 			return &ps.Client{
 				DataImports: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/dataimports/makeplanetscalereplica.go
+++ b/internal/cmd/dataimports/makeplanetscalereplica.go
@@ -2,6 +2,7 @@ package dataimports
 
 import (
 	"fmt"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"

--- a/internal/cmd/dataimports/makeplanetscalereplica_test.go
+++ b/internal/cmd/dataimports/makeplanetscalereplica_test.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
-	"strings"
-	"testing"
 )
 
 func TestImports_MakeReplica_FailsIfNoImport(t *testing.T) {
@@ -148,7 +149,6 @@ func invokeMakeReplica(org, dbName string, c *qt.C, shouldInvokeMakeReplica bool
 			return &ps.Client{
 				DataImports: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/dataimports/printer.go
+++ b/internal/cmd/dataimports/printer.go
@@ -1,9 +1,10 @@
 package dataimports
 
 import (
+	"strings"
+
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
-	"strings"
 )
 
 func PrintDataImport(p *printer.Printer, di ps.DataImport) {

--- a/internal/cmd/dataimports/start.go
+++ b/internal/cmd/dataimports/start.go
@@ -3,11 +3,12 @@ package dataimports
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
@@ -34,7 +35,6 @@ func StartDataImportCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short:   "start importing data from an external database",
 		Aliases: []string{"s"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			ctx := cmd.Context()
 			sslMode := cmdutil.ParseSSLMode(flags.sslMode)
 

--- a/internal/cmd/dataimports/start_test.go
+++ b/internal/cmd/dataimports/start_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	qt "github.com/frankban/quicktest"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
-	"strings"
-	"testing"
 )
 
 func TestStart_LintDatabase_Success(t *testing.T) {
@@ -88,11 +89,11 @@ func TestStart_LintDatabase_SchemaIncompatible(t *testing.T) {
 	res := &ps.TestDataImportSourceResponse{
 		CanConnect: true,
 		Errors: []*ps.DataSourceIncompatibilityError{
-			&ps.DataSourceIncompatibilityError{
+			{
 				LintError:        "NO_PRIMARY_KEY",
 				ErrorDescription: "Table \"employees\" has no primary key",
 			},
-			&ps.DataSourceIncompatibilityError{
+			{
 				LintError:        "NO_PRIMARY_KEY",
 				ErrorDescription: "Table \"departments\" has no primary key",
 			},
@@ -137,7 +138,6 @@ func invokeStartDatabase(externalDataSource *ps.DataImportSource, psdbName, org 
 			return &ps.Client{
 				DataImports: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/apply_test.go
+++ b/internal/cmd/deployrequest/apply_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_ApplyCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/cancel_test.go
+++ b/internal/cmd/deployrequest/cancel_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_CancelCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/close_test.go
+++ b/internal/cmd/deployrequest/close_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_CloseCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/create_test.go
+++ b/internal/cmd/deployrequest/create_test.go
@@ -47,7 +47,6 @@ func TestDeployRequest_CreateCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 
@@ -95,7 +94,6 @@ func TestDeployRequest_CreateCmdIntoFlag(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 
@@ -145,7 +143,6 @@ func TestDeployRequest_CreateCmdDeprecatedDeployToFlag(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/deploy_test.go
+++ b/internal/cmd/deployrequest/deploy_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_DeployCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/diff_test.go
+++ b/internal/cmd/deployrequest/diff_test.go
@@ -51,7 +51,6 @@ func TestDeployRequest_DiffCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/edit_test.go
+++ b/internal/cmd/deployrequest/edit_test.go
@@ -48,7 +48,6 @@ func TestDeployRequest_EditCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/list_test.go
+++ b/internal/cmd/deployrequest/list_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_ListCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/revert_test.go
+++ b/internal/cmd/deployrequest/revert_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_RevertCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/review_test.go
+++ b/internal/cmd/deployrequest/review_test.go
@@ -54,7 +54,6 @@ func TestDeployRequest_ReviewCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/show_test.go
+++ b/internal/cmd/deployrequest/show_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_ShowCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/deployrequest/skiprevert_test.go
+++ b/internal/cmd/deployrequest/skiprevert_test.go
@@ -46,7 +46,6 @@ func TestDeployRequest_SkipRevertCmd(t *testing.T) {
 			return &ps.Client{
 				DeployRequests: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/org/show.go
+++ b/internal/cmd/org/show.go
@@ -53,7 +53,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if ch.Printer.Format() == printer.CSV {
-				var res = []struct {
+				res := []struct {
 					Org string `json:"org"`
 				}{{Org: cfg.Organization}}
 

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -50,7 +50,6 @@ func TestPassword_CreateCmd(t *testing.T) {
 			return &ps.Client{
 				Passwords: svc,
 			}, nil
-
 		},
 	}
 
@@ -98,7 +97,6 @@ func TestPassword_CreateCmd_InvalidRole(t *testing.T) {
 			return &ps.Client{
 				Passwords: svc,
 			}, nil
-
 		},
 	}
 
@@ -108,7 +106,6 @@ func TestPassword_CreateCmd_InvalidRole(t *testing.T) {
 	err := cmd.Execute()
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(svc.CreateFnInvoked, qt.IsFalse)
-
 }
 
 func TestPassword_CreateCmd_DefaultRoleAdmin(t *testing.T) {
@@ -146,7 +143,6 @@ func TestPassword_CreateCmd_DefaultRoleAdmin(t *testing.T) {
 			return &ps.Client{
 				Passwords: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/password/delete_test.go
+++ b/internal/cmd/password/delete_test.go
@@ -47,7 +47,6 @@ func TestPassword_DeleteCmd(t *testing.T) {
 			return &ps.Client{
 				Passwords: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/password/list_test.go
+++ b/internal/cmd/password/list_test.go
@@ -50,7 +50,6 @@ func TestPassword_ListCmd(t *testing.T) {
 			return &ps.Client{
 				Passwords: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/region/list_test.go
+++ b/internal/cmd/region/list_test.go
@@ -45,7 +45,6 @@ func TestRegion_ListCmd(t *testing.T) {
 			return &ps.Client{
 				Organizations: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/signup/signup.go
+++ b/internal/cmd/signup/signup.go
@@ -50,7 +50,7 @@ func SignupCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			ch.Printer.Println("You are registering a new PlanetScale account.")
 
-			var qs = []*survey.Question{
+			qs := []*survey.Question{
 				{
 					Name:     "email",
 					Prompt:   &survey.Input{Message: "What is your e-mail?"},
@@ -143,7 +143,6 @@ func SignupCmd(ch *cmdutil.Helper) *cobra.Command {
 			ch.Printer.Println("\nYou've successfully signed up for PlanetScale!\nPlease check your email for a confirmation link and then get started with `pscale auth login`. ")
 
 			return nil
-
 		},
 	}
 

--- a/internal/cmd/token/addaccess_test.go
+++ b/internal/cmd/token/addaccess_test.go
@@ -60,7 +60,6 @@ func TestServiceToken_AddAccessCmd(t *testing.T) {
 			return &ps.Client{
 				ServiceTokens: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/token/create_test.go
+++ b/internal/cmd/token/create_test.go
@@ -43,7 +43,6 @@ func TestServiceToken_CreateCmd(t *testing.T) {
 			return &ps.Client{
 				ServiceTokens: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/token/delete_test.go
+++ b/internal/cmd/token/delete_test.go
@@ -42,7 +42,6 @@ func TestServiceToken_DeleteCmd(t *testing.T) {
 			return &ps.Client{
 				ServiceTokens: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/token/deleteaccess_test.go
+++ b/internal/cmd/token/deleteaccess_test.go
@@ -46,7 +46,6 @@ func TestServiceToken_DeleteAccessCmd(t *testing.T) {
 			return &ps.Client{
 				ServiceTokens: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/token/list_test.go
+++ b/internal/cmd/token/list_test.go
@@ -44,7 +44,6 @@ func TestServiceToken_ListCmd(t *testing.T) {
 			return &ps.Client{
 				ServiceTokens: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/token/showaccess_test.go
+++ b/internal/cmd/token/showaccess_test.go
@@ -61,7 +61,6 @@ func TestServiceToken_ShowAccess(t *testing.T) {
 			return &ps.Client{
 				ServiceTokens: svc,
 			}, nil
-
 		},
 	}
 

--- a/internal/cmd/token/token.go
+++ b/internal/cmd/token/token.go
@@ -49,6 +49,7 @@ func toServiceToken(st *ps.ServiceToken) *ServiceToken {
 		orig:  st,
 	}
 }
+
 func toServiceTokens(serviceTokens []*ps.ServiceToken) []*ServiceToken {
 	snapshots := make([]*ServiceToken, 0, len(serviceTokens))
 

--- a/internal/cmdutil/errors.go
+++ b/internal/cmdutil/errors.go
@@ -8,8 +8,10 @@ import (
 	"github.com/planetscale/planetscale-go/planetscale"
 )
 
-const ActionRequestedExitCode = 1
-const FatalErrExitCode = 2
+const (
+	ActionRequestedExitCode = 1
+	FatalErrExitCode        = 2
+)
 
 var errExpiredAuthMessage = errors.New("the access token has expired. Please run 'pscale auth login'")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -300,7 +300,7 @@ func writeAccessTokenPath(accessToken string) error {
 
 	_, err = os.Stat(configDir)
 	if os.IsNotExist(err) {
-		err := os.MkdirAll(configDir, 0771)
+		err := os.MkdirAll(configDir, 0o771)
 		if err != nil {
 			return errors.New("error creating config directory")
 		}

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -77,7 +77,7 @@ func (f *FileConfig) Write(path string) error {
 		return fmt.Errorf("can't marshal file config: %s", err)
 	}
 
-	return os.WriteFile(path, d, 0644)
+	return os.WriteFile(path, d, 0o644)
 }
 
 // WriteDefault creates the config directory and persists the file config
@@ -90,7 +90,7 @@ func (f *FileConfig) WriteDefault() error {
 
 	_, err = os.Stat(configDir)
 	if os.IsNotExist(err) {
-		err := os.MkdirAll(configDir, 0771)
+		err := os.MkdirAll(configDir, 0o771)
 		if err != nil {
 			return errors.New("error creating config directory")
 		}

--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -159,7 +159,6 @@ func (d *Dumper) Run(ctx context.Context) error {
 				if err != nil {
 					d.log.Error("error dumping table", zap.Error(err))
 				}
-
 			}(conn, database, table)
 		}
 	}
@@ -402,7 +401,6 @@ func (d *Dumper) dumpableFieldNames(conn *Connection, table string) ([]string, e
 	qr, err := conn.Fetch(fmt.Sprintf("SHOW FIELDS FROM `%s`", table))
 	if err != nil {
 		return nil, err
-
 	}
 
 	fields := make([]string, 0, len(qr.Rows))

--- a/internal/mock/servicetoken.go
+++ b/internal/mock/servicetoken.go
@@ -57,7 +57,6 @@ func (s *ServiceTokenService) AddAccess(ctx context.Context, req *ps.AddServiceT
 func (s *ServiceTokenService) DeleteAccess(ctx context.Context, req *ps.DeleteServiceTokenAccessRequest) error {
 	s.DeleteAccessFnInvoked = true
 	return s.DeleteAccessFn(ctx, req)
-
 }
 
 func (s *ServiceTokenService) ListGrants(ctx context.Context, req *ps.ListServiceTokenGrantsRequest) ([]*ps.ServiceTokenGrant, error) {

--- a/internal/proxyutil/remotesource.go
+++ b/internal/proxyutil/remotesource.go
@@ -28,8 +28,10 @@ func NewRemoteCertSource(client *ps.Client, role cmdutil.PasswordRole) *RemoteCe
 	}
 }
 
-const publicIdAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
-const publicIdLength = 6
+const (
+	publicIdAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+	publicIdLength   = 6
+)
 
 func (r *RemoteCertSource) Cert(ctx context.Context, org, db, branch string) (*proxy.Cert, error) {
 	pkey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -144,7 +144,6 @@ func checkVersion(
 			info.Version, buildVersion),
 		ReleaseInfo: info,
 	}, nil
-
 }
 
 func latestVersion(ctx context.Context, addr string) (*ReleaseInfo, error) {
@@ -218,7 +217,7 @@ func setStateEntry(stateFilePath string, t time.Time, r ReleaseInfo) error {
 	if err != nil {
 		return err
 	}
-	_ = os.WriteFile(stateFilePath, content, 0600)
+	_ = os.WriteFile(stateFilePath, content, 0o600)
 
 	return nil
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -15,7 +15,7 @@ import (
 func TestLatestVersion(t *testing.T) {
 	c := qt.New(t)
 
-	var tests = []struct {
+	tests := []struct {
 		name       string
 		resp       *ReleaseInfo
 		statusCode int
@@ -50,16 +50,14 @@ func TestLatestVersion(t *testing.T) {
 				c.Assert(err, qt.IsNil)
 				c.Assert(info, qt.DeepEquals, tt.resp)
 			}
-
 		})
 	}
-
 }
 
 func TestCheckVersion(t *testing.T) {
 	c := qt.New(t)
 
-	var tests = []struct {
+	tests := []struct {
 		name          string
 		buildVersion  string
 		latestVersion string
@@ -95,7 +93,6 @@ func TestCheckVersion(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-
 			dir := t.TempDir()
 			path := filepath.Join(dir, "state.yml")
 
@@ -115,8 +112,6 @@ func TestCheckVersion(t *testing.T) {
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(updateInfo.Update, qt.Equals, tt.update, qt.Commentf("reason: %s", updateInfo.Reason))
-
 		})
 	}
-
 }


### PR DESCRIPTION
This formatter cleans up weird inconsistencies in Go code and applies simplifications where possible.

https://github.com/mvdan/gofumpt