### PR TITLE
Use number instead of name for the workflow messages

### DIFF
--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -67,7 +67,7 @@ marks it as cancelled, allowing you to start a new workflow if needed.`,
 				}
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Cancelling workflow %s in database %s…", printer.BoldBlue(number), printer.BoldBlue(db)))
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Cancelling workflow %s in database %s…", printer.BoldBlue(printer.Number(number)), printer.BoldBlue(db)))
 			defer end()
 
 			workflow, err := client.Workflows.Cancel(ctx, &ps.CancelWorkflowRequest{
@@ -88,7 +88,7 @@ marks it as cancelled, allowing you to start a new workflow if needed.`,
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Workflow %s in database %s has been cancelled.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db),
 				)
 				return nil

--- a/internal/cmd/workflow/complete.go
+++ b/internal/cmd/workflow/complete.go
@@ -31,7 +31,7 @@ func CompleteCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Marking workflow %s in database %s as complete…", printer.BoldBlue(number), printer.BoldBlue(db)))
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Marking workflow %s in database %s as complete…", printer.BoldBlue(printer.Number(number)), printer.BoldBlue(db)))
 			defer end()
 
 			workflow, err := client.Workflows.Complete(ctx, &ps.CompleteWorkflowRequest{
@@ -52,7 +52,7 @@ func CompleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Workflow %s in database %s has been marked as complete.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db),
 				)
 				return nil

--- a/internal/cmd/workflow/create.go
+++ b/internal/cmd/workflow/create.go
@@ -296,7 +296,7 @@ func createInteractive(ctx context.Context, ch *cmdutil.Helper, org, db, branch 
 		numTables = fmt.Sprintf("%d tables", len(workflow.Tables))
 	}
 
-	ch.Printer.Printf("Successfully created workflow %s. It will copy %s tables from %s to %s.", printer.BoldBlue(printer.Number(workflow.Number)), printer.Bold(numTables), printer.BoldBlue(workflow.SourceKeyspace.Name), printer.BoldBlue(workflow.TargetKeyspace.Name))
+	ch.Printer.Printf("Successfully created workflow %s. It will copy %s from %s to %s.", printer.BoldBlue(printer.Number(workflow.Number)), printer.Bold(numTables), printer.BoldBlue(workflow.SourceKeyspace.Name), printer.BoldBlue(workflow.TargetKeyspace.Name))
 
 	return nil
 }

--- a/internal/cmd/workflow/create.go
+++ b/internal/cmd/workflow/create.go
@@ -57,7 +57,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Successfully created workflow %s to copy %d tables from %s to %s.\n", printer.BoldBlue(workflow.Name), len(flags.tables), printer.Bold(flags.sourceKeyspace), printer.Bold(flags.targetKeyspace))
+				ch.Printer.Printf("Successfully created workflow %s to copy %d tables from %s to %s.\n", printer.BoldBlue(printer.Number(workflow.Number)), len(flags.tables), printer.Bold(flags.sourceKeyspace), printer.Bold(flags.targetKeyspace))
 				return nil
 			}
 
@@ -291,7 +291,12 @@ func createInteractive(ctx context.Context, ch *cmdutil.Helper, org, db, branch 
 		return err
 	}
 
-	ch.Printer.Printf("Successfully created workflow %s. It will copy %s tables from %s to %s.", printer.BoldBlue(workflow.Name), printer.Bold(len(workflow.Tables)), printer.BoldBlue(workflow.SourceKeyspace.Name), printer.BoldBlue(workflow.TargetKeyspace.Name))
+	numTables := "1 table"
+	if len(workflow.Tables) > 1 {
+		numTables = fmt.Sprintf("%d tables", len(workflow.Tables))
+	}
+
+	ch.Printer.Printf("Successfully created workflow %s. It will copy %s tables from %s to %s.", printer.BoldBlue(printer.Number(workflow.Number)), printer.Bold(numTables), printer.BoldBlue(workflow.SourceKeyspace.Name), printer.BoldBlue(workflow.TargetKeyspace.Name))
 
 	return nil
 }

