### PR TITLE
Do not reset default organization on auth

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -73,9 +73,17 @@ func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 			ch.Printer.Println("Successfully logged in.")
 
-			err = writeDefaultOrganization(ctx, accessToken, authURL)
+			writeConfig := false
+			cfg, err := ch.ConfigFS.DefaultConfig()
 			if err != nil {
-				return err
+				writeConfig = true
+			}
+
+			if writeConfig || cfg.Organization == "" {
+				err = writeDefaultOrganization(ctx, accessToken, authURL)
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil


### PR DESCRIPTION
This preserves the `org` setting when running `pscale auth login`. It will now only write it if there is no setting, or the setting is blank.