### PR TITLE
Add an experimental MCP server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.7.0
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
+	github.com/mark3labs/mcp-go v0.19.0
 	github.com/matoous/go-nanoid/v2 v2.1.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12
@@ -65,6 +66,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/golang/glog v1.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23 // indirect
@@ -97,6 +99,7 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/term v0.24.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241223144023-3abc09e42ca8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
@@ -102,6 +104,8 @@ github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7 h1:k/1ku0yeh
 github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7/go.mod h1:YR/zYthNdWfO8+0IOyHDcIDBBBS2JMnYUIwSsnwmRqU=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mark3labs/mcp-go v0.19.0 h1:cYKBPFD+fge273/TV6f5+TZYBSTnxV6GCJAO08D2wvA=
+github.com/mark3labs/mcp-go v0.19.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/matoous/go-nanoid/v2 v2.1.0 h1:P64+dmq21hhWdtvZfEAofnvJULaRR1Yib0+PnU669bE=
 github.com/matoous/go-nanoid/v2 v2.1.0/go.mod h1:KlbGNQ+FhrUNIHUxZdL63t7tl4LaPkZNpUULS8H4uVM=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -194,6 +198,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/xelabs/go-mysqlstack v1.0.0 h1:go/UqwlxKRNh9df+AQ/pAAgcCCHCaeyv0PYZ/quRbbw=
 github.com/xelabs/go-mysqlstack v1.0.0/go.mod h1:xw+rgelmcSTN/55nk7EcfriA9EeblS8w3nMSbad2yTc=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=

--- a/internal/cmd/mcp/install.go
+++ b/internal/cmd/mcp/install.go
@@ -1,0 +1,23 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// InstallCmd returns a new cobra.Command for the mcp install command.
+func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install the MCP server",
+		Long:  `Install the PlanetScale model context protocol (MCP) server.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("hello mcp install")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/mcp/install.go
+++ b/internal/cmd/mcp/install.go
@@ -1,11 +1,36 @@
 package mcp
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
+
+// ClaudeConfig represents the structure of the Claude Desktop config file
+type ClaudeConfig map[string]interface{}
+
+// getClaudeConfigDir returns the path to the Claude Desktop config directory based on the OS
+func getClaudeConfigDir() (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		// macOS path: ~/Library/Application Support/Claude/
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("could not determine user home directory: %w", err)
+		}
+		return filepath.Join(homeDir, "Library", "Application Support", "Claude"), nil
+	case "windows":
+		// Windows path: %APPDATA%\Claude\
+		return filepath.Join(os.Getenv("APPDATA"), "Claude"), nil
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+}
 
 // InstallCmd returns a new cobra.Command for the mcp install command.
 func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
@@ -19,7 +44,61 @@ func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
 			if target != "claude" {
 				return fmt.Errorf("invalid target vendor: %s (only 'claude' is supported)", target)
 			}
-			fmt.Printf("hello mcp install for target: %s\n", target)
+
+			configDir, err := getClaudeConfigDir()
+			if err != nil {
+				return fmt.Errorf("failed to determine Claude config directory: %w", err)
+			}
+
+			// Check if the directory exists
+			if _, err := os.Stat(configDir); os.IsNotExist(err) {
+				return fmt.Errorf("Claude Desktop is not installed: path %s not found", configDir)
+			}
+
+			configPath := filepath.Join(configDir, "claude_desktop_config.json")
+			config := make(ClaudeConfig)
+
+			// Check if the file exists
+			if _, err := os.Stat(configPath); err == nil {
+				// File exists, read it
+				configData, err := os.ReadFile(configPath)
+				if err != nil {
+					return fmt.Errorf("failed to read Claude config file: %w", err)
+				}
+
+				if err := json.Unmarshal(configData, &config); err != nil {
+					return fmt.Errorf("failed to parse Claude config file: %w", err)
+				}
+			}
+
+			// Get or initialize the mcpServers map
+			var mcpServers map[string]interface{}
+			if existingServers, ok := config["mcpServers"].(map[string]interface{}); ok {
+				mcpServers = existingServers
+			} else {
+				mcpServers = make(map[string]interface{})
+			}
+
+			// Add or update the planetscale server configuration
+			mcpServers["planetscale"] = map[string]interface{}{
+				"command": "pscale",
+				"args":    []string{"mcp", "server"},
+			}
+			
+			// Update the config with the new mcpServers
+			config["mcpServers"] = mcpServers
+
+			// Write the updated config back to file
+			configJSON, err := json.MarshalIndent(config, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal Claude config: %w", err)
+			}
+
+			if err := os.WriteFile(configPath, configJSON, 0644); err != nil {
+				return fmt.Errorf("failed to write Claude config file: %w", err)
+			}
+
+			fmt.Printf("MCP server successfully configured for %s at %s\n", target, configPath)
 			return nil
 		},
 	}

--- a/internal/cmd/mcp/install.go
+++ b/internal/cmd/mcp/install.go
@@ -9,15 +9,26 @@ import (
 
 // InstallCmd returns a new cobra.Command for the mcp install command.
 func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
+	var target string
+	
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the MCP server",
 		Long:  `Install the PlanetScale model context protocol (MCP) server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("hello mcp install")