--- a/internal/cmd/workflow/cutover.go
+++ b/internal/cmd/workflow/cutover.go
@@ -82,7 +82,7 @@ func CutoverCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Completing workflow %s in database %s…", printer.BoldBlue(number), printer.BoldBlue(db)))
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Completing workflow %s in database %s…", printer.BoldBlue(printer.Number(number)), printer.BoldBlue(db)))
 			defer end()
 
 			workflow, err := client.Workflows.Cutover(ctx, &ps.CutoverWorkflowRequest{
@@ -103,7 +103,7 @@ func CutoverCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Workflow %s successfully completed.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 				)
 				return nil
 			}

--- a/internal/cmd/workflow/retry.go
+++ b/internal/cmd/workflow/retry.go
@@ -31,7 +31,7 @@ func RetryCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Retrying workflow %s in database %s…", printer.BoldBlue(number), printer.BoldBlue(db)))
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Retrying workflow %s in database %s…", printer.BoldBlue(printer.Number(number)), printer.BoldBlue(db)))
 			defer end()
 
 			workflow, err := client.Workflows.Retry(ctx, &ps.RetryWorkflowRequest{
@@ -52,7 +52,7 @@ func RetryCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Workflow %s in database %s has been retried.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db),
 				)
 				return nil

--- a/internal/cmd/workflow/reverse_cutover.go
+++ b/internal/cmd/workflow/reverse_cutover.go
@@ -32,7 +32,7 @@ This is useful if your application has errors and you need to rollback after a c
 				return err
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Reversing cutover for workflow %s in database %s…", printer.BoldBlue(number), printer.BoldBlue(db)))
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Reversing cutover for workflow %s in database %s…", printer.BoldBlue(printer.Number(number)), printer.BoldBlue(db)))
 			defer end()
 
 			workflow, err := client.Workflows.ReverseCutover(ctx, &ps.ReverseCutoverWorkflowRequest{
@@ -54,7 +54,7 @@ This is useful if your application has errors and you need to rollback after a c
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Cutover reversed for workflow %s in database %s.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db),
 				)
 				return nil

--- a/internal/cmd/workflow/reverse_traffic.go
+++ b/internal/cmd/workflow/reverse_traffic.go
@@ -53,7 +53,7 @@ This is useful when you need to rollback a traffic switch operation.`,
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Successfully reversed traffic for workflow %s in database %s.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db),
 				)
 				return nil

--- a/internal/cmd/workflow/switch_traffic.go
+++ b/internal/cmd/workflow/switch_traffic.go
@@ -108,13 +108,13 @@ By default, this command will route all queries for primary, replica, and read-o
 			if ch.Printer.Format() == printer.Human {
 				if replicasOnly {
 					ch.Printer.Printf("Successfully switched query traffic from replica and read-only tablets to target keyspace for workflow %s in database %s.\n",
-						printer.BoldBlue(workflow.Name),
+						printer.BoldBlue(printer.Number(workflow.Number)),
 						printer.BoldBlue(db),
 					)
 					return nil
 				}
 				ch.Printer.Printf("Successfully switched queries from primary, replica, and read-only tablets to target keyspace for workflow %s in database %s.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db),
 				)
 				return nil

--- a/internal/cmd/workflow/verify_data.go
+++ b/internal/cmd/workflow/verify_data.go
@@ -51,7 +51,7 @@ func VerifyDataCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Successfully started data verification for workflow %s in database %s.\n",
-					printer.BoldBlue(workflow.Name),
+					printer.BoldBlue(printer.Number(workflow.Number)),
 					printer.BoldBlue(db))
 				return nil
 			}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -325,3 +325,8 @@ func Bold(msg interface{}) string {
 	// the 'color' package already handles IsTTY gracefully
 	return color.New(color.Bold).Sprint(msg)
 }
+
+// Number returns a formatted number with the # prefix
+func Number(number uint64) string {
+	return fmt.Sprintf("#%d", number)
+}


### PR DESCRIPTION
This pull request changes the workflow output messages to use the number instead of the name in workflow commands, since that's the primary identifier we use in the CLI commands. 