### PR TITLE
cmd/password: use a duration for TTL

### DIFF
--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -3,6 +3,7 @@ package password
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -10,12 +11,13 @@ import (
 	ps "github.com/planetscale/planetscale-go/planetscale"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		role string
-		ttl  time.Duration
+		ttl  ttlFlag
 	}
 
 	cmd := &cobra.Command{
@@ -35,11 +37,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
-			ttl, err := ttlSeconds(flags.ttl)
-			if err != nil {
-				return err
-			}
-
 			client, err := ch.Client()
 			if err != nil {
 				return err
@@ -54,7 +51,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				Organization: ch.Config.Organization,
 				Name:         name,
 				Role:         flags.role,
-				TTL:          ttl,
+				TTL:          int(flags.ttl.Value.Seconds()),
 			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
@@ -78,19 +75,49 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
-	cmd.PersistentFlags().DurationVar(&flags.ttl, "ttl", 0*time.Second, "TTL defines the time to live for the password, rounded to the nearest second. By default it is 0 which means it will never expire.")
+	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
+
 	return cmd
 }
 
-// ttlSeconds validates and converts a duration TTL into an integer TTL in
-// seconds.
-func ttlSeconds(ttl time.Duration) (int, error) {
+var _ pflag.Value = &ttlFlag{}
+
+// A ttlFlag is a pflag.Value specialized for parsing TTL durations which may or
+// may not have an accompanying time unit.
+type ttlFlag struct{ Value time.Duration }
+
+func (f *ttlFlag) String() string { return f.Value.String() }
+func (f *ttlFlag) Type() string   { return "duration" }
+
+func (f *ttlFlag) Set(value string) error {
+	if value == "" {
+		// Empty string or undefined.
+		return f.set(0 * time.Second)
+	}
+
+	if d, derr := time.ParseDuration(value); derr == nil {
+		// Valid stdlib duration.
+		return f.set(d)
+	}
+
+	// Fall back to parsing a bare integer in seconds for CLI compatibility.
+	i, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("cannot parse %q as TTL in seconds", value)
+	}
+
+	return f.set(time.Duration(i) * time.Second)
+}
+
+// set sets d into f after performing validation.
+func (f *ttlFlag) set(d time.Duration) error {
 	switch {
-	case ttl < 0:
-		return 0, errors.New("TTL cannot be negative")
-	case ttl > 0 && ttl < 1*time.Second:
-		return 0, errors.New("TTL must be at least 1 second")
+	case d < 0:
+		return errors.New("TTL cannot be negative")
+	case d.Round(time.Second) != d:
+		return errors.New("TTL must be defined in increments of 1 second")
 	default:
-		return int(ttl.Round(1 * time.Second).Seconds()), nil
+		f.Value = d
+		return nil
 	}
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -1,7 +1,9 @@
 package password
 
 import (
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
@@ -13,16 +15,15 @@ import (
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		role string
+		ttl  time.Duration
 	}
 
-	createReq := &ps.DatabaseBranchPasswordRequest{}
 	cmd := &cobra.Command{
 		Use:     "create <database> <branch> <name>",
 		Short:   "Create password to access a branch's data",
 		Args:    cmdutil.RequiredArgs("database", "branch", "name"),
 		Aliases: []string{"p"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
 			database := args[0]
 			branch := args[1]
 			name := args[2]
@@ -34,11 +35,10 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
-			createReq.Database = database
-			createReq.Branch = branch
-			createReq.Organization = ch.Config.Organization
-			createReq.Name = name
-			createReq.Role = flags.role
+			ttl, err := ttlSeconds(flags.ttl)
+			if err != nil {
+				return err
+			}
 
 			client, err := ch.Client()
 			if err != nil {
@@ -48,7 +48,14 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating password of %s/%s...", printer.BoldBlue(database), printer.BoldBlue(branch)))
 			defer end()
 
-			pass, err := client.Passwords.Create(ctx, createReq)
+			pass, err := client.Passwords.Create(cmd.Context(), &ps.DatabaseBranchPasswordRequest{
+				Database:     database,
+				Branch:       branch,
+				Organization: ch.Config.Organization,
+				Name:         name,
+				Role:         flags.role,
+				TTL:          ttl,
+			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
@@ -71,6 +78,19 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
-	cmd.PersistentFlags().IntVar(&createReq.TTL, "ttl", 0, "TTL defines the time to live for the password in seconds. By default it is 0 which means it will never expire.")
+	cmd.PersistentFlags().DurationVar(&flags.ttl, "ttl", 0*time.Second, "TTL defines the time to live for the password, rounded to the nearest second. By default it is 0 which means it will never expire.")
 	return cmd
+}
+
+// ttlSeconds validates and converts a duration TTL into an integer TTL in
+// seconds.
+func ttlSeconds(ttl time.Duration) (int, error) {
+	switch {
+	case ttl < 0:
+		return 0, errors.New("TTL cannot be negative")
+	case ttl > 0 && ttl < 1*time.Second:
+		return 0, errors.New("TTL must be at least 1 second")
+	default:
+		return int(ttl.Round(1 * time.Second).Seconds()), nil
+	}
 }


### PR DESCRIPTION
Go has a native duration type and it's much friendlier than requiring the caller to do integer math. `--ttl 6h`, `--ttl 1h30m`, etc.

To prevent misuse, require the caller to specify _at least_ 1 second as the TTL when the flag is set.