### PR TITLE
internal/update: create parent directories for state file

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -217,8 +217,21 @@ func setStateEntry(path string, t time.Time, r ReleaseInfo) error {
 		LatestRelease:      r,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal state: %w", err)
 	}
 
-	return os.WriteFile(path, content, 0o600)
+	// Make sure all parent directories exist (ex: ~/.config/planetscale) to
+	// allow writing the state file.
+	dir := filepath.Dir(path)
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0o775); err != nil {
+			return fmt.Errorf("create %q: %w", dir, err)
+		}
+	}
+
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("write %q: %w", path, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
The previous version of this code that I replaced threw away the error when it couldn't write the state file, resulting in errors such as the following being ignored:

```
open /home/runner/.config/planetscale/state.yml: no such file or directory
```

The likely problem here is that the state file exists in nested directories that may not exist when the state entry is written. Ensure the parent directories exist and have reasonable permissions to enable walking them.

Relax the permissions on the state file to `0o644`; there's nothing sensitive in here so making it group and world-readable is totally fine.

For https://github.com/planetscale/setup-pscale-action/issues/8. /cc @mscoutermarsh