### PR TITLE
Default to `reader` role when passing `--replica` and not `--role`

### DIFF
--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -31,9 +31,13 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			branch := args[1]
 			name := args[2]
 
-			// "admin" is the default value for role
-			if flags.role == "" && flags.replica {
-				flags.role = "reader"
+			if flags.role == "" {
+				if flags.replica {
+					flags.role = "reader"
+				} else {
+					// Maintain old behavior - "admin" is the default role.
+					flags.role = "admin"
+				}
 			}
 
 			if flags.role != "" {

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -85,7 +85,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
+		"", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
 	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
 	cmd.Flags().MarkHidden("replica")

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -31,6 +31,11 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			branch := args[1]
 			name := args[2]
 
+			// "admin" is the default value for role
+			if flags.role == "" && flags.replica {
+				flags.role = "reader"
+			}
+
 			if flags.role != "" {
 				_, err := cmdutil.RoleFromString(flags.role)
 				if err != nil {
@@ -76,7 +81,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"admin", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
+		"", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. By default it is admin.")
 	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
 	cmd.Flags().MarkHidden("replica")

--- a/internal/cmd/password/create_test.go
+++ b/internal/cmd/password/create_test.go
@@ -333,3 +333,52 @@ func TestPassword_CreateCmd_Replica(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 }
+
+func TestPassword_CreateCmd_ReplicaWithoutRole(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+	name := "production-replica-password"
+	replica := true
+	res := &ps.DatabaseBranchPassword{Name: "foo"}
+
+	svc := &mock.PasswordsService{
+		CreateFn: func(ctx context.Context, req *ps.DatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Name, qt.Equals, name)
+			c.Assert(req.Role, qt.Equals, "reader")
+			c.Assert(req.Replica, qt.Equals, replica)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Passwords: svc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, name, "--replica"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+}


### PR DESCRIPTION
This PR makes it so that we default to a `reader` role when passing `--replica`, and not `--role`. 
- The default `admin` for `--replica` flag is set in the `RunE` func instead of the flag definition
    - This is so we can differentiate between a user passing no `--role`, and the user intentionally setting `--role=admin`
- If no `--role` is passed, we default it to `reader` if `--replica` is passed, and `admin` if `--replica` is _not_ passed  