### PR TITLE
Revise the phrasing of `password delete` subcmd usage to place greater emphasis on the intention of receiving a password ID

### DIFF
--- a/internal/cmd/password/delete.go
+++ b/internal/cmd/password/delete.go
@@ -19,15 +19,15 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:     "delete <database> <branch> <password>",
+		Use:     "delete <database> <branch> <password-id>",
 		Short:   "Delete a branch password",
-		Args:    cmdutil.RequiredArgs("database", "branch", "password"),
+		Args:    cmdutil.RequiredArgs("database", "branch", "password-id"),
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
-			password := args[2]
+			passwordId := args[2]
 
 			client, err := ch.Client()
 			if err != nil {
@@ -39,7 +39,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 					return fmt.Errorf("cannot delete password with the output format %q (run with -force to override)", ch.Printer.Format())
 				}
 
-				confirmationName := fmt.Sprintf("%s/%s/%s", database, branch, password)
+				confirmationName := fmt.Sprintf("%s/%s/%s", database, branch, passwordId)
 				if !printer.IsTTY {
 					return fmt.Errorf("cannot confirm deletion of password %q (run with -force to override)", confirmationName)
 				}
@@ -67,20 +67,20 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting password %s from %s/%s",
-				printer.BoldBlue(password), printer.BoldBlue(database), printer.BoldBlue(branch)))
+				printer.BoldBlue(passwordId), printer.BoldBlue(database), printer.BoldBlue(branch)))
 			defer end()
 
 			err = client.Passwords.Delete(ctx, &ps.DeleteDatabaseBranchPasswordRequest{
 				Organization: ch.Config.Organization,
 				Database:     database,
 				Branch:       branch,
-				PasswordId:   password,
+				PasswordId:   passwordId,
 			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
 					return fmt.Errorf("password %s does not exist in branch %s of %s (organization: %s)",
-						printer.BoldBlue(password), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+						printer.BoldBlue(passwordId), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}
@@ -90,15 +90,15 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Password %s was successfully deleted from %s.\n",
-					printer.BoldBlue(password), printer.BoldBlue(branch))
+					printer.BoldBlue(passwordId), printer.BoldBlue(branch))
 				return nil
 			}
 
 			return ch.Printer.PrintResource(
 				map[string]string{
-					"result":   "password deleted",
-					"password": password,
-					"branch":   branch,
+					"result":      "password deleted",
+					"password_id": passwordId,
+					"branch":      branch,
 				},
 			)
 		},

--- a/internal/cmd/password/delete_test.go
+++ b/internal/cmd/password/delete_test.go
@@ -58,9 +58,9 @@ func TestPassword_DeleteCmd(t *testing.T) {
 	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
 
 	res := map[string]string{
-		"result":   "password deleted",
-		"password": password,
-		"branch":   branch,
+		"result":      "password deleted",
+		"password_id": password,
+		"branch":      branch,
 	}
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }


### PR DESCRIPTION
Following the previous `password delete` subcmd's instruction, I misunderstood that I should pass the password's name instead of its ID, but actually that was wrong. The reason why I did such misoperation is I can only see the password's name on the web UI.
So this patch emphasizes the intention of receiving the password's ID on the subcmd in the usage description.