+			if target != "claude" {
+				return fmt.Errorf("invalid target vendor: %s (only 'claude' is supported)", target)
+			}
+			fmt.Printf("hello mcp install for target: %s\n", target)
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&target, "target", "", "Target vendor for MCP installation (required). Possible values: [claude]")
+	cmd.MarkFlagRequired("target")
+	cmd.RegisterFlagCompletionFunc("target", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"claude"}, cobra.ShellCompDirectiveDefault
+	})
 
 	return cmd
 }

--- a/internal/cmd/mcp/install.go
+++ b/internal/cmd/mcp/install.go
@@ -52,7 +52,7 @@ func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			// Check if the directory exists
 			if _, err := os.Stat(configDir); os.IsNotExist(err) {
-				return fmt.Errorf("Claude Desktop is not installed: path %s not found", configDir)
+				return fmt.Errorf("no Claude Desktop installation: path %s not found", configDir)
 			}
 
 			configPath := filepath.Join(configDir, "claude_desktop_config.json")

--- a/internal/cmd/mcp/mcp.go
+++ b/internal/cmd/mcp/mcp.go
@@ -1,0 +1,23 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// McpCmd returns a new cobra.Command for the mcp command.
+func McpCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp <command>",
+		Short: "Manage and use the MCP server",
+		Long:  `Manage and use the PlanetScale model context protocol (MCP) server.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("hello mcp")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/mcp/mcp.go
+++ b/internal/cmd/mcp/mcp.go
@@ -1,8 +1,6 @@
 package mcp
 
 import (
-	"fmt"
-
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -13,11 +11,10 @@ func McpCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "mcp <command>",
 		Short: "Manage and use the MCP server",
 		Long:  `Manage and use the PlanetScale model context protocol (MCP) server.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("hello mcp")
-			return nil
-		},
 	}
