### PR TITLE
Add `--replica` flag to create password

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
-	github.com/planetscale/planetscale-go v0.98.0
+	github.com/planetscale/planetscale-go v0.99.0
 	github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7
 	github.com/planetscale/psdbproxy v0.0.0-20240307093246-10916da42cd0
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2v
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
 github.com/planetscale/planetscale-go v0.98.0 h1:tPh/K7V77JED/Qflon6HHTWpQ+mHFfG4AH+ljr7rvWA=
 github.com/planetscale/planetscale-go v0.98.0/go.mod h1:BC1MsrlPC/w62X5VQwbo0pBvE/5qROc5EckUV/Lk2HY=
+github.com/planetscale/planetscale-go v0.99.0 h1:QacXdkWQTXIT/exkX965uAjNw/f7idRR7rqnN5Sd8XM=
+github.com/planetscale/planetscale-go v0.99.0/go.mod h1:BC1MsrlPC/w62X5VQwbo0pBvE/5qROc5EckUV/Lk2HY=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7 h1:dxdoFKWVDlV1gq8UQC8NWCofLjCEjEHw47gfeojgs28=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20240307093246-10916da42cd0 h1:CV6G8hSnCZnbI5KoWaoGj+W6XOZKcuu/2i+HcWU3B/Q=

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -16,8 +16,9 @@ import (
 
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		role string
-		ttl  ttlFlag
+		role    string
+		ttl     ttlFlag
+		replica bool
 	}
 
 	cmd := &cobra.Command{
@@ -52,6 +53,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				Name:         name,
 				Role:         flags.role,
 				TTL:          int(flags.ttl.Value.Seconds()),
+				Replica:      flags.replica,
 			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
@@ -76,6 +78,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
 	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
+	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas, and all read-only regions.")
+	cmd.Flags().MarkHidden("replica")
 
 	return cmd
 }

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -38,6 +38,7 @@ func TestPassword_CreateCmd(t *testing.T) {
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.Name, qt.Equals, name)
 			c.Assert(req.Role, qt.Equals, role)
+			c.Assert(req.Replica, qt.Equals, false)
 
 			return res, nil
 		},
@@ -85,6 +86,7 @@ func TestPassword_CreateCmd_InvalidRole(t *testing.T) {
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.Name, qt.Equals, name)
 			c.Assert(req.Role, qt.Equals, "")
+			c.Assert(req.Replica, qt.Equals, false)
 
 			return res, nil
 		},
@@ -131,6 +133,7 @@ func TestPassword_CreateCmd_DefaultRoleAdmin(t *testing.T) {
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.Name, qt.Equals, name)
 			c.Assert(req.Role, qt.Equals, "admin")
+			c.Assert(req.Replica, qt.Equals, false)
 
 			return res, nil
 		},
@@ -280,7 +283,7 @@ func Test_ttlFlag(t *testing.T) {
 	}
 }
 
