### PR TITLE
Add ability to `deploy-request show` by branch name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.88.0
+	github.com/planetscale/planetscale-go v0.89.0
 	github.com/planetscale/sql-proxy v0.13.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qR
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
 github.com/planetscale/planetscale-go v0.88.0 h1:CJ9abIDFD6UT8nKuykvvYDQNF06jHz/08/As7v0saNg=
 github.com/planetscale/planetscale-go v0.88.0/go.mod h1:U9jqlqAgN1ErFWHmTcSC/0mEUgCl+AF3b9BatuUSzf0=
+github.com/planetscale/planetscale-go v0.89.0 h1:oU6aAy4FW22cOXBUkwjyHfsacMxxDYwvRB+MD3K1Pvk=
+github.com/planetscale/planetscale-go v0.89.0/go.mod h1:U9jqlqAgN1ErFWHmTcSC/0mEUgCl+AF3b9BatuUSzf0=
 github.com/planetscale/sql-proxy v0.13.0 h1:NDjcdqgoNzwbZQTyoIDEoI+K7keC5RRKvdML2roAMn4=
 github.com/planetscale/sql-proxy v0.13.0/go.mod h1:4Sk6JdoBqQhHv9V4FCOC27YIM3EjU8cLIsw5HqxN8x4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -295,6 +297,7 @@ go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
+go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/internal/cmd/deployrequest/show.go
+++ b/internal/cmd/deployrequest/show.go
@@ -19,33 +19,56 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "show <database> <number>",
+		Use:   "show <database> <number|branch>",
 		Short: "Show a specific deploy request",
-		Args:  cmdutil.RequiredArgs("database", "number"),
+		Args:  cmdutil.RequiredArgs("database", "number|branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database := args[0]
-			number := args[1]
-
-			if flags.web {
-				ch.Printer.Println("🌐  Redirecting you to your deploy request in your web browser.")
-				return browser.OpenURL(fmt.Sprintf("%s/%s/%s/deploy-requests/%s", cmdutil.ApplicationURL, ch.Config.Organization, database, number))
-			}
+			number_or_branch := args[1]
+			var number uint64
 
 			client, err := ch.Client()
 			if err != nil {
 				return err
 			}
 
-			n, err := strconv.ParseUint(number, 10, 64)
+			number, err = strconv.ParseUint(number_or_branch, 10, 64)
+
+			// Not a valid number, try branch name
 			if err != nil {
-				return fmt.Errorf("the argument <number> is invalid: %s", err)
+				deployRequests, err := client.DeployRequests.List(ctx, &planetscale.ListDeployRequestsRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+					Branch:       number_or_branch,
+				})
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case planetscale.ErrNotFound:
+						return fmt.Errorf("database %s does not exist in organization %s",
+							printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+					default:
+						return cmdutil.HandleError(err)
+					}
+				}
+
+				// if there are no deploy requests, return an error
+				if len(deployRequests) == 0 {
+					return fmt.Errorf("no deploy requests found for branch %s", printer.BoldBlue(number_or_branch))
+				}
+
+				number = deployRequests[0].Number
+			}
+
+			if flags.web {
+				ch.Printer.Println("🌐  Redirecting you to your deploy request in your web browser.")
+				return browser.OpenURL(fmt.Sprintf("%s/%s/%s/deploy-requests/%s", cmdutil.ApplicationURL, ch.Config.Organization, database, strconv.FormatUint(number, 10)))
 			}
 
 			dr, err := client.DeployRequests.Get(ctx, &planetscale.GetDeployRequestRequest{
 				Organization: ch.Config.Organization,
 				Database:     database,
-				Number:       n,
+				Number:       number,
 			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {

--- a/internal/cmd/deployrequest/show_test.go
+++ b/internal/cmd/deployrequest/show_test.go
@@ -59,3 +59,60 @@ func TestDeployRequest_ShowCmd(t *testing.T) {
 	res := &DeployRequest{Number: number}
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
+
+func TestDeployRequest_ShowBranchName(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	var number uint64 = 10
+	var branchName string = "dev"
+
+	svc := &mock.DeployRequestsService{
+		GetFn: func(ctx context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Number, qt.Equals, number)
+
+			return &ps.DeployRequest{Number: number}, nil
+		},
+		ListFn: func(ctx context.Context, req *ps.ListDeployRequestsRequest) ([]*ps.DeployRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branchName)
+
+			return []*ps.DeployRequest{
+				{
+					Number: number,
+				},
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DeployRequests: svc,
+			}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branchName})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+
+	res := &DeployRequest{Number: number}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}


### PR DESCRIPTION
For: https://github.com/planetscale/cli/issues/702

When automating workflows, we don't always have the DR number. This allows us to lookup a DR by the `branch` name (head branch).