+
+	cmd.AddCommand(InstallCmd(ch))
+	cmd.AddCommand(ServerCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -14,7 +17,28 @@ func ServerCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Start the MCP server",
 		Long:  `Start the PlanetScale model context protocol (MCP) server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("hello mcp server")
+			// Create a new MCP server
+			s := server.NewMCPServer(
+				"PlanetScale MCP Server",
+				"0.1.0",
+			)
+
+			// Create a simple hello tool without parameters
+			helloTool := mcp.NewTool("hello",
+				mcp.WithDescription("A simple hello world tool"),
+			)
+
+			// Add the hello tool handler
+			s.AddTool(helloTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				// Simply return "world" when called
+				return mcp.NewToolResultText("world"), nil
+			})
+
+			// Start the server
+			if err := server.ServeStdio(s); err != nil {
+				return fmt.Errorf("MCP server error: %v", err)
+			}
+
 			return nil
 		},
 	}

--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
 )
 
@@ -57,6 +58,70 @@ func ServerCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				// Return the JSON array as text
 				return mcp.NewToolResultText(string(orgNamesJSON)), nil
+			})
+
+			// Create a list_databases tool with an optional org parameter
+			listDatabasesTool := mcp.NewTool("list_databases",
+				mcp.WithDescription("List all databases in an organization"),
+				mcp.WithString("org", 
+					mcp.Description("The organization name (uses default organization if not specified)"),
+				),
+			)
+
+			// Add the list_databases tool handler
+			s.AddTool(listDatabasesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				// Get the PlanetScale client
+				client, err := ch.Client()
+				if err != nil {
+					return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
+				}
+
+				// Get the organization from the parameters or use the default
+				var orgName string
+				if org, ok := request.Params.Arguments["org"].(string); ok && org != "" {
+					orgName = org
+				} else {
+					// Try to load from default config file
+					fileConfig, err := ch.ConfigFS.DefaultConfig()
+					if err == nil && fileConfig.Organization != "" {
+						orgName = fileConfig.Organization
+					} else {
+						// Fall back to the config passed to the helper
+						orgName = ch.Config.Organization
+					}
+				}
+
+				if orgName == "" {
+					return nil, fmt.Errorf("no organization specified and no default organization set")
+				}
+
+				// Get the list of databases
+				databases, err := client.Databases.List(ctx, &planetscale.ListDatabasesRequest{
+					Organization: orgName,
+				})
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case planetscale.ErrNotFound:
+						return nil, fmt.Errorf("organization %s does not exist or your account is not authorized to access it", orgName)
+					default:
+						return nil, fmt.Errorf("failed to list databases: %w", err)
+					}
+				}
+
+				// Extract only the database names
+				dbNames := make([]string, 0, len(databases))
+				for _, db := range databases {
+					dbNames = append(dbNames, db.Name)
+				}
+
+				// Convert to JSON
+				dbNamesJSON, err := json.Marshal(dbNames)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal database names: %w", err)
+				}
+
+				// Return the JSON array as text
+				return mcp.NewToolResultText(string(dbNamesJSON)), nil
 			})
 
 			// Start the server

--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -1,0 +1,23 @@
+package mcp
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// ServerCmd returns a new cobra.Command for the mcp server command.
+func ServerCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "Start the MCP server",
+		Long:  `Start the PlanetScale model context protocol (MCP) server.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("hello mcp server")
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -12,6 +12,122 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Tool handler function type
+type ToolHandler func(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error)
+
+// Tool definition
+type ToolDef struct {
+	tool    mcp.Tool
+	handler ToolHandler
+}
+
+// HandleListOrgs implements the list_orgs tool
+func HandleListOrgs(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
+	// Get the PlanetScale client
+	client, err := ch.Client()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
+	}
+
+	// Get the list of organizations
+	orgs, err := client.Organizations.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organizations: %w", err)
+	}
+
+	// Extract only the organization names
+	orgNames := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		orgNames = append(orgNames, org.Name)
+	}
+
+	// Convert to JSON
+	orgNamesJSON, err := json.Marshal(orgNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal organization names: %w", err)
+	}
+
+	// Return the JSON array as text
+	return mcp.NewToolResultText(string(orgNamesJSON)), nil
+}
+
+// HandleListDatabases implements the list_databases tool
+func HandleListDatabases(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
+	// Get the PlanetScale client
+	client, err := ch.Client()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
+	}
+
+	// Get the organization from the parameters or use the default
+	var orgName string
+	if org, ok := request.Params.Arguments["org"].(string); ok && org != "" {
+		orgName = org
+	} else {
+		// Try to load from default config file
+		fileConfig, err := ch.ConfigFS.DefaultConfig()
+		if err == nil && fileConfig.Organization != "" {
+			orgName = fileConfig.Organization
+		} else {
+			// Fall back to the config passed to the helper
+			orgName = ch.Config.Organization
+		}
+	}
+
+	if orgName == "" {
+		return nil, fmt.Errorf("no organization specified and no default organization set")
+	}
+
+	// Get the list of databases
+	databases, err := client.Databases.List(ctx, &planetscale.ListDatabasesRequest{
+		Organization: orgName,
+	})
+	if err != nil {
+		switch cmdutil.ErrCode(err) {
+		case planetscale.ErrNotFound:
+			return nil, fmt.Errorf("organization %s does not exist or your account is not authorized to access it", orgName)
+		default:
+			return nil, fmt.Errorf("failed to list databases: %w", err)
+		}
+	}
+
+	// Extract only the database names
+	dbNames := make([]string, 0, len(databases))
+	for _, db := range databases {
+		dbNames = append(dbNames, db.Name)
+	}
+
+	// Convert to JSON
+	dbNamesJSON, err := json.Marshal(dbNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal database names: %w", err)
+	}
+
+	// Return the JSON array as text
+	return mcp.NewToolResultText(string(dbNamesJSON)), nil
+}
+
+// getToolDefinitions returns the list of all available MCP tools
+func getToolDefinitions() []ToolDef {
+	return []ToolDef{
+		{
+			tool: mcp.NewTool("list_orgs",
+				mcp.WithDescription("List all available organizations"),
+			),
+			handler: HandleListOrgs,
+		},
+		{
+			tool: mcp.NewTool("list_databases",
+				mcp.WithDescription("List all databases in an organization"),
+				mcp.WithString("org",
+					mcp.Description("The organization name (uses default organization if not specified)"),
+				),
+			),
+			handler: HandleListDatabases,
+		},
+	}
+}
+
 // ServerCmd returns a new cobra.Command for the mcp server command.
 func ServerCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