-func TestPassword_CreateReplicaCmd(t *testing.T) {
+func TestPassword_CreateCmd_Replica(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -279,3 +279,54 @@ func Test_ttlFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestPassword_CreateReplicaCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+	role := "reader"
+	name := "production-replica-password"
+	replica := true
+	res := &ps.DatabaseBranchPassword{Name: "foo"}
+
+	svc := &mock.PasswordsService{
+		CreateFn: func(ctx context.Context, req *ps.DatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Name, qt.Equals, name)
+			c.Assert(req.Role, qt.Equals, role)
+			c.Assert(req.Replica, qt.Equals, replica)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Passwords: svc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, name, "--replica"})
+	cmd.Flag("role").Value.Set(role)
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -40,7 +40,7 @@ type Password struct {
 	Username  string `header:"username" json:"username"`
 	Role      string `header:"role" json:"role"`
 	RoleDesc  string `header:"role description" json:"-"`
-	Replica   string `header:"replica" json:"replica"`
+	Replica   bool   `header:"replica" json:"replica"`
 	TTL       int    `header:"ttl" json:"ttl"`
 	Remaining int    `header:"ttl_remaining" json:"-"`
 	CreatedAt int64  `json:"created_at"`
@@ -55,7 +55,7 @@ type passwordWithoutTTL struct {
 	Username  string `header:"username" json:"username"`
 	Role      string `header:"role" json:"role"`
 	RoleDesc  string `header:"role description" json:"-"`
-	Replica   string `header:"replica" json:"replica"`
+	Replica   bool   `header:"replica" json:"replica"`
 	CreatedAt int64  `json:"created_at"`
 	orig      *ps.DatabaseBranchPassword
 }
@@ -68,7 +68,7 @@ type PasswordWithPlainText struct {
 	AccessHostUrl     string               `header:"access host url" json:"access_host_url"`
 	Role              string               `header:"role" json:"role"`
 	RoleDesc          string               `header:"role description" json:"role_description"`
-	Replica           string               `header:"replica" json:"replica"`
+	Replica           bool                 `header:"replica" json:"replica"`
 	PlainText         string               `header:"password" json:"password"`
 	TTL               int                  `header:"ttl" json:"ttl"`
 	ConnectionStrings ps.ConnectionStrings `json:"connection_strings"`

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -34,30 +34,30 @@ func PasswordCmd(ch *cmdutil.Helper) *cobra.Command {
 type Passwords []*Password
 
 type Password struct {
-	PublicID  string `header:"id" json:"id"`
-	Name      string `header:"name" json:"name"`
-	Branch    string `header:"branch" json:"branch"`
-	Username  string `header:"username" json:"username"`
-	Role      string `header:"role" json:"role"`
-	RoleDesc  string `header:"role description" json:"-"`
-	Replica   bool   `header:"replica" json:"replica"`
-	TTL       int    `header:"ttl" json:"ttl"`
-	Remaining int    `header:"ttl_remaining" json:"-"`
-	CreatedAt int64  `json:"created_at"`
-	Expired   bool   `header:"expired" json:"expired"`
-	orig      *ps.DatabaseBranchPassword
+	PublicID       string `header:"id" json:"id"`
+	Name           string `header:"name" json:"name"`
+	Branch         string `header:"branch" json:"branch"`
+	Username       string `header:"username" json:"username"`
+	Role           string `header:"role" json:"role"`
+	RoleDesc       string `header:"role description" json:"-"`
+	ConnectionType string `header:"connection type" json:"connection_type"`
+	TTL            int    `header:"ttl" json:"ttl"`
+	Remaining      int    `header:"ttl_remaining" json:"-"`
+	CreatedAt      int64  `json:"created_at"`
+	Expired        bool   `header:"expired" json:"expired"`
+	orig           *ps.DatabaseBranchPassword
 }
 
 type passwordWithoutTTL struct {
-	PublicID  string `header:"id" json:"id"`
-	Name      string `header:"name" json:"name"`
-	Branch    string `header:"branch" json:"branch"`
-	Username  string `header:"username" json:"username"`
-	Role      string `header:"role" json:"role"`
-	RoleDesc  string `header:"role description" json:"-"`
-	Replica   bool   `header:"replica" json:"replica"`
-	CreatedAt int64  `json:"created_at"`
-	orig      *ps.DatabaseBranchPassword
+	PublicID       string `header:"id" json:"id"`
+	Name           string `header:"name" json:"name"`
+	Branch         string `header:"branch" json:"branch"`
+	Username       string `header:"username" json:"username"`
+	Role           string `header:"role" json:"role"`
+	RoleDesc       string `header:"role description" json:"-"`
+	ConnectionType string `header:"connection type" json:"connection_type"`
+	CreatedAt      int64  `json:"created_at"`
+	orig           *ps.DatabaseBranchPassword
 }
 
 type PasswordWithPlainText struct {
@@ -68,7 +68,7 @@ type PasswordWithPlainText struct {
 	AccessHostUrl     string               `header:"access host url" json:"access_host_url"`
 	Role              string               `header:"role" json:"role"`
 	RoleDesc          string               `header:"role description" json:"role_description"`
-	Replica           bool                 `header:"replica" json:"replica"`
+	ConnectionType    string               `header:"connection type" json:"connection_type"`
 	PlainText         string               `header:"password" json:"password"`
 	TTL               int                  `header:"ttl" json:"ttl"`
 	ConnectionStrings ps.ConnectionStrings `json:"connection_strings"`
@@ -104,32 +104,32 @@ func toPassword(password *ps.DatabaseBranchPassword) *Password {
 		ttlRemaining = max(int(time.Until(password.ExpiresAt).Seconds()), 0)
 	}
 	return &Password{
-		Name:      password.Name,
-		Branch:    password.Branch.Name,
-		PublicID:  password.PublicID,
-		Username:  password.Username,
-		Role:      password.Role,
-		RoleDesc:  toRoleDesc(password.Role),
-		Replica:   password.Replica,
-		TTL:       password.TTL,
-		Remaining: ttlRemaining,
-		CreatedAt: toTimestamp(password.CreatedAt),
-		Expired:   password.TTL > 0 && ttlRemaining == 0,
-		orig:      password,
+		Name:           password.Name,
+		Branch:         password.Branch.Name,
+		PublicID:       password.PublicID,
+		Username:       password.Username,
+		Role:           password.Role,
+		RoleDesc:       toRoleDesc(password.Role),
+		ConnectionType: toConnectionTypeDesc(password.Replica),
+		TTL:            password.TTL,
+		Remaining:      ttlRemaining,
+		CreatedAt:      toTimestamp(password.CreatedAt),
+		Expired:        password.TTL > 0 && ttlRemaining == 0,
+		orig:           password,
 	}
 }
 
 func toPasswordWithoutTTL(password *ps.DatabaseBranchPassword) *passwordWithoutTTL {
 	return &passwordWithoutTTL{
-		Name:      password.Name,
-		Branch:    password.Branch.Name,
-		PublicID:  password.PublicID,
-		Username:  password.Username,
-		Role:      password.Role,
-		RoleDesc:  toRoleDesc(password.Role),
-		Replica:   password.Replica,
-		CreatedAt: toTimestamp(password.CreatedAt),
-		orig:      password,
+		Name:           password.Name,
+		Branch:         password.Branch.Name,
+		PublicID:       password.PublicID,
+		Username:       password.Username,
+		Role:           password.Role,
+		RoleDesc:       toRoleDesc(password.Role),
+		ConnectionType: toConnectionTypeDesc(password.Replica),
+		CreatedAt:      toTimestamp(password.CreatedAt),
+		orig:           password,
 	}
 }
 
@@ -170,7 +170,7 @@ func toPasswordWithPlainText(password *ps.DatabaseBranchPassword) *PasswordWithP
 		AccessHostUrl:     password.Hostname,
 		Role:              password.Role,
 		RoleDesc:          toRoleDesc(password.Role),
-		Replica:           password.Replica,
+		ConnectionType:    toConnectionTypeDesc(password.Replica),
 		TTL:               password.TTL,
 		ConnectionStrings: password.ConnectionStrings,
 		orig:              password,
@@ -189,6 +189,14 @@ func toRoleDesc(role string) string {
 		return "Can Read, Write & Administer"
 	}
 	return "Can Read"
+}
+
+func toConnectionTypeDesc(replica bool) string {
+	if replica {
+		return "Replica"
+	} else {
+		return "Primary"
+	}
 }
 
 func toTimestamp(t time.Time) int64 {

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -40,6 +40,7 @@ type Password struct {
 	Username  string `header:"username" json:"username"`
 	Role      string `header:"role" json:"role"`
 	RoleDesc  string `header:"role description" json:"-"`
+	Replica   string `header:"replica" json:"replica"`
 	TTL       int    `header:"ttl" json:"ttl"`
 	Remaining int    `header:"ttl_remaining" json:"-"`
 	CreatedAt int64  `json:"created_at"`
@@ -54,6 +55,7 @@ type passwordWithoutTTL struct {
 	Username  string `header:"username" json:"username"`
 	Role      string `header:"role" json:"role"`
 	RoleDesc  string `header:"role description" json:"-"`
+	Replica   string `header:"replica" json:"replica"`
 	CreatedAt int64  `json:"created_at"`
 	orig      *ps.DatabaseBranchPassword
 }
@@ -66,6 +68,7 @@ type PasswordWithPlainText struct {
 	AccessHostUrl     string               `header:"access host url" json:"access_host_url"`
 	Role              string               `header:"role" json:"role"`
 	RoleDesc          string               `header:"role description" json:"role_description"`
+	Replica           string               `header:"replica" json:"replica"`
 	PlainText         string               `header:"password" json:"password"`
 	TTL               int                  `header:"ttl" json:"ttl"`
 	ConnectionStrings ps.ConnectionStrings `json:"connection_strings"`
@@ -107,6 +110,7 @@ func toPassword(password *ps.DatabaseBranchPassword) *Password {
 		Username:  password.Username,
 		Role:      password.Role,
 		RoleDesc:  toRoleDesc(password.Role),
+		Replica:   password.Replica,
 		TTL:       password.TTL,
 		Remaining: ttlRemaining,
 		CreatedAt: toTimestamp(password.CreatedAt),
@@ -123,6 +127,7 @@ func toPasswordWithoutTTL(password *ps.DatabaseBranchPassword) *passwordWithoutT
 		Username:  password.Username,
 		Role:      password.Role,
 		RoleDesc:  toRoleDesc(password.Role),
+		Replica:   password.Replica,
 		CreatedAt: toTimestamp(password.CreatedAt),
 		orig:      password,
 	}
@@ -165,6 +170,7 @@ func toPasswordWithPlainText(password *ps.DatabaseBranchPassword) *PasswordWithP
 		AccessHostUrl:     password.Hostname,
 		Role:              password.Role,
 		RoleDesc:          toRoleDesc(password.Role),
+		Replica:           password.Replica,
 		TTL:               password.TTL,
 		ConnectionStrings: password.ConnectionStrings,
 		orig:              password,


### PR DESCRIPTION
This PR adds `--replica` flag to create password, which when enabled, will create a password that redirects queries to the replica tablets, or the  branch's read-only-regions, depending on where latency is smallest.

