### PR TITLE
Added context to longer-running functions for quicker cancellation

### DIFF
--- a/internal/dumper/loader.go
+++ b/internal/dumper/loader.go
@@ -85,7 +85,7 @@ func (l *Loader) Run(ctx context.Context) error {
 		eg.Go(func() error {
 			defer pool.Put(conn)
 
-			r, err := l.restoreTable(table, conn)
+			r, err := l.restoreTable(ctx, table, conn)
 			if err != nil {
 				return err
 			}
@@ -234,7 +234,7 @@ func (l *Loader) restoreTableSchema(overwrite bool, tables []string, conn *Conne
 	return nil
 }
 
-func (l *Loader) restoreTable(table string, conn *Connection) (int, error) {
+func (l *Loader) restoreTable(ctx context.Context, table string, conn *Connection) (int, error) {
 	bytes := 0
 	part := "0"
 	base := filepath.Base(table)
@@ -277,6 +277,11 @@ func (l *Loader) restoreTable(table string, conn *Connection) (int, error) {
 	querys := strings.Split(query1, ";\n")
 	bytes = len(query1)
 	for _, query := range querys {
+		// Allows for quicker exit when using Ctrl+C at the Terminal:
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+
 		if !strings.HasPrefix(query, "/*") && query != "" {
 			err = conn.Execute(query)
 			if err != nil {


### PR DESCRIPTION
Currently, when using either the `pscale database dump` or `pscale database restore-dump` commands there may be times where you would like to cancel out of the operation because it is taking too long, a mistake was made, etc.

At the moment the behavior for both commands is not ideal in these cases since you can attempt to send a `Ctrl+C` command but it won't be very responsive / immediate as you expect it to be.

Instead, depending on the length of time the operation has remaining, it may actually continue to completion and/or the renewal of the temporary 5 minute credential won't occur and it will stop / error then.

```console
# This is an example of the dump completing in spite of pressing Ctrl+C early on in the process:
% pscale database dump <DATABASE> <BRANCH> --org=<ORG> --output="<DUMP_DIRECTORY>"    

Starting to dump all tables from database <DATABASE> to folder <DUMP_DIRECTORY>
Dumping is finished! (elapsed time: 1m20.733552s)

# This is an example of Ctrl+C being somewhat received but the restore times out ~5 minutes later when the credential can't renew:
% pscale database restore-dump <DATABASE> <BRANCH> --org=<ORG> --dir="<DUMP_DIRECTORY>" --overwrite-tables --threads=4
Starting to restore database <DATABASE> from folder <DUMP_DIRECTORY>

⠹ Restoring database ...2024-10-25T14:07:09-07:00	error	error restoring	{"error": "unauthenticated: invalid auth credentials (errno 1105) (sqlstate HY000)"}
Error: failed to restore database: unauthenticated: invalid auth credentials (errno 1105) (sqlstate HY000)
```

There is likely a more comprehensive approach to using contexts properly here that my limited Go knowledge is unaware of, but it seemed like passing in the current context into the longer-running functions that do the bulk of the data exporting / loading was enough to make `Ctrl+C` responsive enough for my expectations.

Now with the quicker cancellation option as soon as I press `Ctrl+C` the restore cancels pretty immediately thereafter:


```console
% pscale database dump <DATABASE> <BRANCH> --org=<ORG> --output="<DUMP_DIRECTORY>"

Starting to dump all tables from database <DATABASE> to folder <DUMP_DIRECTORY>
⠋ Dumping tables ...^C2024-10-25T14:11:32-07:00	error	error dumping table	{"error": "context canceled"}
Dumping is finished! (elapsed time: 6.207360375s)

% pscale database restore-dump <DATABASE> <BRANCH> --org=<ORG> --dir="<DUMP_DIRECTORY>" --overwrite-tables --threads=4

Starting to restore database <DATABASE> from folder <DUMP_DIRECTORY>
⠙ Restoring database ...2024-10-25T14:01:34-07:00	error	error restoring	{"error": "context canceled"}
Error: failed to restore database: context canceled
```