@@ -25,104 +141,16 @@ func ServerCmd(ch *cmdutil.Helper) *cobra.Command {
 				"0.1.0",
 			)
 
-			// Create a list_orgs tool without parameters
-			listOrgsTool := mcp.NewTool("list_orgs",
-				mcp.WithDescription("List all available organizations"),
-			)
-
-			// Add the list_orgs tool handler
-			s.AddTool(listOrgsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				// Get the PlanetScale client
-				client, err := ch.Client()
-				if err != nil {
-					return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
-				}
-
-				// Get the list of organizations
-				orgs, err := client.Organizations.List(ctx)
-				if err != nil {
-					return nil, fmt.Errorf("failed to list organizations: %w", err)
-				}
-
-				// Extract only the organization names
-				orgNames := make([]string, 0, len(orgs))
-				for _, org := range orgs {
-					orgNames = append(orgNames, org.Name)
-				}
-
-				// Convert to JSON
-				orgNamesJSON, err := json.Marshal(orgNames)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal organization names: %w", err)
-				}
-
-				// Return the JSON array as text
-				return mcp.NewToolResultText(string(orgNamesJSON)), nil
-			})
-
-			// Create a list_databases tool with an optional org parameter
-			listDatabasesTool := mcp.NewTool("list_databases",
-				mcp.WithDescription("List all databases in an organization"),
-				mcp.WithString("org", 
-					mcp.Description("The organization name (uses default organization if not specified)"),
-				),
-			)
-
-			// Add the list_databases tool handler
-			s.AddTool(listDatabasesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-				// Get the PlanetScale client
-				client, err := ch.Client()
-				if err != nil {
-					return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
-				}
-
-				// Get the organization from the parameters or use the default
-				var orgName string
-				if org, ok := request.Params.Arguments["org"].(string); ok && org != "" {
-					orgName = org
-				} else {
-					// Try to load from default config file
-					fileConfig, err := ch.ConfigFS.DefaultConfig()
-					if err == nil && fileConfig.Organization != "" {
-						orgName = fileConfig.Organization
-					} else {
-						// Fall back to the config passed to the helper
-						orgName = ch.Config.Organization
-					}
-				}
-
-				if orgName == "" {
-					return nil, fmt.Errorf("no organization specified and no default organization set")
-				}
-
-				// Get the list of databases
-				databases, err := client.Databases.List(ctx, &planetscale.ListDatabasesRequest{
-					Organization: orgName,
+			// Register all tools
+			for _, toolDef := range getToolDefinitions() {
+				// Create a tool-specific handler that will forward to our function
+				// We need to create a local copy of the tool definition to avoid closure issues
+				def := toolDef
+				// AddTool expects the tool value directly
+				s.AddTool(def.tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return def.handler(ctx, request, ch)
 				})
-				if err != nil {
-					switch cmdutil.ErrCode(err) {
-					case planetscale.ErrNotFound:
-						return nil, fmt.Errorf("organization %s does not exist or your account is not authorized to access it", orgName)
-					default:
-						return nil, fmt.Errorf("failed to list databases: %w", err)
-					}
-				}
-
-				// Extract only the database names
-				dbNames := make([]string, 0, len(databases))
-				for _, db := range databases {
-					dbNames = append(dbNames, db.Name)
-				}
-
-				// Convert to JSON
-				dbNamesJSON, err := json.Marshal(dbNames)
-				if err != nil {
-					return nil, fmt.Errorf("failed to marshal database names: %w", err)
-				}
-
-				// Return the JSON array as text
-				return mcp.NewToolResultText(string(dbNamesJSON)), nil
-			})
+			}
 
 			// Start the server
 			if err := server.ServeStdio(s); err != nil {

--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -2,14 +2,21 @@ package mcp
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net"
+	"time"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/passwordutil"
+	"github.com/planetscale/cli/internal/proxyutil"
 	"github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
+	"vitess.io/vitess/go/mysql"
 )
 
 // Tool handler function type
