### PR TITLE
cmd/password/list: show TTL remaining and if password is expired

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.94.1-0.20240129031810-f7180eeaa9e4
+	github.com/planetscale/planetscale-go v0.95.0
 	github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664
 	github.com/planetscale/psdbproxy v0.0.0-20240103083722-1341ef2326d1
 	github.com/planetscale/sql-proxy v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.94.1-0.20240126214049-b69a8ac210a0
+	github.com/planetscale/planetscale-go v0.94.1-0.20240129031810-f7180eeaa9e4
 	github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664
 	github.com/planetscale/psdbproxy v0.0.0-20240103083722-1341ef2326d1
 	github.com/planetscale/sql-proxy v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.94.0
+	github.com/planetscale/planetscale-go v0.94.1-0.20240126214049-b69a8ac210a0
 	github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664
 	github.com/planetscale/psdbproxy v0.0.0-20240103083722-1341ef2326d1
 	github.com/planetscale/sql-proxy v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
-github.com/planetscale/planetscale-go v0.94.1-0.20240126214049-b69a8ac210a0 h1:Tmzq/rQ3cAeL4LbCwfnuMSUCiubQON5ktl30zqYlADY=
-github.com/planetscale/planetscale-go v0.94.1-0.20240126214049-b69a8ac210a0/go.mod h1:hDSA/dClhuKuW8dNhKN9vQW8E5fo034Rb6qGTf86/yI=
+github.com/planetscale/planetscale-go v0.94.1-0.20240129031810-f7180eeaa9e4 h1:NS9OG8D0BDO+G6vQazYhVUOjpgWn4Be9rdRsy8W79H0=
+github.com/planetscale/planetscale-go v0.94.1-0.20240129031810-f7180eeaa9e4/go.mod h1:hDSA/dClhuKuW8dNhKN9vQW8E5fo034Rb6qGTf86/yI=
 github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664 h1:hmerwr1c1L9aBEr0HPWlwushah3kmyT+r5DUKQtMgYo=
 github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20240103083722-1341ef2326d1 h1:HWBvak/eA+wm/GED6vlq7t9KwMWl5qF3TpcxOfw85YI=

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
-github.com/planetscale/planetscale-go v0.94.0 h1:/G9161noNN7/LSpBnhiULez+RQEQSs2mTVUadfABV6s=
-github.com/planetscale/planetscale-go v0.94.0/go.mod h1:hDSA/dClhuKuW8dNhKN9vQW8E5fo034Rb6qGTf86/yI=
+github.com/planetscale/planetscale-go v0.94.1-0.20240126214049-b69a8ac210a0 h1:Tmzq/rQ3cAeL4LbCwfnuMSUCiubQON5ktl30zqYlADY=
+github.com/planetscale/planetscale-go v0.94.1-0.20240126214049-b69a8ac210a0/go.mod h1:hDSA/dClhuKuW8dNhKN9vQW8E5fo034Rb6qGTf86/yI=
 github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664 h1:hmerwr1c1L9aBEr0HPWlwushah3kmyT+r5DUKQtMgYo=
 github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20240103083722-1341ef2326d1 h1:HWBvak/eA+wm/GED6vlq7t9KwMWl5qF3TpcxOfw85YI=

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
 github.com/planetscale/planetscale-go v0.51.0/go.mod h1:+rGpW2u7iQZZx4O/nFj4MZe4xIS22CVegEgl1IkTExQ=
