### PR TITLE
goreleaser: correct version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.22.0
+GORELEASE_CROSS_VERSION ?= v1.21.5
 SYFT_VERSION ?= 0.102.0
 
 .PHONY: all


### PR DESCRIPTION
It's not this, it's that. https://github.com/goreleaser/goreleaser-cross/releases/tag/v1.21.5