### PR TITLE
Max query size: clarify in help message

### DIFF
--- a/internal/cmd/database/restore.go
+++ b/internal/cmd/database/restore.go
@@ -59,7 +59,7 @@ func RestoreCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&f.endingTable, "ending-table", "",
 		"Table to end at for the restore (useful for stopping restore at a certain point)")
 	cmd.PersistentFlags().BoolVar(&f.allowDifferentDestination, "allow-different-destination", false, "If true, will allow you to restore the files to a database with a different name without needing to rename the existing dump's files.")
-	cmd.PersistentFlags().IntVar(&f.maxQuerySize, "max-query-size", 16777216, "The maximum size allowed for each individual query processed by the command. Currently limited to 16777216 bytes (16 MiB).")
+	cmd.PersistentFlags().IntVar(&f.maxQuerySize, "max-query-size", 16777216, "The maximum size allowed for each individual query processed by the command. Defaults to 16777216 bytes (16 MiB).")
 	cmd.PersistentFlags().IntVar(&f.threads, "threads", 1, "Number of concurrent threads to use to restore the database.")
 	return cmd
 }


### PR DESCRIPTION
This can be configured higher, this is the default. 