### PR TITLE
vschema get: show keyspaces param

### DIFF
--- a/internal/cmd/branch/vschema.go
+++ b/internal/cmd/branch/vschema.go
@@ -78,7 +78,6 @@ func GetVSchemaCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "The keyspace in the branch")
-	cmd.Flags().MarkHidden("keyspace")
 
 	return cmd
 }


### PR DESCRIPTION
This was hidden, but it doesn't need to be. 