### PR TITLE
Prevent --from and --seed-data being used with --restore

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -118,12 +118,14 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "Branch to be created from")
-	cmd.Flags().StringVar(&createReq.Region, "region", "", "Region for the database. Can not be used with --restore")
+	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
+	cmd.Flags().StringVar(&createReq.Region, "region", "", "Region for the branch. Can not be used with --restore")
 	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "Backup to restore into the branch. Backup can only be restored to its original region")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
+	cmd.MarkFlagsMutuallyExclusive("from", "restore")
 	cmd.MarkFlagsMutuallyExclusive("region", "restore")
+	cmd.MarkFlagsMutuallyExclusive("restore", "seed-data")
 
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		ctx := cmd.Context()


### PR DESCRIPTION
Marks a couple of additional flags as incompatible with `--restore`.

`--from` seems to be ignored during a restore as the new branch will always have the same parent as the branch the backup was taken from. There's no "from" option when restoring a backup from the web app.

`--seed-data` will always use the latest backup of the parent branch.



