### PR TITLE
Improve view support for pscale database dump / restore-dump

### DIFF
--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -107,11 +107,19 @@ func (d *Dumper) Run(ctx context.Context) error {
 	}
 
 	tables := make([][]string, len(databases))
+	views := make([]map[string]bool, len(databases))
 	for i, database := range databases {
 		if d.cfg.Table != "" {
 			tables[i] = strings.Split(d.cfg.Table, ",")
 		} else {
 			tables[i], err = d.allTables(conn, database)
+
+			if err != nil {
+				return err
+			}
+
+			views[i], err = d.allViews(conn, database)
+
 			if err != nil {
 				return err
 			}
@@ -135,12 +143,17 @@ func (d *Dumper) Run(ctx context.Context) error {
 			}
 
 			conn := initPool.Get()
-			err := d.dumpTableSchema(conn, database, table)
+			err := d.dumpTableSchema(conn, database, table, views[i])
 			if err != nil {
 				return err
 			}
 
 			initPool.Put(conn)
+
+			if _, ok := views[i][table]; ok {
+				// If we just processed a view we don't want to dump it so the next part is skipped:
+				continue
+			}
 
 			conn = pool.Get()
 			wg.Add(1)
@@ -200,7 +213,7 @@ func writeMetaData(outdir string) error {
 	return writeFile(file, "")
 }
 
-func (d *Dumper) dumpTableSchema(conn *Connection, database string, table string) error {
+func (d *Dumper) dumpTableSchema(conn *Connection, database string, table string, views map[string]bool) error {
 	qr, err := conn.Fetch(fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`", database, table))
 	if err != nil {
 		return err
@@ -209,6 +222,11 @@ func (d *Dumper) dumpTableSchema(conn *Connection, database string, table string
 	schema := qr.Rows[0][1].String() + ";\n"
 
 	file := fmt.Sprintf("%s/%s.%s-schema.sql", d.cfg.Outdir, database, table)
+	if _, ok := views[table]; ok {
+		// https://github.com/mydumper/mydumper/blob/e55612616d17281a45eed0a60a9b054cdd1fe064/src/myloader_common.c#L374
+		file = fmt.Sprintf("%s/%s.%s-schema-view.sql", d.cfg.Outdir, database, table)
+	}
+
 	err = writeFile(file, schema)
 	if err != nil {
 		return err
@@ -372,6 +390,24 @@ func (d *Dumper) allTables(conn *Connection, database string) ([]string, error) 
 		tables = append(tables, t[0].String())
 	}
 	return tables, nil
+}
+
+func (d *Dumper) allViews(conn *Connection, database string) (map[string]bool, error) {
+	query := `SELECT TABLE_NAME 
+			 FROM information_schema.TABLES 
+			 WHERE TABLE_SCHEMA LIKE '%s' 
+			 AND TABLE_TYPE = 'VIEW'
+			`
+	qr, err := conn.Fetch(fmt.Sprintf(query, database))
+	if err != nil {
+		return nil, err
+	}
+
+	views := make(map[string]bool)
+	for _, t := range qr.Rows {
+		views[t[0].String()] = true
+	}
+	return views, nil
 }
 
 func (d *Dumper) allDatabases(conn *Connection) ([]string, error) {

--- a/internal/dumper/dumper_test.go
+++ b/internal/dumper/dumper_test.go
@@ -115,6 +115,23 @@ func TestDumper(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	fieldsResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Field", Type: querypb.Type_VARCHAR},
@@ -140,6 +157,7 @@ func TestDumper(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test`\\..* .*", selectResult)
 		fakedbs.AddQueryPattern("set .*", &sqltypes.Result{})
@@ -261,6 +279,23 @@ func TestDumperUseUseReplica(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	fieldsResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Field", Type: querypb.Type_VARCHAR},
@@ -286,6 +321,7 @@ func TestDumperUseUseReplica(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* FROM `test@replica`\\..* .*", selectResult)
 		fakedbs.AddQueryPattern("set .*", &sqltypes.Result{})
@@ -408,6 +444,23 @@ func TestDumperGeneratedFields(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	fieldsResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{Name: "Field", Type: querypb.Type_VARCHAR},
@@ -433,6 +486,7 @@ func TestDumperGeneratedFields(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test`\\..* .*", selectResult)
 		fakedbs.AddQueryPattern("set .*", &sqltypes.Result{})
@@ -571,6 +625,23 @@ func TestDumperAll(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -614,6 +685,8 @@ func TestDumperAll(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2`\\..* .*", selectResult2)
@@ -758,6 +831,23 @@ func TestDumperAllUseReplica(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -801,6 +891,8 @@ func TestDumperAllUseReplica(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1@replica`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2@replica`\\..* .*", selectResult2)
@@ -946,6 +1038,23 @@ func TestDumperMultiple(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -989,6 +1098,8 @@ func TestDumperMultiple(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2`\\..* .*", selectResult2)
@@ -1134,6 +1245,23 @@ func TestDumperMultipleUseReplica(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -1177,6 +1305,8 @@ func TestDumperMultipleUseReplica(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1@replica`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2@replica`\\..* .*", selectResult2)
@@ -1323,6 +1453,23 @@ func TestDumperSimpleRegexp(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -1375,6 +1522,8 @@ func TestDumperSimpleRegexp(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2`\\..* .*", selectResult2)
@@ -1520,6 +1669,23 @@ func TestDumperComplexRegexp(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -1572,6 +1738,8 @@ func TestDumperComplexRegexp(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2`\\..* .*", selectResult2)
@@ -1717,6 +1885,23 @@ func TestDumperInvertMatch(t *testing.T) {
 		},
 	}
 
+	viewsResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "Views_in_test",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v1-2024-10-25")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("v2-2024-10-25")),
+			},
+		},
+	}
+
 	databasesResult := &sqltypes.Result{
 		Fields: []*querypb.Field{
 			{
@@ -1773,6 +1958,8 @@ func TestDumperInvertMatch(t *testing.T) {
 		fakedbs.AddQueryPattern("use .*", &sqltypes.Result{})
 		fakedbs.AddQueryPattern("show create table .*", schemaResult)
 		fakedbs.AddQueryPattern("show tables from .*", tablesResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test1' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
+		fakedbs.AddQueryPattern("select table_name \n\t\t\t from information_schema.tables \n\t\t\t where table_schema like 'test2' \n\t\t\t and table_type = 'view'\n\t\t\t", viewsResult)
 		fakedbs.AddQueryPattern("show fields from .*", fieldsResult)
 		fakedbs.AddQueryPattern("select .* from `test1`\\..* .*", selectResult1)
 		fakedbs.AddQueryPattern("select .* from `test2`\\..* .*", selectResult2)


### PR DESCRIPTION
This should address the problem described in the following two issues:
https://github.com/planetscale/cli/issues/921
https://github.com/planetscale/cli/issues/701

And adds support for exporting views with the `-schema-view.sql` suffix, avoids running the view queries and exporting data from them unnecessarily, and allows for restoring / overwriting the views when the `--overwrite-tables` flag is passed in.

The goal was to implement the desired functionality with minimal changes to the existing files but the new `information_schema` query that was added in `dumper.go` did lead to some required additions in the `dumper_test.go` file.

As I also have [PR#910](https://github.com/planetscale/cli/pull/910) open at the moment that includes other modifications to `dumper.go` and `loader.go` this one may be simpler to review / approve first and then I can update the other pull request afterward.
