### PR TITLE
Allow `pscale connect` to accept interactivity

### DIFF
--- a/internal/cmd/connect/connect.go
+++ b/internal/cmd/connect/connect.go
@@ -262,6 +262,7 @@ func runCommand(ctx context.Context, addr, command, protocol, databaseEnvURL, da
 
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Env = os.Environ()
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
View the before and after video here: https://screen.studio/share/YVe5yTeO

Updates the `pscale` connect command to support interactive input during execution. Previously, the command couldn’t handle user interactions. By adjusting the standard input configuration in `internal/cmd/connect/connect.go`, this change enables interactive sessions, enhancing the command’s usability.

**Why?**
I was having issues getting DrizzleORM's `push` command working with the new `VECTOR` data type in PlanetScale. It would not work with `drizzle-kit` by normally adding the credentials.

Though, when setting the `dbCredentials` in the Drizzle config to the following and using `pscale connect --execute` it works just fine:
```ts
export default {
	schema: './src/db/schema.ts',
	out: './drizzle/migrations',
	dialect: 'mysql',
	dbCredentials: {
		url: process.env.DATABASE_URL!,
	},
	strict: process.env.NODE_ENV !== 'production',
	verbose: true,
	casing: 'snake_case',
} satisfies Config
```

Reference Discord Thread: https://discord.com/channels/1134636291691126885/1321148787611402240