### PR TITLE
Default to empty string for `parent-branch` for `branch switch`

### DIFF
--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -49,7 +49,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 						ch.Config.Database, ch.Config.Organization)
 				}
 
-				end := ch.Printer.PrintProgress(fmt.Sprintf("Branch does not exist, creating %s branch from %s...", printer.BoldBlue(branch), printer.BoldBlue(parentBranch)))
+				end := ch.Printer.PrintProgress(fmt.Sprintf("Branch does not exist, creating %s branch...", printer.BoldBlue(branch)))
 				defer end()
 
 				createReq := &ps.CreateDatabaseBranchRequest{
@@ -105,7 +105,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 		"The organization for the current user")
 	cmd.PersistentFlags().StringVar(&ch.Config.Database, "database", ch.Config.Database,
 		"The database this project is using")
-	cmd.Flags().StringVar(&parentBranch, "parent-branch", "main",
+	cmd.Flags().StringVar(&parentBranch, "parent-branch", "",
 		"parent branch to inherit from if a new branch is being created")
 	cmd.Flags().BoolVar(&autoCreate, "create", false,
 		"if enabled, will automatically create the branch if it does not exist")


### PR DESCRIPTION
Not every user has a default of `main` for their default branch. This pull request leaves this value to be explicitly blank, the API will then branch from whatever the default branch is anyways, so the user doesn't have to type it every time.