### PR TITLE
Add `size` command for listing sizes

### DIFF
--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -72,7 +72,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
 
 	cmd.Flags().String("plan", "", "plan for the database. Options: hobby or scaler_pro")
-	cmd.Flags().String("cluster-size", "PS_10", "cluster size for Scaler Pro databases")
+	cmd.Flags().String("cluster-size", "PS_10", "cluster size for Scaler Pro databases. Use `pscale size cluster list` to see the valid sizes.")
 
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		return cmdutil.RegionsCompletionFunc(ch, cmd, args, toComplete)

--- a/internal/cmd/keyspace/create.go
+++ b/internal/cmd/keyspace/create.go
@@ -63,7 +63,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&flags.shards, "shards", 1, "Number of shards in the keyspace")
-	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS_10", "cluster size for the keyspace")
+	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS_10", "cluster size for the keyspace. Use `pscale size cluster list` to get a list of valid sizes.")
 	cmd.Flags().IntVar(&flags.additionalReplicas, "additional-replicas", 0, "number of additional replicas per shard. By default, each production cluster includes 2 replicas.")
 
 	cmd.MarkFlagRequired("cluster-size")

--- a/internal/cmd/keyspace/resize.go
+++ b/internal/cmd/keyspace/resize.go
@@ -89,7 +89,7 @@ func ResizeCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&flags.additionalReplicas, "additional-replicas", 0, "number of additional replicas per shard. By default, each production cluster includes 2 replicas.")
-	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "", "cluster size for the keyspace")
+	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "", "cluster size for the keyspace. Use `pscale size cluster list` to get a list of valid sizes.")
 
 	cmd.RegisterFlagCompletionFunc("cluster-size", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		return cmdutil.BranchClusterSizesCompletionFunc(ch, cmd, args, toComplete)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/planetscale/cli/internal/cmd/dataimports"
+	"github.com/planetscale/cli/internal/cmd/size"
 
 	"github.com/fatih/color"
 	"github.com/planetscale/cli/internal/cmd/api"
@@ -224,6 +225,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.AddCommand(region.RegionCmd(ch))
 	rootCmd.AddCommand(shell.ShellCmd(ch, sigc, signals...))
 	rootCmd.AddCommand(signup.SignupCmd(ch))
+	rootCmd.AddCommand(size.SizeCmd(ch))
 	rootCmd.AddCommand(token.TokenCmd(ch))
 	rootCmd.AddCommand(version.VersionCmd(ch, ver, commit, buildDate))
 

--- a/internal/cmd/size/cluster.go
+++ b/internal/cmd/size/cluster.go
@@ -1,0 +1,123 @@
+package size
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func ClusterCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "cluster <command>",
+		Short:   "List the sizes for PlanetScale databases",
+		Aliases: []string{"clusters"},
+	}
+
+	cmd.AddCommand(
+		ListCmd(ch),
+	)
+
+	return cmd
+}
+
+func ListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		region string
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List the sizes that are available for a PlanetScale database",
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			clusterSKUs, err := client.Organizations.ListClusterSKUs(ctx, &planetscale.ListOrganizationClusterSKUsRequest{
+				Organization: ch.Config.Organization,
+			}, planetscale.WithRates(), planetscale.WithRegion(flags.region))
+			if err != nil {
+				return err
+			}
+
+			slices.SortFunc(clusterSKUs, func(a, b *planetscale.ClusterSKU) int {
+				return cmp.Compare(a.SortOrder, b.SortOrder)
+			})
+
+			return ch.Printer.PrintResource(toClusterSKUs(clusterSKUs))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.region, "region", "", "view cluster sizes and rates for a specific region")
+
+	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		return cmdutil.RegionsCompletionFunc(ch, cmd, args, toComplete)
+	})
+
+	return cmd
+}
+
+type ClusterSKU struct {
+	Name         string `header:"name" json:"name"`
+	Price        string `header:"cost" json:"rate"`
+	ReplicaPrice string `header:"cost per extra replica" json:"replica_rate"`
+	Provider     string `header:"provider,-" json:"provider"`
+	InstanceType string `header:"instance type,n/a" json:"instance_type"`
+	CPU          string `header:"cpu" json:"cpu"`
+	Memory       string `header:"memory" json:"memory"`
+	Storage      string `header:"storage,n/a" json:"storage"`
+}
+
+func toClusterSKUs(clusterSKUs []*planetscale.ClusterSKU) []*ClusterSKU {
+	clusters := make([]*ClusterSKU, 0, len(clusterSKUs))
+
+	for _, clusterSKU := range clusterSKUs {
+		if clusterSKU.Enabled && clusterSKU.Rate != nil {
+			storage := ""
+			if clusterSKU.Storage != nil {
+				storage = cmdutil.FormatParts(*clusterSKU.Storage).IntString()
+			}
+
+			cpu := fmt.Sprintf("%s vCPU", clusterSKU.CPU)
+			memory := cmdutil.FormatParts(clusterSKU.Memory).IntString()
+			rate := fmt.Sprintf("$%d", *clusterSKU.Rate)
+			replicaRate := ""
+			if clusterSKU.ReplicaRate != nil {
+				replicaRate = fmt.Sprintf("$%d", *clusterSKU.ReplicaRate)
+			}
+
+			provider := ""
+			if clusterSKU.Provider != nil {
+				provider = *clusterSKU.Provider
+			}
+
+			instanceType := ""
+			if clusterSKU.ProviderInstanceType != nil {
+				instanceType = *clusterSKU.ProviderInstanceType
+			}
+
+			cluster := &ClusterSKU{
+				Name:         clusterSKU.Name,
+				Storage:      storage,
+				CPU:          cpu,
+				Provider:     provider,
+				InstanceType: instanceType,
+				Memory:       memory,
+				Price:        rate,
+				ReplicaPrice: replicaRate,
+			}
+
+			clusters = append(clusters, cluster)
+		}
+	}
+
+	return clusters
+}

