### PR TITLE
passwordutil: implement a basic refresh loop

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -126,7 +126,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 		Branch:       branch,
 		Role:         cmdutil.AdministratorRole,
 		Name:         passwordutil.GenerateName("pscale-cli-dump"),
-		TTL:          6 * time.Hour, // TODO: use shorter TTL, but implement refreshing
+		TTL:          5 * time.Minute,
 	})
 	if err != nil {
 		return cmdutil.HandleError(err)
@@ -166,6 +166,12 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 
 	go func() {
 		if err := proxy.Serve(l); err != nil {
+			ch.Printer.Println("proxy error: ", err)
+		}
+	}()
+
+	go func() {
+		if err := pw.Renew(ctx); err != nil {
 			ch.Printer.Println("proxy error: ", err)
 		}
 	}()

--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -88,7 +88,7 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 		Branch:       branch,
 		Role:         cmdutil.AdministratorRole,
 		Name:         passwordutil.GenerateName("pscale-cli-restore"),
-		TTL:          6 * time.Hour, // TODO: use shorter TTL, but implement refreshing
+		TTL:          5 * time.Minute,
 	})
 	if err != nil {
 		return cmdutil.HandleError(err)
@@ -128,6 +128,12 @@ func restore(ch *cmdutil.Helper, cmd *cobra.Command, flags *restoreFlags, args [
 
 	go func() {
 		if err := proxy.Serve(l); err != nil {
+			ch.Printer.Println("proxy error: ", err)
+		}
+	}()
+
+	go func() {
+		if err := pw.Renew(ctx); err != nil {
 			ch.Printer.Println("proxy error: ", err)
 		}
 	}()

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -124,14 +124,13 @@ second argument:
 			if !dbBranch.Ready {
 				return errors.New("database branch is not ready yet")
 			}
-
 			pw, err := passwordutil.New(ctx, client, passwordutil.Options{
 				Organization: ch.Config.Organization,
 				Database:     database,
 				Branch:       branch,
 				Role:         role,
 				Name:         passwordutil.GenerateName("pscale-cli-shell"),
-				TTL:          6 * time.Hour, // TODO: use shorter TTL, but implement refreshing
+				TTL:          5 * time.Minute,
 			})
 			if err != nil {
 				return cmdutil.HandleError(err)
@@ -204,6 +203,10 @@ second argument:
 
 			go func() {
 				errCh <- m.Run(ctx, mysqlArgs...)
+			}()
+
+			go func() {
+				errCh <- pw.Renew(ctx)
 			}()
 
 			select {


### PR DESCRIPTION
This then knocks down the TTL for credentials from 6 hours to 5 minutes
+ refreshing every 2.5 minutes.