### PR TITLE
Upgrade `GORELEASE_CROSS_VERSION`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.22.3
+GORELEASE_CROSS_VERSION ?= v1.22.4
 SYFT_VERSION ?= 0.102.0
 
 .PHONY: all

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-ARG GORELEASE_CROSS_VERSION=v2.0.0
+ARG GORELEASE_CROSS_VERSION=v1.22.4
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update && apt-get install -y openssh-client

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-ARG GORELEASE_CROSS_VERSION=v1.25.1
+ARG GORELEASE_CROSS_VERSION=v2.0.0
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update && apt-get install -y openssh-client


### PR DESCRIPTION
This PR upgrades the `GORELASE_CROSS_VERSION` to 1.22.4. I followed the matrix here to get 1.22.4 and 2.0.0 

https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross/versions?filters%5Bversion_type%5D=tagged