### PR TITLE
internal/cmd/ping: allow filtering by provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/frankban/quicktest v1.14.6
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d
+	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.6.0
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
@@ -47,7 +48,6 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/cmd/ping/ping_test.go
+++ b/internal/cmd/ping/ping_test.go
@@ -1,0 +1,135 @@
+package ping
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_processRegions(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		regions  []*ps.Region
+		rd       regionData
+	}{
+		{
+			name: "empty",
+			rd: regionData{
+				Providers:     make(map[string]struct{}),
+				RegionsBySlug: make(map[string]*ps.Region),
+			},
+		},
+		{
+			name: "all providers",
+			regions: []*ps.Region{
+				{
+					Slug:     "aws-us-east-2",
+					Provider: "AWS",
+				},
+				{
+					Slug:     "gcp-us-east4",
+					Provider: "GCP",
+				},
+			},
+			rd: regionData{
+				Providers: map[string]struct{}{
+					"aws": {},
+					"gcp": {},
+				},
+				RegionsBySlug: map[string]*ps.Region{
+					"aws-us-east-2": {
+						Slug:     "aws-us-east-2",
+						Provider: "AWS",
+					},
+					"gcp-us-east4": {
+						Slug:     "gcp-us-east4",
+						Provider: "GCP",
+					},
+				},
+				Endpoints: []string{
+					"aws",
+					"aws-us-east-2",
+					"gcp",
+					"gcp-us-east4",
+				},
+			},
+		},
+		{
+			name:     "AWS",
+			provider: "AWS",
+			regions: []*ps.Region{
+				{
+					Slug:     "aws-us-east-2",
+					Provider: "AWS",
+				},
+				{
+					Slug:     "gcp-us-east4",
+					Provider: "GCP",
+				},
+			},
+			rd: regionData{
+				Providers: map[string]struct{}{
+					"aws": {},
+					"gcp": {},
+				},
+				RegionsBySlug: map[string]*ps.Region{
+					"aws-us-east-2": {
+						Slug:     "aws-us-east-2",
+						Provider: "AWS",
+					},
+					"gcp-us-east4": {
+						Slug:     "gcp-us-east4",
+						Provider: "GCP",
+					},
+				},
+				Endpoints: []string{
+					"aws",
+					"aws-us-east-2",
+				},
+			},
+		},
+		{
+			name:     "GCP",
+			provider: "GCP",
+			regions: []*ps.Region{
+				{
+					Slug:     "aws-us-east-2",
+					Provider: "AWS",
+				},
+				{
+					Slug:     "gcp-us-east4",
+					Provider: "GCP",
+				},
+			},
+			rd: regionData{
+				Providers: map[string]struct{}{
+					"aws": {},
+					"gcp": {},
+				},
+				RegionsBySlug: map[string]*ps.Region{
+					"aws-us-east-2": {
+						Slug:     "aws-us-east-2",
+						Provider: "AWS",
+					},
+					"gcp-us-east4": {
+						Slug:     "gcp-us-east4",
+						Provider: "GCP",
+					},
+				},
+				Endpoints: []string{
+					"gcp",
+					"gcp-us-east4",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Empty(t, cmp.Diff(tt.rd, processRegions(tt.provider, tt.regions)))
+		})
+	}
+}


### PR DESCRIPTION
I wanted to know specifically which GCP region is closest to where I live, so I implemented functionality to filter by IaaS provider for `pscale ping`. Current options are "aws" and "gcp" (and any variation of "AWS", "Aws", etc. due to `strings.EqualFold`).

```
✔ ~/src/github.com/planetscale/cli [mdl-ping|✔] 
10:35 $ pscale ping -p gcp
!! WARNING: You are using a self-compiled binary which is not officially supported.
!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true

  NAME (5)                      LATENCY   ENDPOINT                                         TYPE       
 ----------------------------- --------- ------------------------------------------------ ----------- 
  GCP us-central1               16.2ms    gcp.connect.psdb.cloud                           optimized  
  GCP us-central1               16.3ms    gcp-us-central1.connect.psdb.cloud               direct     
  GCP us-east4                  33.8ms    gcp-us-east4.connect.psdb.cloud                  direct     
  GCP northamerica-northeast1   44ms      gcp-northamerica-northeast1.connect.psdb.cloud   direct     
  GCP asia-northeast3           183.3ms   gcp-asia-northeast3.connect.psdb.cloud           direct     

```

Add some extra test coverage while we're here on the region processing and endpoint generation code.