### PR TITLE
`pscale database dump`: support shard targeting

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -27,6 +27,7 @@ type dumpFlags struct {
 	localAddr  string
 	remoteAddr string
 	keyspace   string
+	shard      string
 	replica    bool
 	tables     string
 	wheres     string
@@ -46,6 +47,7 @@ func DumpCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&f.keyspace, "keyspace",
 		"", "Optionally target a specific keyspace to be dumped. Useful for sharded databases.")
+	cmd.PersistentFlags().StringVar(&f.shard, "shard", "", "Optional shard to target, must be used with keyspace")
 	cmd.PersistentFlags().StringVar(&f.localAddr, "local-addr",
 		"", "Local address to bind and listen for connections. By default the proxy binds to 127.0.0.1 with a random port.")
 	cmd.PersistentFlags().StringVar(&f.remoteAddr, "remote-addr", "",
@@ -72,6 +74,10 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 
 	if keyspace == "" {
 		keyspace = database
+	}
+
+	if flags.shard != "" && flags.keyspace == "" {
+		return fmt.Errorf("to target a single shard, please pass the --keyspace flag")
 	}
 
 	client, err := ch.Client()
@@ -215,6 +221,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	cfg.Password = "nobody"
 	cfg.Address = addr.String()
 	cfg.Database = dbName
+	cfg.Shard = flags.shard
 	cfg.Debug = ch.Debug()
 	cfg.StmtSize = 1000000
 	cfg.IntervalMs = 10 * 1000

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -234,8 +234,6 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 		cfg.SessionVars = append([]string{useCmd}, cfg.SessionVars...)
 	}
 
-	fmt.Println(cfg.SessionVars)
-
 	if flags.replica {
 		cfg.UseReplica = true
 	}

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -226,8 +226,15 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	cfg.StmtSize = 1000000
 	cfg.IntervalMs = 10 * 1000
 	cfg.ChunksizeInMB = 128
-	cfg.SessionVars = "set workload=olap;"
+	cfg.SessionVars = []string{"set workload=olap;"}
 	cfg.Outdir = dir
+
+	if flags.shard != "" {
+		useCmd := fmt.Sprintf("USE `%s/%s`;", dbName, flags.shard)
+		cfg.SessionVars = append([]string{useCmd}, cfg.SessionVars...)
+	}
+
+	fmt.Println(cfg.SessionVars)
 
 	if flags.replica {
 		cfg.UseReplica = true

--- a/internal/dumper/dumper_test.go
+++ b/internal/dumper/dumper_test.go
@@ -155,7 +155,7 @@ func TestDumper(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)
@@ -301,7 +301,7 @@ func TestDumperUseUseReplica(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 		UseReplica:    true,
 	}
 
@@ -448,7 +448,7 @@ func TestDumperGeneratedFields(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)
@@ -629,7 +629,7 @@ func TestDumperAll(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)
@@ -816,7 +816,7 @@ func TestDumperAllUseReplica(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 		UseReplica:    true,
 	}
 
@@ -1005,7 +1005,7 @@ func TestDumperMultiple(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)
@@ -1193,7 +1193,7 @@ func TestDumperMultipleUseReplica(t *testing.T) {
 		Threads:       16,
 		StmtSize:      10000,
 		IntervalMs:    500,
-		SessionVars:   "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:   []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 		UseReplica:    true,
 	}
 
@@ -1391,7 +1391,7 @@ func TestDumperSimpleRegexp(t *testing.T) {
 		Threads:        16,
 		StmtSize:       10000,
 		IntervalMs:     500,
-		SessionVars:    "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:    []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)
@@ -1588,7 +1588,7 @@ func TestDumperComplexRegexp(t *testing.T) {
 		Threads:        16,
 		StmtSize:       10000,
 		IntervalMs:     500,
-		SessionVars:    "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:    []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)
@@ -1790,7 +1790,7 @@ func TestDumperInvertMatch(t *testing.T) {
 		Threads:              16,
 		StmtSize:             10000,
 		IntervalMs:           500,
-		SessionVars:          "SET @@radon_streaming_fetch='ON', @@xx=1",
+		SessionVars:          []string{"SET @@radon_streaming_fetch='ON', @@xx=1"},
 	}
 
 	d, err := NewDumper(cfg)

--- a/internal/dumper/pool.go
+++ b/internal/dumper/pool.go
@@ -38,7 +38,7 @@ func (conn *Connection) StreamFetch(query string) (driver.Rows, error) {
 }
 
 // NewPool creates the new pool.
-func NewPool(log *zap.Logger, cap int, address string, user string, password string, vars string, database string) (*Pool, error) {
+func NewPool(log *zap.Logger, cap int, address string, user string, password string, vars []string, database string) (*Pool, error) {
 	conns := make(chan *Connection, cap)
 	for i := 0; i < cap; i++ {
 		client, err := driver.NewConn(user, password, address, database, "utf8")
@@ -46,10 +46,12 @@ func NewPool(log *zap.Logger, cap int, address string, user string, password str
 			return nil, err
 		}
 		conn := &Connection{ID: i, client: client}
-		if vars != "" {
-			err := conn.Execute(vars)
-			if err != nil {
-				return nil, err
+		if len(vars) > 0 {
+			for _, v := range vars {
+				err := conn.Execute(v)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		conns <- conn

--- a/internal/dumper/pool.go
+++ b/internal/dumper/pool.go
@@ -46,14 +46,13 @@ func NewPool(log *zap.Logger, cap int, address string, user string, password str
 			return nil, err
 		}
 		conn := &Connection{ID: i, client: client}
-		if len(vars) > 0 {
-			for _, v := range vars {
-				err := conn.Execute(v)
-				if err != nil {
-					return nil, err
-				}
+		for _, v := range vars {
+			err := conn.Execute(v)
+			if err != nil {
+				return nil, err
 			}
 		}
+
 		conns <- conn
 	}
 

--- a/internal/dumper/pool_test.go
+++ b/internal/dumper/pool_test.go
@@ -29,7 +29,7 @@ func TestPool(t *testing.T) {
 		fakedbs.AddQueryPattern("select .*", &sqltypes.Result{})
 	}
 
-	pool, err := NewPool(zaptest.NewLogger(t), 8, address, "mock", "mock", "", "")
+	pool, err := NewPool(zaptest.NewLogger(t), 8, address, "mock", "mock", nil, "")
 
 	c.Assert(err, qt.IsNil)
 


### PR DESCRIPTION
This allows one to pass `--shard` as well as `--keyspace` to support dumping from a single shard.

Note that this does not validate the shard exists; if an invalid keyspace is passed it will not dump any data. 