### PR TITLE
internal/update: add Enabled with CI check

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -81,7 +81,7 @@ func Execute(ctx context.Context, ver, commit, buildDate string) int {
 		}
 	}
 
-	if _, ok := os.LookupEnv("PSCALE_NO_UPDATE_NOTIFIER"); !ok {
+	if update.Enabled() {
 		updateCheckRes := make(chan *update.UpdateInfo, 1)
 		updateCheckErr := make(chan error, 1)
 		updateTimeout := time.After(500 * time.Millisecond)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -23,6 +23,32 @@ import (
 	exec "golang.org/x/sys/execabs"
 )
 
+// Enabled reports whether this process should automatically check for updates.
+func Enabled() bool { return enabled(os.LookupEnv) }
+
+// enabled is the internal implementation of Enabled, with the environment
+// variable lookup function factored out for testing.
+func enabled(lookup func(string) (string, bool)) bool {
+	vars := []string{
+		// Local development.
+		"PSCALE_NO_UPDATE_NOTIFIER",
+		// CI environments.
+		"CI",
+		"GITHUB_ACTION",
+		"BUILDKITE",
+	}
+
+	for _, v := range vars {
+		// Just check for the presence of certain values; don't look for
+		// matching strings.
+		if _, ok := lookup(v); ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 type UpdateInfo struct {
 	Update      bool
 	Reason      string

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -172,3 +172,47 @@ func Test_setStateEntry(t *testing.T) {
 		})
 	}
 }
+
+func Test_enabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		vars    map[string]string
+		enabled bool
+	}{
+		{
+			name:    "default",
+			enabled: true,
+		},
+		{
+			name:    "PSCALE_NO_UPDATE_NOTIFIER",
+			vars:    map[string]string{"PSCALE_NO_UPDATE_NOTIFIER": "1"},
+			enabled: false,
+		},
+		{
+			name:    "CI",
+			vars:    map[string]string{"CI": "true"},
+			enabled: false,
+		},
+		{
+			name:    "GITHUB_ACTION",
+			vars:    map[string]string{"GITHUB_ACTION": "__run"},
+			enabled: false,
+		},
+		{
+			name:    "BUILDKITE",
+			vars:    map[string]string{"BUILDKITE": "true"},
+			enabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lookup := func(v string) (string, bool) {
+				s, ok := tt.vars[v]
+				return s, ok
+			}
+
+			require.Equal(t, tt.enabled, enabled(lookup))
+		})
+	}
+}


### PR DESCRIPTION
There is no reason to check for updates in CI environments such as Buildkite or GitHub actions. /cc @nickvanw