### PR TITLE
cmd/api: a command to write authenticated API requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/99designs/keyring v1.2.2
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/adrg/xdg v0.4.0
 	github.com/benbjohnson/clock v1.3.5
 	github.com/briandowns/spinner v1.23.0
@@ -29,6 +30,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/xelabs/go-mysqlstack v1.0.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/oauth2 v0.9.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.10.0
 	golang.org/x/text v0.11.0
@@ -70,7 +72,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.11.0 // indirect
-	golang.org/x/oauth2 v0.9.0 // indirect
 	golang.org/x/term v0.9.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkk
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -1,0 +1,332 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"net/http/httputil"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/pkg/errors"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+type ApiOpts struct {
+	Method    string
+	Query     []string
+	Header    []string
+	Field     []string
+	Input     string
+	ReadStdin bool
+}
+
+// ApiCmd helps users perform API calls using the CLI.
+func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "api <endpoint>",
+		Short: "Performs authenticated calls against the PlanetScale API. Useful for scripting.",
+		Long: heredoc.Docf(`Performs authenticated calls against the PlanetScale API and prints the response to stdout.
+
+		ENDPOINT
+
+			The endpoint should be a path for the v1 PlanetScale API, not including the "v1" prefix. The placeholder "{org}",
+			"{db}" and "{branch}" will be replaced with the currently selected organization, and the project's database and
+			branch. If invoked from outside a project, "{db}" and "{branch}" yield an empty string.
+
+			Query parameters, such as for pagination, can be added with the --query/-Q flag, in "key=value" format.
+			By default, all HTTP requests use the GET method, unless fields for the body are passed via --field/-F, in which
+			case a POST method is used. If another method is required, use the --method/-X flag to specify which one to use.
+
+		HEADERS
+
+			Use the --header/-H flag to specify headers manually. Default headers are already included such as "User-Agent",
+			"Content-Type", "Accept" and "Authorization".
+
+		BODY
+
+			If a body is required for the endpoint you're targeting, the --field/-F flag allows you to specify values at specific
+			paths of a JSON document. Repeat the flag to set multiple values. All bodies sent are JSON objects, it isn't possible
+			to send non JSON content, or JSON entities of non-object type as the root of the body.
+
+			If you wish to pass the content of a file as body, use the --input/-I flag. If the body should be read from stdin,
+			use --input="-".
+
+			Fields specified with --field/-F will be updated in the content of --input/-I if the content is JSON. If not, an error
+			will be returned.
+		`),
+		Example: heredoc.Docf(`
+		# get the current user
+
+		$ pscale api user
+
+		# list an org's databases
+
+		$ pscale api organizations/{org}/databases
+
+		# create a database
+
+		$ pscale api organizations/{org}/databases -F 'name="my-database"'
+
+		# get a database
+
+		$ pscale api organizations/{org}/databases/my-database
+
+		# delete a database
+
+		$ pscale api -X DELETE organizations/{org}/databases/my-database
+
+		# add a note on a database from the content of a file
+
+		$ pscale api -X PATCH organizations/{org}/databases/{db} -F 'notes=@mynotes.txt'
+
+		# create a database branch from a file
+
+		$ pscale api organizations/{org}/databases/{db}/branches --input=spec.json
+
+		# create a database branch from stdin, override the name
+
+		$ pscale api organizations/{org}/databases/{db}/branches --input=- -F 'name="my-name"'
+
+		`),
+		Args:              cobra.ExactArgs(1),
+		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
+	}
+
+	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
+	cmd.PersistentFlags().StringVar(&ch.Config.Database, "database", ch.Config.Database, "The database this project is using")
+	cmd.PersistentFlags().StringVar(&ch.Config.Branch, "branch", ch.Config.Branch, "The branch this project is using")
+
+	opts := &ApiOpts{}
+	cmd.Flags().StringVarP(&opts.Method, "method", "X", "GET", "HTTP method to use for the request.  Defaults to GET for requests without a body, or POST when a body is specified with `--field/-F` or `--input/-I`")
+	cmd.Flags().StringArrayVarP(&opts.Query, "query", "Q", nil, "query to append to the URL path, in `key=value` format")
+	cmd.Flags().StringArrayVarP(&opts.Header, "header", "H", nil, "HTTP headers to add to the request")
+	cmd.Flags().StringArrayVarP(&opts.Field, "field", "F", nil, "HTTP body to send with the request, in `key=value` format where `value` is a JSON entity, unless `value` starts with a `@` in which case the string after `@` represents a file that will be read. Nested types are represented as `root.depth1.depth2=value``")
+	cmd.Flags().StringVarP(&opts.Input, "input", "I", "", "HTTP body to send with the request, as a file that will be read and then sent.")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		method := opts.Method
+		if !cmd.Flags().Changed("method") && len(opts.Field) > 0 {
+			method = http.MethodPost
+		}
+
+		u, err := parseURL(ch, opts, args[0])
+		if err != nil {
+			return errors.Wrap(err, "parsing URL")
+		}
+
+		body, err := parseBody(opts)
+		if err != nil {
+			return errors.Wrap(err, "parsing HTTP request body")
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
+		if err != nil {
+			return errors.Wrap(err, "preparing HTTP request")
+		}
+
+		req.Header, err = parseHeader(opts, req.Method, userAgent, defaultHeaders)
+		if err != nil {
+			return errors.Wrap(err, "parsing HTTP request header")
+		}
+
+		if ch.Debug() {
+			debugReq, err := httputil.DumpRequestOut(req, true)
+			if err != nil {
+				return errors.Wrap(err, "dumping request output")
+			}
+			debugReq = append(debugReq, '\n')
+			_, err = os.Stderr.Write(debugReq)
+			if err != nil {
+				return errors.Wrap(err, "writing request output to stderr")
+			}
+		}
+
+		var cl *http.Client
+		if ch.Config.AccessToken != "" {
+			tok := &oauth2.Token{AccessToken: ch.Config.AccessToken}
+			cl = oauth2.NewClient(ctx, oauth2.StaticTokenSource(tok))
+		} else if ch.Config.ServiceToken != "" && ch.Config.ServiceTokenID != "" {
+			req.Header.Set("Authorization", ch.Config.ServiceTokenID+":"+ch.Config.ServiceToken)
+			cl = &http.Client{}
+		}
+		res, err := cl.Do(req)
+		if err != nil {
+			return errors.Wrap(err, "sending HTTP request")
+		}
+		defer res.Body.Close()
+
+		if _, err := io.Copy(os.Stdout, res.Body); err != nil {
+			return errors.Wrap(err, "reading HTTP response body")
+		}
+
+		if res.StatusCode > 399 {
+			return errors.Errorf("HTTP %s", res.Status)
+		}
+
+		return nil
+	}
+
+	return cmd
+}
+
+func parseURL(ch *cmdutil.Helper, opts *ApiOpts, endpoint string) (*url.URL, error) {
+	reqPath := endpoint
+	reqPath = strings.ReplaceAll(reqPath, `{org}`, ch.Config.Organization)
+	reqPath = strings.ReplaceAll(reqPath, `{db}`, ch.Config.Database)
+	reqPath = strings.ReplaceAll(reqPath, `{branch}`, ch.Config.Branch)
+
+	u, err := url.Parse(ch.Config.BaseURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing base URL")
+	}
+	u = u.ResolveReference(&url.URL{Path: path.Join("v1", reqPath)})
+
+	if len(opts.Query) > 0 {
+		for _, param := range opts.Query {
+			k, v, ok := strings.Cut(param, "=")
+			if !ok {
+				return nil, errors.Wrapf(err, "parsing query param %q", param)
+			}
+			q := u.Query()
+			q.Add(k, v)
+			u.RawQuery = q.Encode()
+		}
+	}
+	return u, nil
+}
+
+func parseHeader(opts *ApiOpts, method, userAgent string, defaultHeaders map[string]string) (http.Header, error) {
+	out := make(http.Header)
+	for k, v := range defaultHeaders {
+		out.Set(k, v)
+	}
+	out.Set("User-Agent", userAgent)
+	switch method {
+	case http.MethodGet:
+		out.Set("Accept", "application/json")
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		out.Set("Accept", "application/json")
+		out.Set("Content-Type", "application/json")
+	}
+	for _, header := range opts.Header {
+		k, v, ok := strings.Cut(header, ":")
+		if !ok {
+			return nil, errors.Errorf("invalid header: %q", header)
+		}
+		out.Set(k, strings.TrimPrefix(v, " "))
+	}
+	return out, nil
+}
+
+func parseBody(opts *ApiOpts) (io.Reader, error) {
+	if opts.Input == "" && len(opts.Field) == 0 {
+		return nil, nil
+	}
+
+	var (
+		bodyMap map[string]interface{}
+		raw     []byte
+		err     error
+	)
+	if opts.Input != "" {
+		if opts.Input == "-" {
+			raw, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, errors.Wrap(err, "reading body from stdin")
+			}
+		} else {
+			raw, err = os.ReadFile(opts.Input)
+			if err != nil {
+				return nil, errors.Wrapf(err, "reading body from file %q", opts.Input)
+			}
+		}
+	}
+	if len(raw) > 0 {
+		bodyMap = make(map[string]interface{})
+		if err := json.Unmarshal(raw, &bodyMap); err != nil {
+			// body wasn't JSON
+			if len(opts.Field) > 0 {
+				return nil, errors.Wrap(err, "parsing input as JSON (--field/-F was specified)")
+			}
+
+			return bytes.NewReader(raw), nil
+		}
+		// body is JSON, continue and append to it with values in `--field`
+	}
+
+	bodyMap, err = parseFields(bodyMap, opts.Field)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing body field")
+	}
+	if bodyMap != nil {
+		jsonBody, err := json.MarshalIndent(bodyMap, "", "\t")
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing body field")
+		}
+		return bytes.NewReader(jsonBody), nil
+	}
+	return nil, nil
+}
+
+func parseFields(out map[string]interface{}, fields []string) (map[string]interface{}, error) {
+	if out == nil {
+		out = make(map[string]interface{}, len(fields))
+	}
+	for _, field := range fields {
+		err := parseFieldInto(out, field)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing field %q", field)
+		}
+	}
+	return out, nil
+}
+
+func parseFieldInto(tgt map[string]interface{}, field string) error {
+	k, v, ok := strings.Cut(field, "=")
+	if !ok {
+		return errors.Errorf("no `=` found in field %q", field)
+	}
+	paths := strings.Split(k, ".")
+
+	tail := tgt
+
+	lastPath := paths[len(paths)-1]
+	for _, path := range paths[:len(paths)-1] {
+		nextTail, ok := tail[path].(map[string]interface{})
+		if !ok {
+			nextTail = make(map[string]interface{})
+		}
+		tail[path] = nextTail
+		tail = nextTail
+	}
+	parsed, err := parseValue(v)
+	if err != nil {
+		return errors.Wrapf(err, "parsing value of field %q", field)
+	}
+	tail[lastPath] = parsed
+	return nil
+}
+
+func parseValue(s string) (interface{}, error) {
+	if len(s) > 0 && s[0] == '@' {
+		filename := s[1:]
+		value, err := os.ReadFile(filename)
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading value %q as file", s)
+		}
+		return string(value), nil
+	}
+
+	var v interface{}
+	return v, json.Unmarshal([]byte(s), &v)
+}

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseField(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []string
+		init   map[string]interface{}
+		want   map[string]interface{}
+	}{
+		{
+			name: "fields only",
+			fields: []string{
+				"hello.world=1",
+				"hello.monde=2",
+				`salut="le monde"`,
+			},
+			want: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": float64(1),
+					"monde": float64(2),
+				},
+				"salut": "le monde",
+			},
+		},
+		{
+			name: "update from fields",
+			init: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"monde": float64(42),
+				},
+				"salut": "fred",
+				"bye":   "ivon",
+			},
+			fields: []string{
+				"hello.world=1",
+				"hello.monde=2",
+				`salut="le monde"`,
+			},
+			want: map[string]interface{}{
+				"hello": map[string]interface{}{
+					"world": float64(1),
+					"monde": float64(2),
+				},
+				"salut": "le monde",
+				"bye":   "ivon",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := parseFields(tt.init, tt.fields)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, out)
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/planetscale/cli/internal/cmd/dataimports"
 
 	"github.com/fatih/color"
