### PR TITLE
Implement `reverse-traffic` command

### DIFF
--- a/internal/cmd/workflow/reverse_traffic.go
+++ b/internal/cmd/workflow/reverse_traffic.go
@@ -1,0 +1,66 @@
+package workflow
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func ReverseTrafficCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reverse-traffic <database> <number>",
+		Short: "Route queries back to the source keyspace for a specific workflow",
+		Long: `Route queries back to the source keyspace for a specific workflow in a PlanetScale database.
+This is useful when you need to rollback a traffic switch operation.`,
+		Args: cmdutil.RequiredArgs("database", "number"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			db, num := args[0], args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			var number uint64
+			number, err = strconv.ParseUint(num, 10, 64)
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Requesting to reverse traffic for workflow %s in database %s...", printer.BoldBlue(number), printer.BoldBlue(db)))
+			defer end()
+
+			workflow, err := client.Workflows.ReverseTraffic(ctx, &ps.ReverseTrafficWorkflowRequest{
+				Organization:   ch.Config.Organization,
+				Database:       db,
+				WorkflowNumber: number,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s or workflow %s does not exist in organization %s",
+						printer.BoldBlue(db), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Successfully started reversing traffic for workflow %s in database %s.\n",
+					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(db),
+				)
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toWorkflow(workflow))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/workflow/reverse_traffic_test.go
+++ b/internal/cmd/workflow/reverse_traffic_test.go
@@ -1,0 +1,131 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestWorkflow_ReverseTrafficCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	workflowNumber := uint64(123)
+
+	createdAt := time.Now()
+	reversedAt := time.Now()
+
+	// Create expected workflow response
+	expectedWorkflow := &ps.Workflow{
+		ID:              "workflow1",
+		Number:          workflowNumber,
+		Name:            "test-workflow",
+		State:           "traffic_reversed",
+		CreatedAt:       createdAt,
+		UpdatedAt:       createdAt,
+		ReversedAt:      &reversedAt,
+		ReplicasSwitched: false,  // Traffic has been reversed
+		PrimariesSwitched: false, // Traffic has been reversed
+		Tables:          []*ps.WorkflowTable{{Name: "table1"}, {Name: "table2"}},
+		SourceKeyspace: ps.Keyspace{
+			Name: "source_ks",
+		},
+		TargetKeyspace: ps.Keyspace{
+			Name: "target_ks",
+		},
+		Branch: ps.DatabaseBranch{
+			Name: "main",
+		},
+		Actor: ps.Actor{
+			Name: "test-user",
+		},
+		ReversedBy: &ps.Actor{
+			Name: "test-user",
+		},
+	}
+
+	// Mock the workflow service
+	svc := &mock.WorkflowsService{
+		ReverseTrafficFn: func(ctx context.Context, req *ps.ReverseTrafficWorkflowRequest) (*ps.Workflow, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.WorkflowNumber, qt.Equals, workflowNumber)
+
+			return expectedWorkflow, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Workflows: svc,
+			}, nil
+		},
+	}
+
+	cmd := ReverseTrafficCmd(ch)
+	cmd.SetArgs([]string{db, "123"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ReverseTrafficFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, expectedWorkflow)
+}
+
+func TestWorkflow_ReverseTrafficCmd_Error(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+
+	// Mock the workflow service to return an error
+	svc := &mock.WorkflowsService{
+		ReverseTrafficFn: func(ctx context.Context, req *ps.ReverseTrafficWorkflowRequest) (*ps.Workflow, error) {
+			return nil, &ps.Error{
+				Code: ps.ErrNotFound,
+			}
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Workflows: svc,
+			}, nil
+		},
+	}
+
+	cmd := ReverseTrafficCmd(ch)
+	cmd.SetArgs([]string{db, "123"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(svc.ReverseTrafficFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/workflow/workflow.go
+++ b/internal/cmd/workflow/workflow.go
@@ -21,6 +21,7 @@ func WorkflowCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(VerifyDataCmd(ch))
 	cmd.AddCommand(CreateCmd(ch))
 	cmd.AddCommand(SwitchTrafficCmd(ch))
+	cmd.AddCommand(ReverseTrafficCmd(ch))
 
 	return cmd
 }


### PR DESCRIPTION
As part of #999, we want to implement the `reverse-traffic` command for reversing traffic back to the source keyspace.