### PR TITLE
Fix error handling for enabling safe migrations

### DIFF
--- a/internal/cmd/branch/safe_migrations.go
+++ b/internal/cmd/branch/safe_migrations.go
@@ -51,13 +51,13 @@ func EnableSafeMigrationsCmd(ch *cmdutil.Helper) *cobra.Command {
 				case ps.ErrNotFound:
 					return fmt.Errorf("branch %s does not exist in database %s", printer.BoldBlue(branch), printer.BoldBlue(db))
 				case ps.ErrRetry:
-					lintErrors, err := client.DatabaseBranches.LintSchema(ctx, &ps.LintSchemaRequest{
+					lintErrors, lintErr := client.DatabaseBranches.LintSchema(ctx, &ps.LintSchemaRequest{
 						Organization: ch.Config.Organization,
 						Database:     db,
 						Branch:       branch,
 					})
-					if err != nil {
-						return cmdutil.HandleError(err)
+					if lintErr != nil {
+						return cmdutil.HandleError(lintErr)
 					}
 
 					if len(lintErrors) > 0 {


### PR DESCRIPTION
Given that we had two variables named `err` but in two different scopes, our `err` variable was getting shadowed by the call to `LintSchema`, so it'd return an empty error. This pull request changes the variable names so the shadowing isn't a problem anymore.

Fixes https://github.com/planetscale/cli/issues/720