+	"github.com/planetscale/cli/internal/cmd/api"
 	"github.com/planetscale/cli/internal/cmd/auditlog"
 	"github.com/planetscale/cli/internal/cmd/auth"
 	"github.com/planetscale/cli/internal/cmd/backup"
@@ -143,16 +144,16 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 		return err
 	}
 
+	userAgent := "pscale-cli/" + ver
+	headers := map[string]string{
+		"pscale-cli-version": ver,
+	}
+
 	ch := &cmdutil.Helper{
 		Printer:  printer.NewPrinter(format),
 		Config:   cfg,
 		ConfigFS: config.NewConfigFS(osFS{}),
 		Client: func() (*ps.Client, error) {
-			userAgent := "pscale-cli/" + ver
-
-			headers := map[string]string{
-				"pscale-cli-version": ver,
-			}
 			return cfg.NewClientFromConfig(ps.WithUserAgent(userAgent), ps.WithRequestHeaders(headers))
 		},
 	}
@@ -183,6 +184,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 
 	rootCmd.AddCommand(loginCmd)
 	rootCmd.AddCommand(logoutCmd)
+	rootCmd.AddCommand(api.ApiCmd(ch, userAgent, headers))
 	rootCmd.AddCommand(auditlog.AuditLogCmd(ch))
 	rootCmd.AddCommand(auth.AuthCmd(ch))
 	rootCmd.AddCommand(backup.BackupCmd(ch))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ func (c *Config) IsAuthenticated() error {
 	return nil
 }
 
