### PR TITLE
Add ability to deploy DR by branch name

### DIFF
--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -39,28 +39,10 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			// Not a valid number, try branch name
 			if err != nil {
-				deployRequests, err := client.DeployRequests.List(ctx, &planetscale.ListDeployRequestsRequest{
-					Organization: ch.Config.Organization,
-					Database:     database,
-					Branch:       number_or_branch,
-					State:        "open",
-				})
+				number, err = cmdutil.DeployRequestBranchToNumber(ctx, client, ch.Config.Organization, database, number_or_branch, "open")
 				if err != nil {
-					switch cmdutil.ErrCode(err) {
-					case planetscale.ErrNotFound:
-						return fmt.Errorf("database %s does not exist in organization %s",
-							printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-					default:
-						return cmdutil.HandleError(err)
-					}
+					return err
 				}
-
-				// if there are no deploy requests, return an error
-				if len(deployRequests) == 0 {
-					return fmt.Errorf("no open deploy requests found for branch %s", printer.BoldBlue(number_or_branch))
-				}
-
-				number = deployRequests[0].Number
 			}
 
 			dr, err := client.DeployRequests.Deploy(ctx, &planetscale.PerformDeployRequest{

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -21,29 +21,54 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "deploy <database> <number>",
+		Use:   "deploy <database> <number|branch>",
 		Short: "Deploy a specific deploy request",
-		Args:  cmdutil.RequiredArgs("database", "number"),
+		Args:  cmdutil.RequiredArgs("database", "number|branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database := args[0]
-			number := args[1]
+			number_or_branch := args[1]
+			var number uint64
 
 			client, err := ch.Client()
 			if err != nil {
 				return err
 			}
 
-			n, err := strconv.ParseUint(number, 10, 64)
+			number, err = strconv.ParseUint(number_or_branch, 10, 64)
+
+			// Not a valid number, try branch name
 			if err != nil {
-				return fmt.Errorf("the argument <number> is invalid: %s", err)
+				deployRequests, err := client.DeployRequests.List(ctx, &planetscale.ListDeployRequestsRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+					Branch:       number_or_branch,
+					State:        "open",
+				})
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case planetscale.ErrNotFound:
+						return fmt.Errorf("database %s does not exist in organization %s",
+							printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+					default:
+						return cmdutil.HandleError(err)
+					}
+				}
+
+				// if there are no deploy requests, return an error
+				if len(deployRequests) == 0 {
+					return fmt.Errorf("no open deploy requests found for branch %s", printer.BoldBlue(number_or_branch))
+				}
+
+				number = deployRequests[0].Number
 			}
 
 			dr, err := client.DeployRequests.Deploy(ctx, &planetscale.PerformDeployRequest{
 				Organization: ch.Config.Organization,
 				Database:     database,
-				Number:       n,
+				Number:       number,
 			})
+
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
@@ -62,7 +87,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 				getReq := &planetscale.GetDeployRequestRequest{
 					Organization: ch.Config.Organization,
 					Database:     database,
-					Number:       n,
+					Number:       number,
 				}
 				state, err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq)
 				if err != nil {

--- a/internal/cmd/deployrequest/deploy_test.go
+++ b/internal/cmd/deployrequest/deploy_test.go
@@ -59,3 +59,60 @@ func TestDeployRequest_DeployCmd(t *testing.T) {
 	res := &DeployRequest{Number: number}
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
+
+func TestDeployRequest_DeployBranchName(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	var number uint64 = 10
+	var branchName string = "dev"
+
+	svc := &mock.DeployRequestsService{
+		DeployFn: func(ctx context.Context, req *ps.PerformDeployRequest) (*ps.DeployRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Number, qt.Equals, number)
+
+			return &ps.DeployRequest{Number: number}, nil
+		},
+		ListFn: func(ctx context.Context, req *ps.ListDeployRequestsRequest) ([]*ps.DeployRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branchName)
+
+			return []*ps.DeployRequest{
+				{
+					Number: number,
+				},
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DeployRequests: svc,
+			}, nil
+		},
+	}
+
+	cmd := DeployCmd(ch)
+	cmd.SetArgs([]string{db, branchName})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.DeployFnInvoked, qt.IsTrue)
+
+	res := &DeployRequest{Number: number}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/cmd/deployrequest/show.go
+++ b/internal/cmd/deployrequest/show.go
@@ -37,27 +37,10 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			// Not a valid number, try branch name
 			if err != nil {
-				deployRequests, err := client.DeployRequests.List(ctx, &planetscale.ListDeployRequestsRequest{
-					Organization: ch.Config.Organization,
-					Database:     database,
-					Branch:       number_or_branch,
-				})
+				number, err = cmdutil.DeployRequestBranchToNumber(ctx, client, ch.Config.Organization, database, number_or_branch, "")
 				if err != nil {
-					switch cmdutil.ErrCode(err) {
-					case planetscale.ErrNotFound:
-						return fmt.Errorf("database %s does not exist in organization %s",
-							printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-					default:
-						return cmdutil.HandleError(err)
-					}
+					return err
 				}
-
-				// if there are no deploy requests, return an error
-				if len(deployRequests) == 0 {
-					return fmt.Errorf("no deploy requests found for branch %s", printer.BoldBlue(number_or_branch))
-				}
-
-				number = deployRequests[0].Number
 			}
 
 			if flags.web {

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -257,7 +257,7 @@ func DeployRequestBranchToNumber(ctx context.Context, client *ps.Client, organiz
 
 	// if there are no deploy requests, return an error
 	if len(deployRequests) == 0 {
-		return 0, fmt.Errorf("no open deploy requests found for branch %s", printer.BoldBlue(branch))
+		return 0, fmt.Errorf("no deploy requests found for branch %s", printer.BoldBlue(branch))
 	}
 
 	return deployRequests[0].Number, nil


### PR DESCRIPTION
Closes: https://github.com/planetscale/cli/issues/702

Allows targeting an open DR by the head branch name. Making it easier to script deploy requests without needing to know the DR number.