### PR TITLE
Add --instant flag for deploying DR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dist/
 completions/
 vendor/
 .idea
+
+# Output of running go build cmd/pscale/main.go
+main

--- a/internal/cmd/deployrequest/create.go
+++ b/internal/cmd/deployrequest/create.go
@@ -55,6 +55,9 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if ch.Printer.Format() == printer.Human {
 				number := fmt.Sprintf("#%d", dr.Number)
 				ch.Printer.Printf("Deploy request %s successfully created.\n\nView this deploy request in the browser: %s\n", printer.BoldBlue(number), printer.BoldBlue(dr.HtmlURL))
+				if dr.Deployment.InstantDDLEligible {
+					ch.Printer.Printf("This deploy request is instant DDL eligible. Pass the %s flag during deploy to deploy these schema changes using MySQL’s built-in ALGORITHM=INSTANT option. Deployment will be faster, but cannot be reverted.\n", printer.BoldYellow("--instant"))
+				}
 				return nil
 			}
 

--- a/internal/cmd/deployrequest/create.go
+++ b/internal/cmd/deployrequest/create.go
@@ -55,9 +55,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if ch.Printer.Format() == printer.Human {
 				number := fmt.Sprintf("#%d", dr.Number)
 				ch.Printer.Printf("Deploy request %s successfully created.\n\nView this deploy request in the browser: %s\n", printer.BoldBlue(number), printer.BoldBlue(dr.HtmlURL))
-				if dr.Deployment.InstantDDLEligible {
-					ch.Printer.Printf("This deploy request is instant DDL eligible. Pass the %s flag during deploy to deploy these schema changes using MySQL’s built-in ALGORITHM=INSTANT option. Deployment will be faster, but cannot be reverted.\n", printer.BoldYellow("--instant"))
-				}
 				return nil
 			}
 

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -17,7 +17,8 @@ import (
 // DeployCmd is the command for deploying deploy requests.
 func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		wait bool
+		wait        bool
+		instant_ddl bool
 	}
 
 	cmd := &cobra.Command{
@@ -45,10 +46,16 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
+			if flags.instant_ddl {
+				ch.Printer.Printf("--instant flag passed, deploy request %s/%s will be deployed instantly.\n",
+					printer.BoldBlue(database), printer.BoldBlue(number))
+			}
+
 			dr, err := client.DeployRequests.Deploy(ctx, &planetscale.PerformDeployRequest{
 				Organization: ch.Config.Organization,
 				Database:     database,
 				Number:       number,
+				InstantDDL:   flags.instant_ddl,
 			})
 
 			if err != nil {
@@ -102,6 +109,8 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is deployed")
+	cmd.Flags().BoolVar(&flags.instant_ddl, "instant", false, "If enabled, the schema migrations from this DR will be applied using MySQL’s built-in ALGORITHM=INSTANT option. Deployment will be faster, but cannot be reverted.")
+	cmd.Flags().MarkHidden("instant")
 
 	return cmd
 }

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -86,13 +86,13 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				switch state {
 				case "complete_pending_revert":
-					ch.Printer.Printf("Deploy request %s/%s is successfully deployed and revertable. You can skip the revert to unblock the deploy queue.\n",
+					ch.Printer.Printf("Deploy request %s/%s is successfully deployed and revertable. You can skip the revert to unblock the deploy queue.\n\n",
 						printer.BoldBlue(database), printer.BoldBlue(number))
 				case "pending_cutover":
-					ch.Printer.Printf("Deploy request %s/%s is successfully staged and waiting to be applied.\n",
+					ch.Printer.Printf("Deploy request %s/%s is successfully staged and waiting to be applied.\n\n",
 						printer.BoldBlue(database), printer.BoldBlue(number))
 				default:
-					ch.Printer.Printf("Deploy request %s/%s is successfully deployed.\n",
+					ch.Printer.Printf("Deploy request %s/%s is successfully deployed.\n\n",
 						printer.BoldBlue(database), printer.BoldBlue(number))
 				}
 

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -47,7 +47,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if flags.instant_ddl {
-				ch.Printer.Printf("--instant flag passed, deploy request %s/%s will be deployed instantly.\n",
+				ch.Printer.Printf("Deploy request %s/%s will be deployed instantly.\n\n",
 					printer.BoldBlue(database), printer.BoldBlue(number))
 			}
 
@@ -98,8 +98,8 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			} else {
 				if ch.Printer.Format() == printer.Human {
-					ch.Printer.Printf("Successfully queued %s from %s for deployment to %s.\n",
-						dr.ID, dr.Branch, dr.IntoBranch)
+					ch.Printer.Printf("Successfully queued deploy request %s/%s from %s for deployment to %s.\n",
+						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(dr.Branch), printer.BoldBlue(dr.IntoBranch))
 					return nil
 				}
 			}
@@ -109,8 +109,8 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is deployed")
-	cmd.Flags().BoolVar(&flags.instant_ddl, "instant", false, "If enabled, the schema migrations from this DR will be applied using MySQL’s built-in ALGORITHM=INSTANT option. Deployment will be faster, but cannot be reverted.")
-	cmd.Flags().MarkHidden("instant")
+	cmd.Flags().BoolVar(&flags.instant_ddl, "instant", false, "If enabled, the schema migrations from this deploy request will be applied using MySQL’s built-in ALGORITHM=INSTANT option. Deployment will be faster, but cannot be reverted.")
+	// cmd.Flags().MarkHidden("instant")
 
 	return cmd
 }

--- a/internal/cmd/deployrequest/dr.go
+++ b/internal/cmd/deployrequest/dr.go
@@ -58,8 +58,9 @@ type DeployRequest struct {
 }
 
 type inlineDeployment struct {
-	State      string `header:"deploy state" json:"state"`
-	Deployable bool   `header:"deployable" json:"deployable"`
+	State              string `header:"deploy state" json:"state"`
+	Deployable         bool   `header:"deployable" json:"deployable"`
+	InstantDDLEligible bool   `header:"instant ddl eligible" json:"instant_ddl_eligible"`
 
 	QueuedAt   *int64 `header:"queued_at,timestamp(ms|utc|human),-" json:"queued_at"`
 	StartedAt  *int64 `header:"started_at,timestamp(ms|utc|human),-" json:"started_at"`
@@ -80,10 +81,11 @@ func toInlineDeployment(d *planetscale.Deployment) inlineDeployment {
 	return inlineDeployment{
 		State: d.State,
 
-		Deployable: d.Deployable,
-		FinishedAt: printer.GetMillisecondsIfExists(d.FinishedAt),
-		StartedAt:  printer.GetMillisecondsIfExists(d.StartedAt),
-		QueuedAt:   printer.GetMillisecondsIfExists(d.QueuedAt),
+		Deployable:         d.Deployable,
+		InstantDDLEligible: d.InstantDDLEligible,
+		FinishedAt:         printer.GetMillisecondsIfExists(d.FinishedAt),
+		StartedAt:          printer.GetMillisecondsIfExists(d.StartedAt),
+		QueuedAt:           printer.GetMillisecondsIfExists(d.QueuedAt),
 
 		orig: d,
 	}


### PR DESCRIPTION
This PR adds the `--instant` flag to `pscale deploy-request deploy` that will deploy the deploy request using an instant ddl strategy:
![CleanShot 2024-05-07 at 09 32 49@2x](https://github.com/planetscale/cli/assets/31225471/529c51cd-0a87-4686-9387-0d7f703025c9)

It also adds the `Instant DDL Eligible` field to `pscale deploy-request list` that denotes whether or not the `--instant` flag can be used for deploy:
![CleanShot 2024-05-07 at 09 33 14@2x](https://github.com/planetscale/cli/assets/31225471/17c676fe-9e4f-4abb-a2df-63bdf8b6024c)

with the `--wait` flag and `--instant`:
![CleanShot 2024-05-07 at 10 54 38@2x](https://github.com/planetscale/cli/assets/31225471/6f47b599-5ce3-407c-975e-e3d034bda572)

