### PR TITLE
Removing --access-token from error message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6 as build
+FROM golang:1.22 as build
 WORKDIR /app
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.21.5
+GORELEASE_CROSS_VERSION ?= v1.22.0
 SYFT_VERSION ?= 0.102.0
 
 .PHONY: all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: golang:1.21.6
+    image: golang:1.22
     volumes:
       - .:/work
     working_dir: /work

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ func (c *Config) IsAuthenticated() error {
 	}
 
 	if c.AccessToken == "" {
-		return errors.New("--access-token is required for access token authentication")
+		return errors.New("you must run 'pscale auth login' to authenticate before using this command")
 	}
 
 	return nil


### PR DESCRIPTION
We don't allow for `--access-token` in our configuration. From what I can tell this error occurs if you haven't yet authenticated with `pscale auth login`. This error message is slightly different than trying to login using tokens. 