@@ -228,6 +235,193 @@ func HandleListKeyspaces(ctx context.Context, request mcp.CallToolRequest, ch *c
 	return mcp.NewToolResultText(string(keyspaceNamesJSON)), nil
 }
 
+// HandleRunQuery implements the run_query tool
+func HandleRunQuery(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
+	// Get the PlanetScale client
+	client, err := ch.Client()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
+	}
+
+	// Get the required database parameter
+	dbArg, ok := request.Params.Arguments["database"]
+	if !ok || dbArg == "" {
+		return nil, fmt.Errorf("database parameter is required")
+	}
+	database := dbArg.(string)
+
+	// Get the required branch parameter
+	branchArg, ok := request.Params.Arguments["branch"]
+	if !ok || branchArg == "" {
+		return nil, fmt.Errorf("branch parameter is required")
+	}
+	branch := branchArg.(string)
+
+	// Get the required keyspace parameter
+	keyspaceArg, ok := request.Params.Arguments["keyspace"]
+	if !ok || keyspaceArg == "" {
+		return nil, fmt.Errorf("keyspace parameter is required")
+	}
+	keyspace := keyspaceArg.(string)
+
+	// Get the required query parameter
+	queryArg, ok := request.Params.Arguments["query"]
+	if !ok || queryArg == "" {
+		return nil, fmt.Errorf("query parameter is required")
+	}
+	query := queryArg.(string)
+
+	// Get the organization
+	orgName, err := getOrganization(request, ch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if database and branch exist
+	dbBranch, err := client.DatabaseBranches.Get(ctx, &planetscale.GetDatabaseBranchRequest{
+		Organization: orgName,
+		Database:     database,
+		Branch:       branch,
+	})
+	if err != nil {
+		switch cmdutil.ErrCode(err) {
+		case planetscale.ErrNotFound:
+			return nil, fmt.Errorf("database %s and branch %s does not exist in organization %s",
+				database, branch, orgName)
+		default:
+			return nil, fmt.Errorf("failed to get database branch: %w", err)
+		}
+	}
+
+	if !dbBranch.Ready {
+		return nil, fmt.Errorf("database branch is not ready yet")
+	}
+
+	// Create a temporary password with reader role
+	pw, err := passwordutil.New(ctx, client, passwordutil.Options{
+		Organization: orgName,
+		Database:     database,
+		Branch:       branch,
+		Role:         cmdutil.ReaderRole, // Use reader role for safety
+		Name:         passwordutil.GenerateName("pscale-cli-mcp-query"),
+		TTL:          5 * time.Minute,
+		Replica:      true, // Use replica for read-only queries
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary password: %w", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := pw.Cleanup(ctx); err != nil {
+			// Just log the error, don't return it
+			fmt.Printf("failed to delete credentials: %v\n", err)
+		}
+	}()
+
+	// Create a proxy for the connection
+	proxy := proxyutil.New(proxyutil.Config{
+		Logger:       cmdutil.NewZapLogger(ch.Debug()),
+		UpstreamAddr: pw.Password.Hostname,
+		Username:     pw.Password.Username,
+		Password:     pw.Password.PlainText,
+	})
+	defer proxy.Close()
+
+	// Create a local listener
+	l, err := net.Listen("tcp", "127.0.0.1:0") // Use random port
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener: %w", err)
+	}
+	defer l.Close()
+
+	// Start serving the proxy
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- proxy.Serve(l, mysql.CachingSha2Password)
+	}()
+
+	// Get the local address
+	localAddr := l.Addr().String()
+
+	// Create a MySQL connection to the local proxy
+	db, err := sql.Open("mysql", fmt.Sprintf("root@tcp(%s)/%s", localAddr, keyspace))
+	if err != nil {
+		return nil, fmt.Errorf("failed to open MySQL connection: %w", err)
+	}
+	defer db.Close()
+
+	// Set a timeout for the connection
+	db.SetConnMaxLifetime(30 * time.Second)
+
+	// Execute the query
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+	defer rows.Close()
+
+	// Get column names
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get column names: %w", err)
+	}
+
+	// Prepare a slice of interface{} to hold the row values
+	values := make([]interface{}, len(columns))
+	scanArgs := make([]interface{}, len(columns))
+	for i := range values {
+		scanArgs[i] = &values[i]
+	}
+
+	// Convert rows to JSON objects
+	var results []map[string]interface{}
+	for rows.Next() {
+		// Scan the row into the values slice
+		err = rows.Scan(scanArgs...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		// Create a map for the row
+		rowMap := make(map[string]interface{})
+		for i, col := range columns {
+			val := values[i]
+
+			// Handle different types
+			switch v := val.(type) {
+			case []byte:
+				// Try to convert to string
+				rowMap[col] = string(v)
+			case nil:
+				rowMap[col] = nil
+			default:
+				rowMap[col] = v
+			}
+		}
+
+		results = append(results, rowMap)
+	}
+
+	// Check for errors from iterating over rows
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error while iterating over query results: %w", err)
+	}
+
+	// Convert to JSON
+	resultsJSON, err := json.Marshal(results)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal query results: %w", err)
+	}
+
+	// Stop the proxy
+	proxy.Close()
+
+	// Return the JSON array as text
+	return mcp.NewToolResultText(string(resultsJSON)), nil
+}
+
 // getToolDefinitions returns the list of all available MCP tools
 func getToolDefinitions() []ToolDef {
 	return []ToolDef{
@@ -275,6 +469,31 @@ func getToolDefinitions() []ToolDef {
 				),
 			),
 			handler: HandleListKeyspaces,
+		},
+		{
+			tool: mcp.NewTool("run_query",
+				mcp.WithDescription("Run a SQL query against a database branch keyspace"),
+				mcp.WithString("database",
+					mcp.Description("The database name"),
+					mcp.Required(),
+				),
+				mcp.WithString("branch",
+					mcp.Description("The branch name"),
+					mcp.Required(),
+				),
+				mcp.WithString("keyspace",
+					mcp.Description("The keyspace name"),
+					mcp.Required(),
+				),
+				mcp.WithString("query",
+					mcp.Description("The SQL query to run (read-only queries only)"),
+					mcp.Required(),
+				),
+				mcp.WithString("org",
+					mcp.Description("The organization name (uses default organization if not specified)"),
+				),
+			),
+			handler: HandleRunQuery,
 		},
 	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/planetscale/cli/internal/cmd/dataimports"
