### PR TITLE
service-token delete-access for Orgs

### DIFF
--- a/internal/cmd/token/deleteaccess.go
+++ b/internal/cmd/token/deleteaccess.go
@@ -18,7 +18,7 @@ func DeleteAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 
 For example, to remove access for a specific database, include the --database flag:
 
-  pscale service-token remove-access <token id> read_branch --database <database name>
+  pscale service-token delete-access <token id> read_branch --database <database name>
 
 To remove an organization level grant:
   

--- a/internal/cmd/token/deleteaccess.go
+++ b/internal/cmd/token/deleteaccess.go
@@ -14,6 +14,15 @@ func DeleteAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete-access <token> <access> <access> ...",
 		Short: "delete access granted to a service token in the organization",
+		Example: `The delete-access command removes an access grant from a service token.
+
+For example, to remove access for a specific database, include the --database flag:
+
+  pscale service-token remove-access <token id> read_branch --database <database name>
+
+To remove an organization level grant:
+  
+  pscale service-token add-access <token id> delete_databases`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			client, err := ch.Client()
@@ -29,19 +38,24 @@ func DeleteAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			req := &planetscale.DeleteServiceTokenAccessRequest{
 				ID:           token,
-				Database:     ch.Config.Database,
 				Organization: ch.Config.Organization,
 				Accesses:     perms,
+			}
+
+			if ch.Config.Database != "" {
+				req.Database = ch.Config.Database
 			}
 
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Removing access %s on database %s", printer.BoldBlue(strings.Join(perms, ", ")), printer.BoldBlue(ch.Config.Database)))
 			defer end()
 
-			if err := client.ServiceTokens.DeleteAccess(ctx, req); err != nil {
+			err = client.ServiceTokens.DeleteAccess(ctx, req)
+
+			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("database %s or token does not exist in organization %s",
-						printer.BoldBlue(ch.Config.Database), printer.BoldBlue(ch.Config.Organization))
+					return fmt.Errorf("token %s does not exist in organization %s.\nPlease run 'pscale service-token list' to see a list of tokens",
+						printer.BoldBlue(token), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}
@@ -50,22 +64,26 @@ func DeleteAccessCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Accesses %v were successfully deleted.\n",
-					printer.BoldBlue(strings.Join(perms, ",")))
+				if len(perms) == 1 {
+					ch.Printer.Printf("%v has been removed.\n",
+						printer.BoldBlue(perms[0]))
+				} else {
+					ch.Printer.Printf("%v have been removed.\n",
+						printer.BoldBlue(strings.Join(perms, ", ")))
+				}
 				return nil
 			}
 
 			return ch.Printer.PrintResource(
 				map[string]string{
-					"result": "accesses deleted",
+					"result": "access removed",
 					"perms":  strings.Join(perms, ","),
 				},
 			)
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&ch.Config.Database, "database", ch.Config.Database, "The database this project is using")
-	cmd.MarkPersistentFlagRequired("database") // nolint:errcheck
+	cmd.PersistentFlags().StringVar(&ch.Config.Database, "database", ch.Config.Database, "The database to remove access to")
 
 	return cmd
 }


### PR DESCRIPTION
Follow up to: https://github.com/planetscale/cli/pull/783

This enables `delete-access` to work for org level permissions.

Now by leaving `--database` off, it will send a delete request for org level token access.

```
➜  cli git:(main) ✗ go run cmd/pscale/main.go service-token delete-access n8in8gt1j23g create_databases delete_databases

create_databases, delete_databases have been removed.
```