-// NewClientFromConfig creates a PlaentScale API client from our configuration
+// NewClientFromConfig creates a PlanetScale API client from our configuration
 func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client, error) {
 	opts := []ps.ClientOption{
 		ps.WithBaseURL(c.BaseURL),


### PR DESCRIPTION
`pscale api ...` makes it easy to write API requests in scripts without having to use `curl` and manage reading credentials from the environment.

```
$ pscale api --help
Performs authenticated calls against the PlanetScale API and prints the response to stdout.

ENDPOINT

        The endpoint should be a path for the v1 PlanetScale API, not including the "v1" prefix. The placeholder "{org}",
        "{db}" and "{branch}" will be replaced with the currently selected organization, and the project's database and
        branch. If invoked from outside a project, "{db}" and "{branch}" yield an empty string.

        Query parameters, such as for pagination, can be added with the --query/-Q flag, in "key=value" format.
        By default, all HTTP requests use the GET method, unless fields for the body are passed via --field/-F, in which
        case a POST method is used. If another method is required, use the --method/-X flag to specify which one to use.

HEADERS

        Use the --header/-H flag to specify headers manually. Default headers are already included such as "User-Agent",
        "Content-Type", "Accept" and "Authorization".

BODY

        If a body is required for the endpoint you're targeting, the --field/-F flag allows you to specify values at specific
        paths of a JSON document. Repeat the flag to set multiple values. All bodies sent are JSON objects, it isn't possible
        to send non JSON content, or JSON entities of non-object type as the root of the body.

        If you wish to pass the content of a file as body, use the --input/-I flag. If the body should be read from stdin,
        use --input="-".

        Fields specified with --field/-F will be updated in the content of --input/-I if the content is JSON. If not, an error
        will be returned.

Usage:
  pscale api <endpoint> [flags]

Examples:
# get the current user

$ pscale api user

# list an org's databases

$ pscale api organizations/{org}/databases

# create a database

$ pscale api organizations/{org}/databases -F 'name="my-database"'

# get a database

$ pscale api organizations/{org}/databases/my-database

# delete a database

$ pscale api -X DELETE organizations/{org}/databases/my-database

# add a note on a database from the content of a file

$ pscale api -X PATCH organizations/{org}/databases/{db} -F 'notes=@mynotes.txt'

# create a database branch from a file

$ pscale api organizations/{org}/databases/{db}/branches --input=spec.json

# create a database branch from stdin, override the name

$ pscale api organizations/{org}/databases/{db}/branches --input=- -F 'name="my-name"'



Flags:
      --branch string        The branch this project is using
      --database string      The database this project is using
  -F, --field key=value      HTTP body to send with the request, in key=value format where `value` is a JSON entity, unless `value` starts with a `@` in which case the string after `@` represents a file that will be read. Nested types are represented as `root.depth1.depth2=value``
  -H, --header stringArray   HTTP headers to add to the request
  -h, --help                 help for api
  -I, --input string         HTTP body to send with the request, as a file that will be read and then sent.
  -X, --method string        HTTP method to use for the request (default "GET")
      --org string           The organization for the current user
  -Q, --query key=value      query to append to the URL path, in key=value format

Global Flags:
      --api-token string          The API token to use for authenticating against the PlanetScale API.
      --api-url string            The base URL for the PlanetScale API. (default "https://api.planetscale.com/")
      --config string             Config file (default is $HOME/.config/planetscale/pscale.yml)
      --debug                     Enable debug mode
  -f, --format string             Show output in a specific format. Possible values: [human, json, csv] (default "human")
      --no-color                  Disable color output
      --service-token string      Service Token for authenticating.
      --service-token-id string   The Service Token ID for authenticating.
```