+	"github.com/planetscale/cli/internal/cmd/mcp"
 	"github.com/planetscale/cli/internal/cmd/size"
 	"github.com/planetscale/cli/internal/cmd/workflow"
 
@@ -220,6 +221,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.AddCommand(dataimports.DataImportsCmd(ch))
 	rootCmd.AddCommand(deployrequest.DeployRequestCmd(ch))
 	rootCmd.AddCommand(keyspace.KeyspaceCmd(ch))
+	rootCmd.AddCommand(mcp.McpCmd(ch))
 	rootCmd.AddCommand(org.OrgCmd(ch))
 	rootCmd.AddCommand(password.PasswordCmd(ch))
 	rootCmd.AddCommand(ping.PingCmd(ch))


### PR DESCRIPTION
[Model Context Protocol](https://modelcontextprotocol.io/introduction) is kinda cool.  This PR adds two new commands to the CLI:
 - `pscale mcp install --target claude` to install a PlanetScale MCP server in Claude Desktop
 - `pscale mcp server` for Claude to invoke some read-only interactions with a user's database

The tools I've added so far are:
 - `list_orgs`
 - `list_databases [org]`
 - `list_branches [org] database`
 - `list_keyspaces [org] database branch`
 - `list_tables [org] database branch keyspace`
 - `get_schema [org] database branch keyspace tables(s)`
 - `run_query [org] database branch keyspace query`

It's basically a watered down, read-only subset of `pscale`'s normal commands and subcommands focused on information that might be useful to an LLM.  Output is dense JSON, to optimize for context windows.

I've tested this with my own PS databases in Claude Desktop, and it can answer questions like "How many tables in my PlanetScale database have a vector key?" and "How many rows are in that table?"