### PR TITLE
Update cluster sizing to use updated names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.129.0
+	github.com/planetscale/planetscale-go v0.130.0
 	github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7
 	github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.129.0 h1:lmmp+qbgJ2CDStZic7Tv1CgtIdnyvGA3/vTEHj3I3oE=
-github.com/planetscale/planetscale-go v0.129.0/go.mod h1:VE4Vn8+qWV8KlfcasKurXByncyqaL4NIA68DGep+AFg=
+github.com/planetscale/planetscale-go v0.130.0 h1:aA2nYW3JPAKTS8N9H5joEwk67xVWClfMjxz5qSp+SJw=
+github.com/planetscale/planetscale-go v0.130.0/go.mod h1:VE4Vn8+qWV8KlfcasKurXByncyqaL4NIA68DGep+AFg=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7 h1:dxdoFKWVDlV1gq8UQC8NWCofLjCEjEHw47gfeojgs28=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6 h1:/Ox1ZTAdk+soSngzzKoJh5voOzptrpPrux11o30rIaw=

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -64,7 +64,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().MarkDeprecated("notes", "is no longer available.")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
 
-	cmd.Flags().String("cluster-size", "PS_10", "cluster size for Scaler Pro databases. Use `pscale size cluster list` to see the valid sizes.")
+	cmd.Flags().String("cluster-size", "PS-10", "cluster size for Scaler Pro databases. Use `pscale size cluster list` to see the valid sizes.")
 
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		return cmdutil.RegionsCompletionFunc(ch, cmd, args, toComplete)

--- a/internal/cmd/keyspace/create.go
+++ b/internal/cmd/keyspace/create.go
@@ -63,7 +63,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 	cmd.Flags().IntVar(&flags.shards, "shards", 1, "Number of shards in the keyspace")
-	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS_10", "cluster size for the keyspace. Use `pscale size cluster list` to get a list of valid sizes.")
+	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS-10", "cluster size for the keyspace. Use `pscale size cluster list` to get a list of valid sizes.")
 	cmd.Flags().IntVar(&flags.additionalReplicas, "additional-replicas", 0, "number of additional replicas per shard. By default, each production cluster includes 2 replicas.")
 
 	cmd.MarkFlagRequired("cluster-size")

--- a/internal/cmd/keyspace/keyspace.go
+++ b/internal/cmd/keyspace/keyspace.go
@@ -40,7 +40,7 @@ type Keyspace struct {
 	Resizing      bool   `header:"resizing" json:"resizing"`
 	PendingResize bool   `header:"pending_resize" json:"resize_pending"`
 
-	ClusterSize string `header:"cluster_size" json:"cluster_rate_name"`
+	ClusterSize string `header:"cluster_size" json:"cluster_name"`
 	CreatedAt   int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
 	UpdatedAt   int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
 

--- a/internal/cmd/keyspace/resize.go
+++ b/internal/cmd/keyspace/resize.go
@@ -14,8 +14,8 @@ type KeyspaceResizeRequest struct {
 	ID    string `json:"id"`
 	State string `header:"state" json:"state"`
 
-	ClusterSize         string `header:"cluster_size" json:"cluster_rate_name"`
-	PreviousClusterSize string `header:"previous_cluster_size" json:"previous_cluster_rate_name"`
+	ClusterSize        string `header:"cluster_size" json:"cluster_name"`
+	PeviousClusterSize string `header:"previous_cluster_size" json:"previous_cluster_name"`
 
 	PreviousReplicas uint `header:"previous_replicas" json:"previous_replicas"`
 	Replicas         uint `header:"replicas" json:"replicas"`

--- a/internal/cmd/keyspace/resize_test.go
+++ b/internal/cmd/keyspace/resize_test.go
@@ -45,7 +45,7 @@ func TestKeyspace_ResizeCmd(t *testing.T) {
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.Keyspace, qt.Equals, keyspace)
 			c.Assert(*req.ExtraReplicas, qt.Equals, uint(3))
-			c.Assert(*req.ClusterSize, qt.Equals, "PS_10")
+			c.Assert(*req.ClusterSize, qt.Equals, "PS-10")
 
 			return krr, nil
 		},
@@ -64,7 +64,7 @@ func TestKeyspace_ResizeCmd(t *testing.T) {
 	}
 
 	cmd := ResizeCmd(ch)
-	cmd.SetArgs([]string{db, branch, keyspace, "--additional-replicas", "3", "--cluster-size", "PS_10"})
+	cmd.SetArgs([]string{db, branch, keyspace, "--additional-replicas", "3", "--cluster-size", "PS-10"})
 	err := cmd.Execute()
 	c.Assert(err, qt.IsNil)
 	c.Assert(svc.ResizeFnInvoked, qt.IsTrue)
@@ -102,7 +102,7 @@ func TestKeyspace_ResizeCmdOnlyClusterSize(t *testing.T) {
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.Keyspace, qt.Equals, keyspace)
 			c.Assert(req.ExtraReplicas, qt.IsNil)
-			c.Assert(*req.ClusterSize, qt.Equals, "PS_10")
+			c.Assert(*req.ClusterSize, qt.Equals, "PS-10")
 
 			return krr, nil
 		},
