### PR TITLE
Do not use github token on update check

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -187,17 +187,6 @@ func latestVersion(ctx context.Context, addr string) (*ReleaseInfo, error) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
-	getToken := func() string {
-		if t := os.Getenv("GH_TOKEN"); t != "" {
-			return t
-		}
-		return os.Getenv("GITHUB_TOKEN")
-	}
-
-	if token := getToken(); token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
-	}
-
 	client := &http.Client{Timeout: time.Second * 15}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
When the token is invalid is causes the request to fail. Doing more harm than good.

Removing it, since rate limits have not been seen to be an issue for people without it set.