### PR TITLE
Fix postitive auth check message

### DIFF
--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -38,7 +38,7 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 						ExitCode: cmdutil.ActionRequestedExitCode,
 					}
 				} else {
-					ch.Printer.Printf("You are authenticated.")
+					ch.Printer.Printf("You are authenticated.\n")
 					return nil
 				}
 			}

--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -38,7 +38,7 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 						ExitCode: cmdutil.ActionRequestedExitCode,
 					}
 				} else {
-					ch.Printer.Printf("You are authenticated.\n")
+					ch.Printer.Println("You are authenticated.")
 					return nil
 				}
 			}


### PR DESCRIPTION
Fixes a missing newline in the affirmative `pscale auth check` output

Currently:
```sh
bash-3.2$ pscale auth check
You are authenticated.bash-3.2$
```