### PR TITLE
Add support for replicas in `shell` and `connect` commands

### DIFF
--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -85,7 +85,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
-		"", "Role defines the access level, allowed values are : reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
+		"", "Role defines the access level, allowed values are: reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
 	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
 	cmd.Flags().MarkHidden("replica")

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -180,11 +180,6 @@ second argument:
 				return cmdutil.HandleError(err)
 			}
 
-			useDatabase := "@primary"
-			if replica {
-				useDatabase = database
-			}
-
 			mysqlArgs := []string{
 				"-u",
 				"root",
@@ -193,7 +188,11 @@ second argument:
 				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,
 				"-P", port,
-				"-D", useDatabase,
+			}
+			if replica {
+				mysqlArgs = append([]string{"--no-defaults"}, mysqlArgs...)
+			} else {
+				mysqlArgs = append(mysqlArgs, "-D", "@primary")
 			}
 
 			historyFile := historyFilePath(ch.Config.Organization, database, branch)

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -188,7 +188,10 @@ second argument:
 				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,
 				"-P", port,
-				"-D", "@primary",
+			}
+
+			if !replica {
+				mysqlArgs = append(mysqlArgs, "-D", "@primary")
 			}
 
 			historyFile := historyFilePath(ch.Config.Organization, database, branch)

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -180,6 +180,11 @@ second argument:
 				return cmdutil.HandleError(err)
 			}
 
+			useDatabase := "@primary"
+			if replica {
+				useDatabase = database
+			}
+
 			mysqlArgs := []string{
 				"-u",
 				"root",
@@ -188,10 +193,7 @@ second argument:
 				"-t", // the -s (silent) flag disables tabular output, re-enable it.
 				"-h", host,
 				"-P", port,
-			}
-
-			if !replica {
-				mysqlArgs = append(mysqlArgs, "-D", "@primary")
+				"-D", useDatabase,
 			}
 
 			historyFile := historyFilePath(ch.Config.Organization, database, branch)

--- a/internal/passwordutil/password.go
+++ b/internal/passwordutil/password.go
@@ -23,6 +23,7 @@ type Options struct {
 	Role         cmdutil.PasswordRole
 	Name         string
 	TTL          time.Duration
+	Replica      bool
 }
 
 type Password struct {
@@ -78,6 +79,7 @@ func New(ctx context.Context, client *ps.Client, opt Options) (*Password, error)
 		Role:         opt.Role.ToString(),
 		Name:         opt.Name,
 		TTL:          int(opt.TTL.Seconds()),
+		Replica:      opt.Replica,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request implements replica credential creation inside of both the shell and connect commands.