### PR TITLE
Adding ssh to goreleaser dockerfile

### DIFF
--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,5 +1,7 @@
 ARG GORELEASE_CROSS_VERSION=v1.21.3
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
+RUN apt-get update && apt-get install -y openssh-client
+
 ARG SYFT_VERSION=0.94.0
 RUN wget -O syft.deb https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.deb && dpkg -i syft.deb


### PR DESCRIPTION
There are 2 goreleaser dockerfiles, this is the one used in the build