### PR TITLE
Upgrade Syft to latest version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
 GORELEASE_CROSS_VERSION ?= v1.22.3
-SYFT_VERSION ?= 0.102.0
+SYFT_VERSION ?= 1.9.0
 
 .PHONY: all
 all: build test lint

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -3,5 +3,5 @@ FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update && apt-get install -y openssh-client
 
-ARG SYFT_VERSION=0.102.0
+ARG SYFT_VERSION=1.9.0
 RUN wget -O syft.deb https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.deb && dpkg -i syft.deb


### PR DESCRIPTION
We're on an old version of Syft, latest version is 1.9.0. 