### PR TITLE
Fix: branch switch ignoring --org flag

### DIFF
--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -108,8 +108,6 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization,
-		"The organization for the current user")
 	cmd.PersistentFlags().StringVar(&ch.Config.Database, "database", ch.Config.Database,
 		"The database this project is using")
 	cmd.Flags().StringVar(&parentBranch, "parent-branch", "",


### PR DESCRIPTION
The --org flag is already defined for all `branch` commands.

I found that being defined twice (in branch and in switch) was causing it to be ignored.

Fixes: https://github.com/planetscale/cli/issues/684