### PR TITLE
Use MySQL 8 client in Docker image instead of MariaDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ ARG DATE
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
 FROM ubuntu:noble
-RUN apt-get update && apt-get install -y ca-certificates mysql-client openssh-client
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates mysql-client openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 ENV LANG=C.utf8
 EXPOSE 3306
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION
 ARG COMMIT
 ARG DATE
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w -X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
 FROM ubuntu:noble
 RUN apt-get update && apt-get install -y ca-certificates mysql-client openssh-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0 as build
+FROM golang:1.24.0 AS build
 WORKDIR /app
 COPY . .
 
@@ -8,10 +8,11 @@ ARG DATE
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w X main.commit=$COMMIT -X main.version=$VERSION -X main.date=$DATE" github.com/planetscale/cli/cmd/pscale
 
-FROM alpine:latest  
-RUN apk --no-cache add ca-certificates mysql-client openssh-client
+FROM ubuntu:noble
+RUN apt-get update && apt-get install -y ca-certificates mysql-client openssh-client
+ENV LANG=C.utf8
 EXPOSE 3306
 
 WORKDIR /app
 COPY --from=build /app/pscale /usr/bin
-ENTRYPOINT ["/usr/bin/pscale"] 
+ENTRYPOINT ["/usr/bin/pscale"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 COMMIT := $(shell git rev-parse --short=7 HEAD 2>/dev/null)
-VERSION := $(shell git describe --abbrev=0 HEAD 2>/dev/null)
+VERSION := $(shell git describe --tags --abbrev=0 HEAD 2>/dev/null)
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 ifeq ($(strip $(shell git status --porcelain 2>/dev/null)),)


### PR DESCRIPTION
As documented in https://github.com/planetscale/cli/issues/929 the mysql client package for Apline is actually MariaDB which breaks `pscale shell`. There doesn't seem to a simple way to get the MySQL 8 client installed in Alpine Linux.

```
/ # mysql --version
mysql  Ver 15.1 Distrib 10.11.8-MariaDB, for Linux (x86_64) using readline 5.1

/ # pscale shell beam main --org=jgreet --service-token-id=XXX --service-token=pscale_tkn_XXX
Error: could not parse server version from: mysql  Ver 15.1 Distrib 10.11.8-MariaDB, for Linux (x86_64) using readline 5.1
```

This PR swaps the base image to a current Ubuntu LTS release for an easy MySQL clien install. The tradeoff is it expands the Docker image from 82MB to 204MB. 

```
# mysql --version
mysql  Ver 8.0.41-0ubuntu0.24.04.1 for Linux on aarch64 ((Ubuntu))
#  pscale shell beam main --org=jgreet --service-token-id=XXX --service-token=pscale_tkn_XXX
beam/|⚠ main ⚠|>
```