### PR TITLE
Replace database name with @primary

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -167,7 +167,7 @@ second argument:
 				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,
 				"-P", port,
-				"-D", database,
+				"-D", "@primary",
 			}
 
 			historyFile := historyFilePath(ch.Config.Organization, database, branch)


### PR DESCRIPTION
If we explicitly pass the database name when connecting to Vitess, we bypass Vitess' transparent query routing capabilities when dealing with multiple keyspaces.

Using `@primary` instead of an explicit keyspace name will allow us to query transparently across all keyspaces as soon as `pscale shell` connects.