### PR TITLE
Make region and restore flags mutually exclusive for branch create

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -118,11 +118,12 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "branch to be created from")
-	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
-	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "backup to restore into the branch")
-	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "add seed data using the Data Branching™ feature")
-	cmd.Flags().BoolVar(&flags.wait, "wait", false, "wait until the branch is ready")
+	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "Branch to be created from")
+	cmd.Flags().StringVar(&createReq.Region, "region", "", "Region for the database. Can not be used with --restore")
+	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "Backup to restore into the branch. Backup can only be restored to its original region")
+	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature")
+	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
+	cmd.MarkFlagsMutuallyExclusive("region", "restore")
 
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := cmd.Context()


### PR DESCRIPTION
A fairly common point of confusion is that `pscale branch create --restore` will accept a `--region` flag but will always restore to the region the backup was taken in. That's the correct behavior but it isn't documented properly.

This changes makes those flags mutually exclusive and documents the incompatibility in the app.

```sh
$ pscale branch create beam main --region us-west --restore abc123
Error: if any flags in the group [region restore] are set none of the others can be; [region restore] were all set
```

```sh
$ pscale branch create --help
Create a new branch from a database
...
Flags:
      --from string      Branch to be created from
  -h, --help             help for create
      --region string    Region for the database. Can not be used with --restore
      --restore string   Backup to restore into the branch. Backup can only be restored to its original region
      --seed-data        Add seed data using the Data Branching™ feature
      --wait             Wait until the branch is ready
...
```

A potential issue with this change is that that providing `--restore` and `--region` with the backup's correct region currently works as expected but would fail with this merged.

Fixes #874 