### PR TITLE
Bump to go1.21.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3 as build
+FROM golang:1.21.5 as build
 WORKDIR /app
 COPY . .
 

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-ARG GORELEASE_CROSS_VERSION=v1.21.3
+ARG GORELEASE_CROSS_VERSION=v1.21.5
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update && apt-get install -y openssh-client


### PR DESCRIPTION
See https://go.dev/doc/devel/release#go1.21.5 for more details.