### PR TITLE
Disable custom signal handling if not on foreground

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -20,7 +20,8 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-var IsTTY = isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
+var IsTTY = (isatty.IsTerminal(os.Stdout.Fd()) && isatty.IsTerminal(os.Stderr.Fd()) && isatty.IsTerminal(os.Stdin.Fd())) ||
+	(isatty.IsCygwinTerminal(os.Stdout.Fd()) && isatty.IsCygwinTerminal(os.Stderr.Fd()) && isatty.IsCygwinTerminal(os.Stdin.Fd()))
 
 // Format defines the option output format of a resource.
 type Format int


### PR DESCRIPTION
If pscale is used in scripts with the explicit
`PSCALE_ALLOW_NONINTERACTIVE_SHELL` env flag, disable the signal changes we do for making the shell work in interactive mode.

This check also needs to verify that all of stdin, stdout & stderr are a proper TTY and not just stdout, since if you pipe in only input for example we still need to disable this since there's no foregrounding.

Fixes #856 