### PR TITLE
Fix syft call in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -150,7 +150,7 @@ sboms:
   -
     id: spdx-default
     documents: ["${artifact}.spdx.sbom"]
-    args: ["$artifact", "--file", "$sbom", "--output", "spdx-json"]
+    args: ["$artifact", "--output", "spdx-json=$document"]
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:


### PR DESCRIPTION
Publishing build is currently failing like this

```
[2024-07-12T18:37:45Z]   • cataloging artifacts
[2024-07-12T18:37:45Z]     • cataloging                                     cmd=syft artifact=dist/pscale_0.203.0_windows_arm.zip sbom=[pscale_0.203.0_windows_arm.zip.spdx.sbom]
[2024-07-12T18:37:46Z]     • took: 1s
[2024-07-12T18:37:46Z]   ⨯ release failed after 1m43s                       error=cataloging artifacts: command did not write any files, check your configuration
[2024-07-12T18:37:53Z] make: *** [Makefile:59: release] Error 
```

Current syft arguments looks like the old goreleaser defaults:
https://github.com/goreleaser/goreleaser/blob/bfdec808aba208cfdedeb3bef0a16255bf1d87b3/www/docs/customization/sbom.md

We're using a newer version of syft now that has deprecated `--file`, and I'm not sure `$sbom` is still available. This change should write the SBOM files to the expected locations and looks closer to the [current defaults](https://goreleaser.com/). 

Tested by running a snapshot release build locally:
<details>

```
~/planetscale/cli (jgreet/fix-release*)$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v `pwd`:/go/src/planetscale/pscale -w /go/src/planetscale/pscale releaser release --clean --snapshot
  • starting release...
  • loading                                          path=.goreleaser.yml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=35ff63b5e4ad671e90b3608e0021d987aeeea75e branch=jgreet/fix-release current_tag=v0.203.0 previous_tag=v0.202.0 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.203.0-next
  • running before hooks
    • running                                        hook=go mod tidy
    • running                                        hook=./script/completions
    • took: 21s
  • checking distribution directory
    • cleaning dist
  • setting up metadata
  • storing release metadata
    • writing                                        file=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/pscale_windows_amd64_v1/pscale.exe
    • building                                       binary=dist/darwin-arm64_darwin_arm64/pscale
    • building                                       binary=dist/pscale_linux_386/pscale
    • building                                       binary=dist/pscale_linux_arm_6/pscale
    • building                                       binary=dist/darwin-amd64_darwin_amd64_v1/pscale
    • building                                       binary=dist/pscale_linux_arm64/pscale
    • building                                       binary=dist/pscale_linux_amd64_v1/pscale
    • building                                       binary=dist/pscale_windows_386/pscale.exe
    • building                                       binary=dist/pscale_windows_arm64/pscale.exe
    • building                                       binary=dist/pscale_windows_arm_6/pscale.exe
    • took: 1m39s
  • archives
    • creating                                       archive=dist/pscale_v0.203.0-next_linux_arm.tar.gz
    • creating                                       archive=dist/pscale_v0.203.0-next_windows_386.zip
    • creating                                       archive=dist/pscale_v0.203.0-next_linux_arm64.tar.gz
    • creating                                       archive=dist/pscale_v0.203.0-next_macOS_arm64.tar.gz
    • creating                                       archive=dist/pscale_v0.203.0-next_windows_arm64.zip
    • creating                                       archive=dist/pscale_v0.203.0-next_linux_386.tar.gz
    • creating                                       archive=dist/pscale_v0.203.0-next_windows_arm.zip
    • creating                                       archive=dist/pscale_v0.203.0-next_macOS_amd64.tar.gz
    • creating                                       archive=dist/pscale_v0.203.0-next_windows_amd64.zip
    • creating                                       archive=dist/pscale_v0.203.0-next_linux_amd64.tar.gz
    • took: 10s
  • linux packages
    • creating                                       package=pscale format=rpm arch=arm64 file=dist/pscale_v0.203.0-next_linux_arm64.rpm
    • creating                                       package=pscale format=deb arch=arm64 file=dist/pscale_v0.203.0-next_linux_arm64.deb
    • creating                                       package=pscale format=deb arch=386 file=dist/pscale_v0.203.0-next_linux_386.deb
    • creating                                       package=pscale format=rpm arch=amd64v1 file=dist/pscale_v0.203.0-next_linux_amd64.rpm
    • creating                                       package=pscale format=deb arch=arm6 file=dist/pscale_v0.203.0-next_linux_arm.deb
    • creating                                       package=pscale format=deb arch=amd64v1 file=dist/pscale_v0.203.0-next_linux_amd64.deb
    • creating                                       package=pscale format=rpm arch=386 file=dist/pscale_v0.203.0-next_linux_386.rpm
    • creating                                       package=pscale format=rpm arch=arm6 file=dist/pscale_v0.203.0-next_linux_arm.rpm
    • took: 1s
  • cataloging artifacts
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_windows_arm.zip sbom=[pscale_v0.203.0-next_windows_arm.zip.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_windows_386.zip sbom=[pscale_v0.203.0-next_windows_386.zip.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_windows_arm64.zip sbom=[pscale_v0.203.0-next_windows_arm64.zip.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_windows_amd64.zip sbom=[pscale_v0.203.0-next_windows_amd64.zip.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_linux_arm.tar.gz sbom=[pscale_v0.203.0-next_linux_arm.tar.gz.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_linux_386.tar.gz sbom=[pscale_v0.203.0-next_linux_386.tar.gz.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_macOS_arm64.tar.gz sbom=[pscale_v0.203.0-next_macOS_arm64.tar.gz.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_linux_arm64.tar.gz sbom=[pscale_v0.203.0-next_linux_arm64.tar.gz.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_macOS_amd64.tar.gz sbom=[pscale_v0.203.0-next_macOS_amd64.tar.gz.spdx.sbom]
    • cataloging                                     cmd=syft artifact=dist/pscale_v0.203.0-next_linux_amd64.tar.gz sbom=[pscale_v0.203.0-next_linux_amd64.tar.gz.spdx.sbom]
    • took: 15s
  • calculating checksums
  • arch user repositories
    • writing                                        file=dist/aur/pscale-cli-bin.pkgbuild
    • writing                                        file=dist/aur/pscale-cli-bin.srcinfo
  • homebrew tap formula
    • writing                                        formula=dist/homebrew/Formula/pscale.rb
  • scoop manifests
    • writing                                        manifest=dist/scoop/pscale.json
  • docker images
    • building docker image                          image=planetscale/pscale:latest
    • took: 1s
  • storing artifacts metadata
    • writing                                        file=dist/artifacts.json
  • release succeeded after 2m27s
  • thanks for using goreleaser!
```
</details>