@@ -121,7 +121,7 @@ func TestKeyspace_ResizeCmdOnlyClusterSize(t *testing.T) {
 	}
 
 	cmd := ResizeCmd(ch)
-	cmd.SetArgs([]string{db, branch, keyspace, "--cluster-size", "PS_10"})
+	cmd.SetArgs([]string{db, branch, keyspace, "--cluster-size", "PS-10"})
 	err := cmd.Execute()
 	c.Assert(err, qt.IsNil)
 	c.Assert(svc.ResizeFnInvoked, qt.IsTrue)

--- a/internal/cmd/size/cluster.go
+++ b/internal/cmd/size/cluster.go
@@ -94,7 +94,7 @@ func toClusterSKU(clusterSKU *planetscale.ClusterSKU) *ClusterSKU {
 	}
 
 	cluster := &ClusterSKU{
-		Name:    clusterSKU.Name,
+		Name:    cmdutil.ToClusterSizeSlug(clusterSKU.Name),
 		Storage: storage,
 		CPU:     cpu,
 		Memory:  memory,

--- a/internal/cmd/size/cluster_test.go
+++ b/internal/cmd/size/cluster_test.go
@@ -26,7 +26,7 @@ func TestSizeCluster_ListCmd(t *testing.T) {
 	org := "planetscale"
 
 	orig := []*ps.ClusterSKU{
-		{Name: "PS_10", Enabled: true, Rate: testutil.Pointer[int64](39)},
+		{Name: "PS-10", Enabled: true, Rate: testutil.Pointer[int64](39)},
 	}
 	svc := &mock.OrganizationsService{
 		ListClusterSKUsFn: func(ctx context.Context, req *ps.ListOrganizationClusterSKUsRequest, opts ...ps.ListOption) ([]*ps.ClusterSKU, error) {

--- a/internal/cmdutil/completions.go
+++ b/internal/cmdutil/completions.go
@@ -39,13 +39,24 @@ func ClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []string, t
 	for _, c := range clusterSKUs {
 		if c.Enabled && strings.Contains(c.Name, toComplete) && c.Rate != nil && c.Name != "PS_DEV" {
 			var description strings.Builder
-			description.WriteString(c.DisplayName)
+			if c.Metal {
+				description.WriteString(c.DisplayName)
+			}
+
 			if *c.Rate > 0 {
-				description.WriteString(fmt.Sprintf(" · $%d/month", *c.Rate))
+				if description.Len() > 0 {
+					description.WriteString(fmt.Sprintf(" · $%d/month", *c.Rate))
+				} else {
+					description.WriteString(fmt.Sprintf("$%d/month", *c.Rate))
+				}
 			}
 
 			if c.CPU != "" {
-				description.WriteString(fmt.Sprintf(" · %s vCPUs", c.CPU))
+				if description.Len() > 0 {
+					description.WriteString(fmt.Sprintf(" · %s vCPUs", c.CPU))
+				} else {
+					description.WriteString(fmt.Sprintf("%s vCPUs", c.CPU))
+				}
 			}
 
 			if c.Memory > 0 {
@@ -56,7 +67,7 @@ func ClusterSizesCompletionFunc(ch *Helper, cmd *cobra.Command, args []string, t
 				description.WriteString(fmt.Sprintf(" · %s storage", FormatPartsGB(*c.Storage).IntString()))
 			}
 
-			clusterSizes = append(clusterSizes, cobra.CompletionWithDesc(c.Name, description.String()))
+			clusterSizes = append(clusterSizes, cobra.CompletionWithDesc(ToClusterSizeSlug(c.Name), description.String()))
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the cluster JSON fields to use `cluster_name` instead of `cluster_rate_name`. Additionally, we now have support for dasherized cluster names in the API, so we can use that everywhere since it looks cleaner.