### PR TITLE
Add ability to set notes when creating a deploy request

### DIFF
--- a/internal/cmd/deployrequest/create.go
+++ b/internal/cmd/deployrequest/create.go
@@ -13,8 +13,8 @@ import (
 // CreateCmd is the command for creating deploy requests.
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		deployTo string
-		into     string
+		into  string
+		notes string
 	}
 
 	cmd := &cobra.Command{
@@ -34,16 +34,12 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Request deploying of %s branch in %s...", printer.BoldBlue(branch), printer.BoldBlue(database)))
 			defer end()
 
-			into := flags.into
-			if len(into) == 0 && len(flags.deployTo) > 0 {
-				into = flags.deployTo
-			}
-
 			dr, err := client.DeployRequests.Create(ctx, &planetscale.CreateDeployRequestRequest{
 				Organization: ch.Config.Organization,
 				Database:     database,
 				Branch:       branch,
-				IntoBranch:   into,
+				IntoBranch:   flags.into,
+				Notes:        flags.notes,
 			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
@@ -66,9 +62,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&flags.deployTo, "deploy-to", "", "Database branch to deploy into. Defaults to the parent of the branch (if present) or the database's default branch.")
-	cmd.PersistentFlags().MarkDeprecated("deploy-to", "this flag will be removed in a future release. Use --into instead.")
 	cmd.PersistentFlags().StringVar(&flags.into, "into", "", "Branch to deploy into. By default, it's the parent branch (if present) or the database's default branch.")
+	cmd.PersistentFlags().StringVar(&flags.notes, "notes", "", "Notes to include with the deploy request.")
 
 	return cmd
 }

--- a/internal/cmd/deployrequest/create_test.go
+++ b/internal/cmd/deployrequest/create_test.go
@@ -102,55 +102,6 @@ func TestDeployRequest_CreateCmdIntoFlag(t *testing.T) {
 	cmd := CreateCmd(ch)
 	cmd.SetArgs([]string{db, branch})
 	cmd.PersistentFlags().Set("into", "main")
-	cmd.PersistentFlags().Set("deploy-to", "other-branch")
-	err := cmd.Execute()
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
-
-	res := &DeployRequest{Number: number}
-	c.Assert(buf.String(), qt.JSONEquals, res)
-}
-
-func TestDeployRequest_CreateCmdDeprecatedDeployToFlag(t *testing.T) {
-	c := qt.New(t)
-
-	var buf bytes.Buffer
-	format := printer.JSON
-	p := printer.NewPrinter(&format)
-	p.SetResourceOutput(&buf)
-
-	org := "planetscale"
-	db := "planetscale"
-	branch := "development"
-	var number uint64 = 10
-
-	svc := &mock.DeployRequestsService{
-		CreateFn: func(ctx context.Context, req *ps.CreateDeployRequestRequest) (*ps.DeployRequest, error) {
-			c.Assert(req.Organization, qt.Equals, org)
-			c.Assert(req.Database, qt.Equals, db)
-			c.Assert(req.Branch, qt.Equals, branch)
-			c.Assert(req.IntoBranch, qt.Equals, "main", qt.Commentf("value of the '--deploy-to' flag has changed"))
-
-			return &ps.DeployRequest{Number: number}, nil
-		},
-	}
-
-	ch := &cmdutil.Helper{
-		Printer: p,
-		Config: &config.Config{
-			Organization: org,
-		},
-		Client: func() (*ps.Client, error) {
-			return &ps.Client{
-				DeployRequests: svc,
-			}, nil
-		},
-	}
-
-	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db, branch})
-	cmd.PersistentFlags().Set("deploy-to", "main")
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)

--- a/internal/cmd/deployrequest/create_test.go
+++ b/internal/cmd/deployrequest/create_test.go
@@ -25,6 +25,7 @@ func TestDeployRequest_CreateCmd(t *testing.T) {
 	org := "planetscale"
 	db := "planetscale"
 	branch := "development"
+	notes := "notes"
 	var number uint64 = 10
 
 	svc := &mock.DeployRequestsService{
@@ -32,6 +33,7 @@ func TestDeployRequest_CreateCmd(t *testing.T) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Notes, qt.Equals, notes)
 			c.Assert(req.IntoBranch, qt.Equals, "", qt.Commentf("default value of the '--into' flag has changed"))
 
 			return &ps.DeployRequest{Number: number}, nil
@@ -51,7 +53,7 @@ func TestDeployRequest_CreateCmd(t *testing.T) {
 	}
 
 	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db, branch})
+	cmd.SetArgs([]string{db, branch, "--notes", notes})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
Closes: https://github.com/planetscale/cli/issues/696

Also, removed the deprecated "deploy-to" field. It has been deprecated for 6 months. 

```diff
Usage:
  pscale deploy-request create <database> <branch> [flags]

Flags:
  -h, --help           help for create
      --into string    Branch to deploy into. By default, it's the parent branch (if present) or the database's default branch.
+     --notes string   Notes to include with the deploy request.
```