### PR TITLE
Fix error message when branching from branch that doesn't exist

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -85,8 +85,13 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("source database %s does not exist in organization %s",
-						printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+					if createReq.ParentBranch != "" {
+						return fmt.Errorf("source branch %s or database %s does not exist (organization: %s)",
+							printer.BoldBlue(createReq.ParentBranch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+					} else {
+						return fmt.Errorf("source database %s does not exist in organization %s",
+							printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+					}
 				default:
 					return cmdutil.HandleError(err)
 				}


### PR DESCRIPTION
The not_found response doesn't specify if it was the database or branch that wasn't found so we shouldn't assume it was the database in the user facing error message.

Fixes #954, https://github.com/planetscale/discussion/discussions/655