### PR TITLE
internal/cmd/ping: CLI help and completion improvements

### DIFF
--- a/internal/cmd/ping/ping.go
+++ b/internal/cmd/ping/ping.go
@@ -121,8 +121,15 @@ func PingCmd(ch *cmdutil.Helper) *cobra.Command {
 		5*time.Second, "Timeout for each ping to succeed.")
 	cmd.PersistentFlags().Uint8Var(&flags.concurrency, "concurrency",
 		8, "Number of concurrent pings.")
-	cmd.PersistentFlags().Uint8VarP(&flags.count, "count", "n", 10, "Number of pings")
-	cmd.PersistentFlags().StringVarP(&flags.provider, "provider", "p", "", `Only ping endpoints for the specified infrastructure provider (options: "aws", "gcp").`)
+	cmd.PersistentFlags().Uint8VarP(&flags.count, "count", "n", 10, "Number of total pings.")
+	cmd.PersistentFlags().StringVarP(&flags.provider, "provider", "p", "", `Only ping endpoints for the specified infrastructure provider. Possible values: [aws, gcp]`)
+
+	cmd.RegisterFlagCompletionFunc("provider", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		// We could arguably fetch this data dynamically from the regions list
+		// but it's wasteful given that the IaaS providers list will rarely ever
+		// change. Hardcode to enable easier completion.
+		return []string{"aws", "gcp"}, cobra.ShellCompDirectiveDefault
+	})
 
 	return cmd
 }


### PR DESCRIPTION
Make `--provider` match the help text style of the top-level `--format` flag. Use periods consistently.

```
✔ ~/src/github.com/planetscale/cli/cmd/pscale [main|✚ 1] 
14:09 $ pscale ping --help
Ping public PlanetScale database endpoints

Usage:
  pscale ping [flags]

Flags:
      --concurrency uint8   Number of concurrent pings. (default 8)
  -n, --count uint8         Number of total pings. (default 10)
  -h, --help                help for ping
  -p, --provider string     Only ping endpoints for the specified infrastructure provider. Possible values: [aws, gcp]
      --timeout duration    Timeout for each ping to succeed. (default 5s)

Global Flags:
      --api-token string          The API token to use for authenticating against the PlanetScale API.
      --api-url string            The base URL for the PlanetScale API. (default "https://api.planetscale.com/")
      --config string             Config file (default is $HOME/.config/planetscale/pscale.yml)
      --debug                     Enable debug mode
  -f, --format string             Show output in a specific format. Possible values: [human, json, csv] (default "human")
      --no-color                  Disable color output
      --service-token string      Service Token for authenticating.
      --service-token-id string   The Service Token ID for authenticating.    
```

Hardcode AWS and GCP for completion; see the comment in code. The list of providers is much more static than the list of regions and thus I think this is totally fine.

```
✔ ~/src/github.com/planetscale/cli/cmd/pscale [main|✚ 1] 
14:09 $ pscale ping --provider 
aws  gcp 
```