### PR TITLE
Add MCP server integration instructions and Cursor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,59 @@ alias pscale="docker run -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/
 
 If you need a more advanced example that works with service tokens and differentiates between commands that need a pseudo terminal or non-interactive mode, [have a look at this shell function](https://github.com/jonico/pscale-cli-helper-scripts/blob/main/.pscale/cli-helper-scripts/use-pscale-docker-image.sh).
 
+## MCP Server Integration
+
+The PlanetScale CLI includes a Model Context Protocol (MCP) server that provides AI tools direct access to your PlanetScale databases. This allows AI assistants to list organizations, databases, branches, and run SQL queries with proper authentication.
+
+### Setting up MCP in AI tools
+
+#### Claude Desktop
+
+To enable the PlanetScale MCP server in Claude Desktop:
+
+```
+pscale mcp install --target claude
+```
+
+#### Cursor Editor
+
+To enable the PlanetScale MCP server in Cursor:
+
+```
+pscale mcp install --target cursor
+```
+
+#### Manual Setup for Other AI Tools
+
+For AI tools that support custom MCP servers but don't have automated installation through the CLI, you can manually configure them:
+
+1. Find your tool's MCP configuration file
+2. Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "planetscale": {
+      "command": "pscale",
+      "args": ["mcp", "server"]
+    }
+  }
+}
+```
+
+3. Restart your AI tool to apply the changes
+
+Verify the tool recognizes the PlanetScale MCP server by asking it to list your databases or perform other PlanetScale operations.
+
+Once configured, these AI tools will be able to use PlanetScale-specific context to help you work with your databases. The MCP server provides the following capabilities:
+- List organizations
+- List databases
+- List branches
+- List keyspaces
+- List tables
+- Get table schemas
+- Run read-only SQL queries
+
 ## GitHub Actions Usage
 Use the [setup-pscale-action](https://github.com/planetscale/setup-pscale-action) to install and use `pscale` in GitHub Actions.
 

--- a/internal/cmd/mcp/install.go
+++ b/internal/cmd/mcp/install.go
@@ -32,6 +32,17 @@ func getClaudeConfigDir() (string, error) {
 	}
 }
 
+// getCursorConfigPath returns the path to the Cursor MCP config file
+func getCursorConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine user home directory: %w", err)
+	}
+	
+	// Cursor uses ~/.cursor/mcp.json for its MCP configuration
+	return filepath.Join(homeDir, ".cursor", "mcp.json"), nil
+}
+
 // InstallCmd returns a new cobra.Command for the mcp install command.
 func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
 	var target string
@@ -41,36 +52,54 @@ func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Install the MCP server",
 		Long:  `Install the PlanetScale model context protocol (MCP) server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if target != "claude" {
-				return fmt.Errorf("invalid target vendor: %s (only 'claude' is supported)", target)
+			var configPath string
+			var err error
+			
+			switch target {
+			case "claude":
+				configDir, err := getClaudeConfigDir()
+				if err != nil {
+					return fmt.Errorf("failed to determine Claude config directory: %w", err)
+				}
+				
+				// Check if the directory exists
+				if _, err := os.Stat(configDir); os.IsNotExist(err) {
+					return fmt.Errorf("no Claude Desktop installation: path %s not found", configDir)
+				}
+				
+				configPath = filepath.Join(configDir, "claude_desktop_config.json")
+			case "cursor":
+				configPath, err = getCursorConfigPath()
+				if err != nil {
+					return fmt.Errorf("failed to determine Cursor config path: %w", err)
+				}
+				
+				// Ensure the .cursor directory exists
+				configDir := filepath.Dir(configPath)
+				if _, err := os.Stat(configDir); os.IsNotExist(err) {
+					if err := os.MkdirAll(configDir, 0755); err != nil {
+						return fmt.Errorf("failed to create Cursor config directory: %w", err)
+					}
+				}
+			default:
+				return fmt.Errorf("invalid target vendor: %s (supported values: claude, cursor)", target)
 			}
-
-			configDir, err := getClaudeConfigDir()
-			if err != nil {
-				return fmt.Errorf("failed to determine Claude config directory: %w", err)
-			}
-
-			// Check if the directory exists
-			if _, err := os.Stat(configDir); os.IsNotExist(err) {
-				return fmt.Errorf("no Claude Desktop installation: path %s not found", configDir)
-			}
-
-			configPath := filepath.Join(configDir, "claude_desktop_config.json")
-			config := make(ClaudeConfig)
-
+			
+			config := make(ClaudeConfig) // Same config structure for both tools
+			
 			// Check if the file exists
 			if _, err := os.Stat(configPath); err == nil {
 				// File exists, read it
 				configData, err := os.ReadFile(configPath)
 				if err != nil {
-					return fmt.Errorf("failed to read Claude config file: %w", err)
+					return fmt.Errorf("failed to read %s config file: %w", target, err)
 				}
-
+				
 				if err := json.Unmarshal(configData, &config); err != nil {
-					return fmt.Errorf("failed to parse Claude config file: %w", err)
+					return fmt.Errorf("failed to parse %s config file: %w", target, err)
 				}
 			}
-
+			
 			// Get or initialize the mcpServers map
 			var mcpServers map[string]interface{}
 			if existingServers, ok := config["mcpServers"].(map[string]interface{}); ok {
@@ -78,7 +107,7 @@ func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
 			} else {
 				mcpServers = make(map[string]interface{})
 			}
-
+			
 			// Add or update the planetscale server configuration
 			mcpServers["planetscale"] = map[string]interface{}{
 				"command": "pscale",
@@ -87,26 +116,26 @@ func InstallCmd(ch *cmdutil.Helper) *cobra.Command {
 			
 			// Update the config with the new mcpServers
 			config["mcpServers"] = mcpServers
-
+			
 			// Write the updated config back to file
 			configJSON, err := json.MarshalIndent(config, "", "  ")
 			if err != nil {
-				return fmt.Errorf("failed to marshal Claude config: %w", err)
+				return fmt.Errorf("failed to marshal %s config: %w", target, err)
 			}
-
+			
 			if err := os.WriteFile(configPath, configJSON, 0644); err != nil {
-				return fmt.Errorf("failed to write Claude config file: %w", err)
+				return fmt.Errorf("failed to write %s config file: %w", target, err)
 			}
-
+			
 			fmt.Printf("MCP server successfully configured for %s at %s\n", target, configPath)
 			return nil
 		},
 	}
 
-	cmd.Flags().StringVar(&target, "target", "", "Target vendor for MCP installation (required). Possible values: [claude]")
+	cmd.Flags().StringVar(&target, "target", "", "Target vendor for MCP installation (required). Possible values: [claude, cursor]")
 	cmd.MarkFlagRequired("target")
 	cmd.RegisterFlagCompletionFunc("target", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"claude"}, cobra.ShellCompDirectiveDefault
+		return []string{"claude", "cursor"}, cobra.ShellCompDirectiveDefault
 	})
 
 	return cmd


### PR DESCRIPTION
## Summary
- Add documentation about MCP server integration in README.md
- Add Cursor editor support to MCP install command
- Add manual setup instructions for other AI tools
- Update MCP install command help text

## Test plan
- Build CLI from local source using 'go run cmd/pscale/main.go'
- Test 'pscale mcp install --target cursor' to ensure it creates/updates the ~/.cursor/mcp.json file
- Verify Claude Desktop configuration with 'pscale mcp install --target claude'
- Test manual integration with supported AI tools

🤖 Generated with [Claude Code](https://claude.ai/code)