### PR TITLE
Pluralize vCPU

### DIFF
--- a/internal/cmd/size/cluster.go
+++ b/internal/cmd/size/cluster.go
@@ -1,10 +1,8 @@
 package size
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
-	"slices"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/planetscale-go/planetscale"
@@ -48,10 +46,6 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			slices.SortFunc(clusterSKUs, func(a, b *planetscale.ClusterSKU) int {
-				return cmp.Compare(a.SortOrder, b.SortOrder)
-			})
 
 			return ch.Printer.PrintResource(toClusterSKUs(clusterSKUs))
 		},

--- a/internal/cmd/size/cluster.go
+++ b/internal/cmd/size/cluster.go
@@ -84,7 +84,7 @@ func toClusterSKU(clusterSKU *planetscale.ClusterSKU) *ClusterSKU {
 		storage = cmdutil.FormatPartsGB(*clusterSKU.Storage).IntString()
 	}
 
-	cpu := fmt.Sprintf("%s vCPUs",s clusterSKU.CPU)
+	cpu := fmt.Sprintf("%s vCPUs", clusterSKU.CPU)
 	memory := cmdutil.FormatParts(clusterSKU.Memory).IntString()
 	rate := ""
 	if *clusterSKU.Rate > 0 {

--- a/internal/cmd/size/cluster.go
+++ b/internal/cmd/size/cluster.go
@@ -84,7 +84,7 @@ func toClusterSKU(clusterSKU *planetscale.ClusterSKU) *ClusterSKU {
 		storage = cmdutil.FormatPartsGB(*clusterSKU.Storage).IntString()
 	}
 
-	cpu := fmt.Sprintf("%s vCPU", clusterSKU.CPU)
+	cpu := fmt.Sprintf("%s vCPUs",s clusterSKU.CPU)
 	memory := cmdutil.FormatParts(clusterSKU.Memory).IntString()
 	rate := ""
 	if *clusterSKU.Rate > 0 {

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -93,7 +93,7 @@ func BranchClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []str
 
 	clusterSizes := make([]cobra.Completion, 0)
 	for _, c := range clusterSKUs {
-		if c.Enabled && strings.Contains(c.Name, toComplete) && c.Rate != nil {
+		if c.Enabled && strings.Contains(c.Name, toComplete) && c.Rate != nil && c.Name != "PS_DEV" {
 			var description strings.Builder
 			description.WriteString(c.DisplayName)
 			if *c.Rate > 0 {

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -45,7 +45,7 @@ func ClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []string, t
 			}
 
 			if c.CPU != "" {
-				description.WriteString(fmt.Sprintf(" · %s vCPU", c.CPU))
+				description.WriteString(fmt.Sprintf(" · %s vCPUs", c.CPU))
 			}
 
 			if c.Memory > 0 {
@@ -101,7 +101,7 @@ func BranchClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []str
 			}
 
 			if c.CPU != "" {
-				description.WriteString(fmt.Sprintf(" · %s vCPU", c.CPU))
+				description.WriteString(fmt.Sprintf(" · %s vCPUs", c.CPU))
 			}
 
 			if c.Memory > 0 {

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -1,9 +1,7 @@
 package cmdutil
 
 import (
-	"cmp"
 	"fmt"
-	"slices"
 	"strings"
 
 	ps "github.com/planetscale/planetscale-go/planetscale"
@@ -36,10 +34,6 @@ func ClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []string, t
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
-	slices.SortFunc(clusterSKUs, func(a, b *ps.ClusterSKU) int {
-		return cmp.Compare(a.SortOrder, b.SortOrder)
-	})
 
 	clusterSizes := make([]cobra.Completion, 0)
 	for _, c := range clusterSKUs {
@@ -96,10 +90,6 @@ func BranchClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []str
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-
-	slices.SortFunc(clusterSKUs, func(a, b *ps.ClusterSKU) int {
-		return cmp.Compare(a.SortOrder, b.SortOrder)
-	})
 
 	clusterSizes := make([]cobra.Completion, 0)
 	for _, c := range clusterSKUs {


### PR DESCRIPTION
This needs to be pluralized. Also, removes the sorting function because we now always return the SKUs in the sorted order.