### PR TITLE
Unhide keyspace flag for `branch schema` command

### DIFF
--- a/internal/cmd/branch/schema.go
+++ b/internal/cmd/branch/schema.go
@@ -82,7 +82,6 @@ func SchemaCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&flags.web, "web", false, "Open in your web browser")
 	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "The keyspace in the branch")
-	cmd.Flags().MarkHidden("keyspace")
 
 	return cmd
 }


### PR DESCRIPTION
This pull request unhides the keyspace flag for the `branch schema` command so users know that they can pass it in to view a specific keyspace's schema.