### PR TITLE
Remove root directory Dockerfile for goreleaser.

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,0 @@
-FROM alpine:latest  
-RUN apk --no-cache add ca-certificates mysql-client openssh-client
-EXPOSE 3306
-
-ENTRYPOINT ["/usr/bin/pscale"] 
-COPY pscale /usr/bin


### PR DESCRIPTION
Removes the `Dockerfile.goreleaser` file from the root directory because the source of truth exists in `docker/Dockerfile.goreleaser`.