### PR TITLE
Attempt to upgrade goreleaser again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.22.4
+GORELEASE_CROSS_VERSION ?= v1.22.3
 SYFT_VERSION ?= 1.9.0
 
 .PHONY: all

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-ARG GORELEASE_CROSS_VERSION=v1.22.4
+ARG GORELEASE_CROSS_VERSION=v1.26.2
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update && apt-get install -y openssh-client


### PR DESCRIPTION
Let's see if this one works. I went up to 1.26.2 from `goreleaser` versions.