### PR TITLE
meta: move goreleaser-cross back to v1.21.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.23.0
+GORELEASE_CROSS_VERSION ?= v1.21.5
 SYFT_VERSION ?= 0.102.0
 
 .PHONY: all

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-ARG GORELEASE_CROSS_VERSION=v1.23.0
+ARG GORELEASE_CROSS_VERSION=v1.25.1
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update && apt-get install -y openssh-client


### PR DESCRIPTION
Turns out, these are different releases for goreleaser-cross vs goreleaser, and v1.21.5 is the latest for -cross variant.