### PR TITLE
Improve service token value input processing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,6 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 	}
 
 	if c.ServiceTokenIsSwapped() {
-		fmt.Println("The --service-token and --service-token-id are currently swapped.")
 		var correctServiceTokenID = c.ServiceToken
 		var correctServiceToken = c.ServiceTokenID
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,10 +56,6 @@ func (c *Config) IsAuthenticated() error {
 		return errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
-	if c.ServiceTokenIsSwapped() {
-		return errors.New("the --service-token and --service-token-id values are swapped")
-	}
-
 	if c.ServiceTokenIsSet() {
 		return nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,10 @@ func (c *Config) IsAuthenticated() error {
 		return errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
+	if c.ServiceTokenIsSwapped() {
+		return errors.New("the --service-token and --service-token-id values are swapped")
+	}
+
 	if c.ServiceTokenIsSet() {
 		return nil
 	}
@@ -71,6 +75,10 @@ func (c *Config) ServiceTokenIsSet() bool {
 	return c.ServiceToken != "" && c.ServiceTokenID != ""
 }
 
+func (c *Config) ServiceTokenIsSwapped() bool {
+	return strings.HasPrefix(c.ServiceTokenID, "pscale_tkn_") && len(c.ServiceToken) == 12
+}
+
 // NewClientFromConfig creates a PlanetScale API client from our configuration
 func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client, error) {
 	opts := []ps.ClientOption{
@@ -79,6 +87,15 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 
 	if (c.ServiceToken == "" && c.ServiceTokenID != "") || (c.ServiceToken != "" && c.ServiceTokenID == "") {
 		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
+	}
+
+	if c.ServiceTokenIsSwapped() {
+		fmt.Println("The --service-token and --service-token-id are currently swapped.")
+		var correctServiceTokenID = c.ServiceToken
+		var correctServiceToken = c.ServiceTokenID
+
+		c.ServiceTokenID = correctServiceTokenID
+		c.ServiceToken = correctServiceToken
 	}
 
 	if c.ServiceTokenIsSet() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ func (c *Config) IsAuthenticated() error {
 	}
 
 	if c.ServiceTokenIsSwapped() {
-		return errors.New("the --service-token and --service-token-id values are swapped")
+		return errors.New("it looks like you swapped the --service-token and --service-token-id values")
 	}
 
 	if c.ServiceTokenIsSet() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,10 @@ func (c *Config) IsAuthenticated() error {
 		return errors.New("both --service-token and --service-token-id are required for service token authentication")
 	}
 
+	if c.ServiceTokenIsSwapped() {
+		return errors.New("the --service-token and --service-token-id values are swapped")
+	}
+
 	if c.ServiceTokenIsSet() {
 		return nil
 	}
@@ -83,14 +87,6 @@ func (c *Config) NewClientFromConfig(clientOpts ...ps.ClientOption) (*ps.Client,
 
 	if (c.ServiceToken == "" && c.ServiceTokenID != "") || (c.ServiceToken != "" && c.ServiceTokenID == "") {
 		return nil, errors.New("both --service-token and --service-token-id are required for service token authentication")
-	}
-
-	if c.ServiceTokenIsSwapped() {
-		var correctServiceTokenID = c.ServiceToken
-		var correctServiceToken = c.ServiceTokenID
-
-		c.ServiceTokenID = correctServiceTokenID
-		c.ServiceToken = correctServiceToken
 	}
 
 	if c.ServiceTokenIsSet() {


### PR DESCRIPTION
Addresses a situation that can currently occur somewhat easily with the `--service-token-id` and `--service-token` values passed in via the CLI.

If the values are accidentally passed in a swapped manner, then when attempting to run your CLI command a user might receive something like the following error, rather than a more specific error message about the values being swapped:

```
Error: organization <ORG> does not exist or your account is not authorized to access it
```

There are a few ways to handle this situation, such as having a hard error thrown during the `IsAuthenticated()` check to direct users to the issue to automatically swapping the values internally for the user if it is detected they have provided values in the correct format that have simply been swapped.

For this pull request the more automatic approach has been used so if a swap is detected, the values will be swapped to the correct variables first and then used, which generally should lead to things simply working for users in these cases.