### PR TITLE
internal/update: don't error with no build version

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,7 +100,7 @@ func Execute(ctx context.Context, ver, commit, buildDate string) int {
 			case ui := <-updateCheckRes:
 				ui.PrintUpdateHint(ver)
 			case err := <-updateCheckErr:
-				fmt.Fprintf(os.Stderr, "Updater error: %#v\n", err)
+				fmt.Fprintf(os.Stderr, "Updater error: %v\n", err)
 			case <-updateTimeout:
 			}
 		}()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -121,6 +121,16 @@ func checkVersion(
 
 	v2, err := version.NewVersion(buildVersion)
 	if err != nil {
+		if buildVersion == "" {
+			// A self-compiled binary has no version and thus parsing the
+			// version fails.
+			return &UpdateInfo{
+				Update:      false,
+				Reason:      fmt.Sprintf("Binary has no build version, cannot compare against latest version (%s)", info.Version),
+				ReleaseInfo: info,
+			}, nil
+		}
+
 		return nil, err
 	}
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -65,6 +65,12 @@ func TestCheckVersion(t *testing.T) {
 		lastChecked   time.Time
 	}{
 		{
+			name:          "self-compiled",
+			buildVersion:  "",
+			latestVersion: "v0.2.0",
+			update:        false,
+		},
+		{
 			name:          "new version",
 			buildVersion:  "v0.1.0",
 			latestVersion: "v0.2.0",
@@ -112,6 +118,10 @@ func TestCheckVersion(t *testing.T) {
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(updateInfo.Update, qt.Equals, tt.update, qt.Commentf("reason: %s", updateInfo.Reason))
+
+			if !tt.update {
+				t.Logf("reason: %s", updateInfo.Reason)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I got the following message while testing my `pscale ping` changes:

```                                                                                                                                                                                       
Updater error: &errors.errorString{s:"skipping update, error: Malformed version: "} 
```

The `%#v` is not particularly human-friendly so remove that. In addition, the version parsing library returns a less than helpful error `Malformed version: ` with empty string, so double check the error return when using a self-compiled binary.

If self-compiled, do not update. Users already get a banner for self-compiled binaries so they shouldn't expect updates to work either. 