### PR TITLE
Goreleaser configuration fixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: pscale
+version: 2
 release:
   prerelease: auto # don't publish release with -rc1,-pre, etc suffixes
 before:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -126,7 +126,7 @@ brews:
     dependencies:
       - name: mysql # needed for 'pscale shell'
         type: optional
-    folder: Formula
+    directory: Formula
     test: |
          system "#{bin}/pscale --version"
     install: |


### PR DESCRIPTION
This adds `version: 2` and changes `folder` to `directory` to see if we can get rid of deprecation warnings.