### PR TITLE
cmd/password: extend ttlFlag with d

### DIFF
--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -95,7 +95,7 @@ func (f *ttlFlag) Set(value string) error {
 		return f.set(0 * time.Second)
 	}
 
-	if d, derr := time.ParseDuration(value); derr == nil {
+	if d, err := parseDuration(value); err == nil {
 		// Valid stdlib duration.
 		return f.set(d)
 	}
@@ -120,4 +120,30 @@ func (f *ttlFlag) set(d time.Duration) error {
 		f.Value = d
 		return nil
 	}
+}
+
+// parseDuration extends time.ParseDuration with a "d" unit that is not
+// permitted by the Go standard library. For more information, see:
+// https://github.com/golang/go/issues/11473.
+func parseDuration(s string) (time.Duration, error) {
+	// This is a very rudimentary parser; just look for a single rune suffix and
+	// match on that using the generally accepted definitions of "day" with no
+	// accounting for leap seconds.
+	//
+	// If these edge cases matter, users can always perform the math and enter
+	// an absolute TTL in seconds.
+	var multiplier time.Duration
+	switch s[len(s)-1] {
+	case 'd':
+		multiplier = 24 * time.Hour
+	default:
+		return time.ParseDuration(s)
+	}
+
+	v, err := strconv.Atoi(s[:len(s)-1])
+	if err != nil {
+		return 0, err
+	}
+
+	return time.Duration(v) * multiplier, nil
 }

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -234,9 +234,34 @@ func Test_ttlFlag(t *testing.T) {
 			out:  12 * time.Hour,
 		},
 		{
+			name: "invalid days",
+			in:   "0.1d",
+			err:  `cannot parse "0.1d" as TTL in seconds`,
+		},
+		{
+			name: "days",
+			in:   "180d",
+			out:  180 * 24 * time.Hour,
+		},
+		{
+			name: "unsupported weeks",
+			in:   "1w",
+			err:  `cannot parse "1w" as TTL in seconds`,
+		},
+		{
+			name: "unsupported years",
+			in:   "1y",
+			err:  `cannot parse "1y" as TTL in seconds`,
+		},
+		{
 			name: "complex",
 			in:   "48h10m30s",
 			out:  48*time.Hour + 10*time.Minute + 30*time.Second,
+		},
+		{
+			name: "complex days",
+			in:   "1d10h",
+			err:  `cannot parse "1d10h" as TTL in seconds`,
 		},
 	}
 


### PR DESCRIPTION
The Go stdlib doesn't want to support "days" for the reasons linked in the issue, but they're very reasonable for a credential TTL argument such as `--ttl 30d`. Support the absolute basics with no conveniences like `30d12h`.