### PR TITLE
Removes `MarkHidden` on `replica` flag

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -215,7 +215,6 @@ argument:
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"", "Role defines the access level, allowed values are: reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
-	cmd.Flags().MarkHidden("replica")
 
 	return cmd
 }

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -88,7 +88,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		"", "Role defines the access level, allowed values are: reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
 	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
-	cmd.Flags().MarkHidden("replica")
 
 	return cmd
 }

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -239,7 +239,6 @@ second argument:
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"", "Role defines the access level, allowed values are: reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
-	cmd.Flags().MarkHidden("replica")
 
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 


### PR DESCRIPTION
Removes the `MarkHidden` annotation on the `replica` flag.