### PR TITLE
cli: write out new default org if the user cannot see the previous default

### DIFF
--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -144,7 +144,7 @@ func listCurrentOrgs(ctx context.Context, accessToken, authURL string) ([]*plane
 		planetscale.WithBaseURL(authURL),
 	)
 	if err != nil {
-		return nil, err
+		return nil, cmdutil.HandleError(err)
 	}
 
 	orgs, err := client.Organizations.List(ctx)


### PR DESCRIPTION
In https://github.com/planetscale/cli/pull/938 we had the CLI not touch the configuration file if the user was authenticating. This is a good thing to do if the user is re-authenticating to the same user, but they're not always doing that.

If a user switches between two accounts and their new account does not have access to the previously configured organization, the CLI will default to the previous account and fail, appearing broken.

This goes ahead and lists the orgs the user is in - if the previous default is not in the list of orgs the new user is in, it rewrites the config. 