### PR TITLE
Fix deprecation in release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ release:
 		-v `pwd`:/go/src/${REPO}/${NAME} \
 		-w /go/src/${REPO}/${NAME} \
 		releaser \
-		release --rm-dist ${GORELEASER_EXTRA_ARGS}
+		release --clean ${GORELEASER_EXTRA_ARGS}


### PR DESCRIPTION
```
Flag --rm-dist has been deprecated, please use --clean instead
```