### PR TITLE
Update psdbproxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/planetscale/planetscale-go v0.116.0
 	github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7
-	github.com/planetscale/psdbproxy v0.0.0-20241106211041-dc5c7c72df26
+	github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/planetscale/planetscale-go v0.116.0 h1:jXR32sTfQOWzoVBuwHLjqh0XktH6AT
 github.com/planetscale/planetscale-go v0.116.0/go.mod h1:ldGffCLckkR8fjGDjDFs4WcjlDr8uqg2qRUZhRYBEMI=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7 h1:dxdoFKWVDlV1gq8UQC8NWCofLjCEjEHw47gfeojgs28=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
-github.com/planetscale/psdbproxy v0.0.0-20241106211041-dc5c7c72df26 h1:u4Q86W+Id75X8RzhSXBwmqZ1HeE1Wbi07JfdFP7DEOc=
-github.com/planetscale/psdbproxy v0.0.0-20241106211041-dc5c7c72df26/go.mod h1:jwsavEvsWJTBIVdk8Ht083vxQbfnvCgsy4MMOM044HQ=
+github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6 h1:/Ox1ZTAdk+soSngzzKoJh5voOzptrpPrux11o30rIaw=
+github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6/go.mod h1:jwsavEvsWJTBIVdk8Ht083vxQbfnvCgsy4MMOM044HQ=
 github.com/planetscale/vitess-types v0.0.0-20231211191709-770e14433716 h1:FD6vnHCirVPeyn+E6Z0HyXoAqXzjfTcRpgss/63im6w=
 github.com/planetscale/vitess-types v0.0.0-20231211191709-770e14433716/go.mod h1:8KWsIjuUBs+xlbfn9wBCxicFZqV8BCPIFoqlOSs+60I=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
Brings in planetscale/psdbproxy#27

This is currently an unexercised path, so in practice this doesn't crash currently, but would trigger a crash once we enable this path on vtgates if using OLAP mode through `pscale connect` only.