### PR TITLE
Add ssh to docker for aur publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG DATE
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
 FROM alpine:latest  
-RUN apk --no-cache add ca-certificates mysql-client
+RUN apk --no-cache add ca-certificates mysql-client openssh-client
 EXPOSE 3306
 
 WORKDIR /app


### PR DESCRIPTION
Adding ssh to the dockerfile since go-releaser needs it to publish to aur.