-github.com/planetscale/planetscale-go v0.94.1-0.20240129031810-f7180eeaa9e4 h1:NS9OG8D0BDO+G6vQazYhVUOjpgWn4Be9rdRsy8W79H0=
-github.com/planetscale/planetscale-go v0.94.1-0.20240129031810-f7180eeaa9e4/go.mod h1:hDSA/dClhuKuW8dNhKN9vQW8E5fo034Rb6qGTf86/yI=
+github.com/planetscale/planetscale-go v0.95.0 h1:7GFazNrmi2X1KnBiexflzYl8CIqRi/naOp2Js+Kf17w=
+github.com/planetscale/planetscale-go v0.95.0/go.mod h1:hDSA/dClhuKuW8dNhKN9vQW8E5fo034Rb6qGTf86/yI=
 github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664 h1:hmerwr1c1L9aBEr0HPWlwushah3kmyT+r5DUKQtMgYo=
 github.com/planetscale/psdb v0.0.0-20231211201729-8cfd83fe2664/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20240103083722-1341ef2326d1 h1:HWBvak/eA+wm/GED6vlq7t9KwMWl5qF3TpcxOfw85YI=

--- a/internal/cmd/password/list.go
+++ b/internal/cmd/password/list.go
@@ -73,6 +73,12 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
+			// if we're doing human display and none of our passwords are ephemeral
+			// we can hide a few of the columns for a more compact view.
+			if ch.Printer.Format() == printer.Human && !hasEphemeral(passwords) {
+				return ch.Printer.PrintResource(toPasswordsWithoutTTL(passwords))
+			}
+
 			return ch.Printer.PrintResource(toPasswords(passwords))
 		},
 	}

--- a/internal/mock/password.go
+++ b/internal/mock/password.go
@@ -15,6 +15,8 @@ type PasswordsService struct {
 	GetFnInvoked    bool
 	DeleteFn        func(context.Context, *ps.DeleteDatabaseBranchPasswordRequest) error
 	DeleteFnInvoked bool
+	RenewFn         func(context.Context, *ps.RenewDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error)
+	RenewFnInvoked  bool
 }
 
 func (b *PasswordsService) Create(ctx context.Context, req *ps.DatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
@@ -35,4 +37,9 @@ func (b *PasswordsService) Get(ctx context.Context, req *ps.GetDatabaseBranchPas
 func (b *PasswordsService) Delete(ctx context.Context, req *ps.DeleteDatabaseBranchPasswordRequest) error {
 	b.DeleteFnInvoked = true
 	return b.DeleteFn(ctx, req)
+}
+
+func (b *PasswordsService) Renew(ctx context.Context, req *ps.RenewDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+	b.RenewFnInvoked = true
+	return b.RenewFn(ctx, req)
 }


### PR DESCRIPTION
This adds two new columns to the password list, "TTL REMAINING", and "EXPIRED".

This allows a user to see, if they have a credential that is ephemeral, to see how long it has left before it's expired, and if it is expired already.

Relies on https://github.com/planetscale/planetscale-go/pull/193

After creating with a 60s TTL:

```
$ ./pscale password list mattdb
  ID             NAME                     BRANCH   USERNAME               ROLE     ROLE DESCRIPTION               TTL   TTL REMAINING   EXPIRED
 -------------- ------------------------ -------- ---------------------- -------- ------------------------------ ----- --------------- ---------
  zxc6td6uu0rh   test-ttl                 main     amzdunhtul1jou6yd11r   reader   Can Read                        60              57   No
  oddkvx4zj8y9   main-2023-11-11-e6qg9j   main     cc7elecd13x7gokz30sh   admin    Can Read, Write & Administer     0               0   No
```

we see both an ephemeral password with a 60s TTL and 57s remaining, but not expired, and a password with a 0 TTL, meaning it has no expiration.

After waiting 60s, we see:

```
$ ./pscale password list mattdb
  ID             NAME                     BRANCH   USERNAME               ROLE     ROLE DESCRIPTION               TTL   TTL REMAINING   EXPIRED
 -------------- ------------------------ -------- ---------------------- -------- ------------------------------ ----- --------------- ---------
  zxc6td6uu0rh   test-ttl                 main     amzdunhtul1jou6yd11r   reader   Can Read                        60               0   Yes
  oddkvx4zj8y9   main-2023-11-11-e6qg9j   main     cc7elecd13x7gokz30sh   admin    Can Read, Write & Administer     0               0   No
```