--- a/internal/cmd/size/cluster_test.go
+++ b/internal/cmd/size/cluster_test.go
@@ -1,0 +1,61 @@
+package size
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/cli/internal/testutil"
+
+	qt "github.com/frankban/quicktest"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestSizeCluster_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+
+	orig := []*ps.ClusterSKU{
+		{Name: "PS_10", Enabled: true, Rate: testutil.Pointer[int64](39)},
+	}
+	svc := &mock.OrganizationsService{
+		ListClusterSKUsFn: func(ctx context.Context, req *ps.ListOrganizationClusterSKUsRequest, opts ...ps.ListOption) ([]*ps.ClusterSKU, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			return orig, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Organizations: svc,
+			}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListClusterSKUsFnInvoked, qt.IsTrue)
+
+	res := []*ClusterSKU{
+		{orig: orig[0]},
+	}
+
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}

--- a/internal/cmd/size/size.go
+++ b/internal/cmd/size/size.go
@@ -1,15 +1,9 @@
 package size
 
 import (
-	"fmt"
-
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
-
-func main() {
-	fmt.Println("vim-go")
-}
 
 func SizeCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{

--- a/internal/cmd/size/size.go
+++ b/internal/cmd/size/size.go
@@ -1,0 +1,28 @@
+package size
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	fmt.Println("vim-go")
+}
+
+func SizeCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "size <command>",
+		Short:             "Lists the sizes for various components within PlanetScale",
+		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
+	}
+
+	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization,
+		"The organization for the current user")
+	cmd.MarkPersistentFlagRequired("org") // nolint: errcheck
+
+	cmd.AddCommand(ClusterCmd(ch))
+
+	return cmd
+}

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -55,11 +55,11 @@ func ClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []string, t
 			}
 
 			if c.Memory > 0 {
-				description.WriteString(fmt.Sprintf(" · %s memory", formatParts(c.Memory).IntString()))
+				description.WriteString(fmt.Sprintf(" · %s memory", FormatParts(c.Memory).IntString()))
 			}
 
 			if c.Storage != nil && *c.Storage > 0 {
-				description.WriteString(fmt.Sprintf(" · %s storage", formatParts(*c.Storage).IntString()))
+				description.WriteString(fmt.Sprintf(" · %s storage", FormatParts(*c.Storage).IntString()))
 			}
 
 			clusterSizes = append(clusterSizes, cobra.CompletionWithDesc(c.Name, description.String()))
@@ -115,11 +115,11 @@ func BranchClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []str
 			}
 
 			if c.Memory > 0 {
-				description.WriteString(fmt.Sprintf(" · %s memory", formatParts(c.Memory).IntString()))
+				description.WriteString(fmt.Sprintf(" · %s memory", FormatParts(c.Memory).IntString()))
 			}
 
 			if c.Storage != nil && *c.Storage > 0 {
-				description.WriteString(fmt.Sprintf(" · %s storage", formatParts(*c.Storage).IntString()))
+				description.WriteString(fmt.Sprintf(" · %s storage", FormatParts(*c.Storage).IntString()))
 			}
 
 			clusterSizes = append(clusterSizes, cobra.CompletionWithDesc(c.Name, description.String()))
@@ -206,7 +206,7 @@ func (b ByteFormat) IntString() string {
 	return fmt.Sprintf("%d %s", int64(b.value), b.unit)
 }
 
-func formatParts(bytes int64) ByteFormat {
+func FormatParts(bytes int64) ByteFormat {
 	kb := int64(1024)
 	mb := int64(kb * 1024)
 	gb := int64(mb * 1024)

--- a/internal/testutil/common.go
+++ b/internal/testutil/common.go
@@ -1,0 +1,5 @@
+package testutil
+
+func Pointer[K any](val K) *K {
+	return &val
+}


### PR DESCRIPTION
This pull request adds a `size` command for us to list sizes of various resources within PlanetScale. The first component that we implemented was cluster sizing, so a user can get a list of all sizes using `pscale size  cluster list` and get all of the valid sizes. This can be used in tandem with the database or keyspace creation flow in order for the users to know what the valid inputs are.

![image](https://github.com/user-attachments/assets/e263a912-d736-41ab-8381-21d142e511bb)
