### PR TITLE
Fix the MySQL shell signal handling

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,7 +71,7 @@ var rootCmd = &cobra.Command{
 
 // Execute executes the command and returns the exit status of the finished
 // command.
-func Execute(ctx context.Context, ver, commit, buildDate string) int {
+func Execute(ctx context.Context, sigc chan os.Signal, signals []os.Signal, ver, commit, buildDate string) int {
 	var format printer.Format
 	var debug bool
 
@@ -106,7 +106,7 @@ func Execute(ctx context.Context, ver, commit, buildDate string) int {
 		}()
 	}
 
-	err := runCmd(ctx, ver, commit, buildDate, &format, &debug)
+	err := runCmd(ctx, ver, commit, buildDate, &format, &debug, sigc, signals)
 	if err == nil {
 		return 0
 	}
@@ -130,7 +130,7 @@ func Execute(ctx context.Context, ver, commit, buildDate string) int {
 
 // runCmd adds all child commands to the root command, sets flags
 // appropriately, and runs the root command.
-func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.Format, debug *bool) error {
+func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.Format, debug *bool, sigc chan os.Signal, signals []os.Signal) error {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config",
@@ -220,7 +220,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.AddCommand(password.PasswordCmd(ch))
 	rootCmd.AddCommand(ping.PingCmd(ch))
 	rootCmd.AddCommand(region.RegionCmd(ch))
-	rootCmd.AddCommand(shell.ShellCmd(ch))
+	rootCmd.AddCommand(shell.ShellCmd(ch, sigc, signals...))
 	rootCmd.AddCommand(signup.SignupCmd(ch))
 	rootCmd.AddCommand(token.TokenCmd(ch))
 	rootCmd.AddCommand(version.VersionCmd(ch, ver, commit, buildDate))


### PR DESCRIPTION
MySQL handles signals like an interrupt (ctrl+c) as a query interrupt / cancelation of the current input. This means it's not expected to have it shut down the CLI.

When we have the MySQL shell active, we should mask any signals and forward them straight to MySQL instead.

This sets up the logic to do so. It means we have to manually set up the initial context and signals instead of using signal.NotifyContext, since we need to be able to later on disable them which means access to the actual channel registed.

So we have to do this work manually and then pass through what we've registed, so we can disable it and setup the proper ones when we invoke the shell.

We also do the work to reverse it all, which is not strictly needed at the moment, but avoids making mistakes with it in the future if we would allow shutting down the shell and doing other commands.

Fixes #850 