### PR TITLE
Use hostname from password instead of from branch

### DIFF
--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -110,7 +110,7 @@ func toPasswordWithPlainText(password *ps.DatabaseBranchPassword) *PasswordWithP
 		PublicID:          password.PublicID,
 		Username:          password.Username,
 		PlainText:         password.PlainText,
-		AccessHostUrl:     password.Branch.AccessHostURL,
+		AccessHostUrl:     password.Hostname,
 		Role:              password.Role,
 		RoleDesc:          toRoleDesc(password.Role),
 		TTL:               password.TTL,


### PR DESCRIPTION
This changes the password creation flow to use the hostname defined on the created password instead of using the hostname defined on the branch itself.

