### PR TITLE
Improve error message when using `service-token` with a ServiceToken

### DIFF
--- a/internal/cmd/token/token.go
+++ b/internal/cmd/token/token.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Service token endpoints cannot be accessed when authed with a service token.
+// If a user tries, show them this error message.
 func checkServiceToken(cmd *cobra.Command, args []string, ch *cmdutil.Helper) error {
 	if ch.Config.ServiceTokenIsSet() {
 		return fmt.Errorf("%s is unavailable when authenticated with a service token", printer.BoldBlue(cmd.CommandPath()))

--- a/internal/cmd/token/token_test.go
+++ b/internal/cmd/token/token_test.go
@@ -1,0 +1,29 @@
+package token
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestServiceToken_TokenCmd_ServiceTokenAuth(t *testing.T) {
+	c := qt.New(t)
+
+	ch := &cmdutil.Helper{
+		Config: &config.Config{
+			ServiceTokenID: "token-id",
+			ServiceToken:   "token",
+		},
+	}
+
+	cmd := TokenCmd(ch)
+	userCommand := &cobra.Command{}
+
+	err := cmd.PersistentPreRunE(userCommand, []string{})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, " is unavailable when authenticated with a service token")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,7 +56,7 @@ func (c *Config) IsAuthenticated() error {
 		return errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
-	if c.ServiceToken != "" && c.ServiceTokenID != "" {
+	if c.ServiceTokenIsSet() {
 		return nil
 	}
 
@@ -65,6 +65,10 @@ func (c *Config) IsAuthenticated() error {
 	}
 
 	return nil
+}
+
+func (c *Config) ServiceTokenIsSet() bool {
+	return c.ServiceToken != "" && c.ServiceTokenID != ""
 }
 
 // NewClientFromConfig creates a PlanetScale API client from our configuration
@@ -77,7 +81,7 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
-	if c.ServiceToken != "" && c.ServiceTokenID != "" {
+	if c.ServiceTokenIsSet() {
 		opts = append(opts, ps.WithServiceToken(c.ServiceTokenID, c.ServiceToken))
 	} else {
 		opts = append(opts, ps.WithAccessToken(c.AccessToken))


### PR DESCRIPTION
Service tokens do not have access to any of the service token endpoints (so that they cannot modify themselves or others)

This improves the error message. Previously it would say "org does not exist".

Context: https://github.com/planetscale/discussion/discussions/565