### PR TITLE
Fix API redirects

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -150,19 +151,75 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 			}
 		}
 
+		// Store the original domain for detecting cross-domain redirects
+		originalDomain := extractRootDomain(req.URL.Host)
+
+		// Create a custom redirect check function that blocks cross-domain redirects
+		redirectCheck := func(req *http.Request, via []*http.Request) error {
+			// Check if this is a redirect to a different domain
+			currentDomain := extractRootDomain(req.URL.Host)
+			if originalDomain != currentDomain {
+				// For cross-domain redirects, don't follow automatically
+				// We'll handle this manually without sending auth headers
+				if ch.Debug() {
+					fmt.Fprintf(os.Stderr, "Cross-domain redirect detected to %s. Will handle without auth headers.\n", req.URL.Host)
+				}
+				return http.ErrUseLastResponse
+			}
+
+			// Standard Go redirect policy (max 10 redirects)
+			if len(via) >= 10 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		}
+
 		var cl *http.Client
 		if ch.Config.AccessToken != "" {
+			// Create a transport chain that uses OAuth2 token but honors our redirect policy
 			tok := &oauth2.Token{AccessToken: ch.Config.AccessToken}
 			cl = oauth2.NewClient(ctx, oauth2.StaticTokenSource(tok))
+
+			// Set our custom redirect policy
+			cl.CheckRedirect = redirectCheck
 		} else if ch.Config.ServiceToken != "" && ch.Config.ServiceTokenID != "" {
+			// For service tokens, manually set the auth header
 			req.Header.Set("Authorization", ch.Config.ServiceTokenID+":"+ch.Config.ServiceToken)
-			cl = &http.Client{}
+
+			// Create client with our redirect policy
+			cl = &http.Client{
+				CheckRedirect: redirectCheck,
+			}
 		}
+
+		if cl == nil {
+			cl = &http.Client{
+				CheckRedirect: redirectCheck,
+			}
+		}
+
 		res, err := cl.Do(req)
 		if err != nil {
 			return fmt.Errorf("sending HTTP request: %w", err)
 		}
 		defer res.Body.Close()
+
+		// Check if we received a redirect response
+		if res.StatusCode >= 300 && res.StatusCode < 400 {
+			location := res.Header.Get("Location")
+			if location != "" {
+				newRes, handleErr := handleRedirect(ctx, req, res, location, ch.Debug())
+				if handleErr != nil {
+					return handleErr
+				}
+
+				// If handleRedirect returned a new response, use it instead
+				if newRes != nil {
+					res.Body.Close()
+					res = newRes
+				}
+			}
+		}
 
 		if _, err := io.Copy(os.Stdout, res.Body); err != nil {
 			return fmt.Errorf("reading HTTP response body: %w", err)
@@ -328,4 +385,50 @@ func parseValue(s string) (interface{}, error) {
 
 	var v interface{}
 	return v, json.Unmarshal([]byte(s), &v)
+}
+
+// handleRedirect processes cross-domain redirects by following the redirect
+// manually without sending authentication headers
+func handleRedirect(ctx context.Context, originalReq *http.Request, originalRes *http.Response, location string, debug bool) (*http.Response, error) {
+	// Create a new request without auth headers
+	redirectReq, err := http.NewRequestWithContext(ctx, "GET", location, nil)
+	if err != nil {
+		return nil, fmt.Errorf("preparing redirect request: %w", err)
+	}
+
+	// Copy all headers except Authorization
+	for k, v := range originalReq.Header {
+		if !strings.EqualFold(k, "Authorization") {
+			redirectReq.Header[k] = v
+		}
+	}
+
+	if debug {
+		fmt.Fprintf(os.Stderr, "Following cross-domain redirect to %s without auth headers\n", location)
+	}
+
+	// Use a new client without auth for the redirect
+	redirectClient := &http.Client{}
+	redirectRes, err := redirectClient.Do(redirectReq)
+	if err != nil {
+		return nil, fmt.Errorf("following redirect: %w", err)
+	}
+
+	return redirectRes, nil
+}
+
+// extractRootDomain gets the root domain from a host string
+func extractRootDomain(host string) string {
+	// Remove port if present
+	host, _, _ = strings.Cut(host, ":")
+
+	// Split by dots and get the root domain (usually last two parts)
+	parts := strings.Split(host, ".")
+	if len(parts) <= 2 {
+		return host // Return full host if it's already a root domain
+	}
+
+	// For domains like example.co.uk, we want to return co.uk
+	// This is a simplified approach - a full implementation would use a public suffix list
+	return strings.Join(parts[len(parts)-2:], ".")
 }

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -152,21 +152,7 @@ func TestRedirectCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			originalDomain := extractRootDomain(tt.originalHost)
-
-			// Create the redirect check function like in the main code
-			redirectCheck := func(req *http.Request, via []*http.Request) error {
-				// Check if this is a redirect to a different domain
-				currentDomain := extractRootDomain(req.URL.Host)
-				if originalDomain != currentDomain {
-					return http.ErrUseLastResponse
-				}
-
-				// Standard Go redirect policy (max 10 redirects)
-				if len(via) >= 10 {
-					return http.ErrUseLastResponse
-				}
-				return nil
-			}
+			redirectCheck := makeRedirectCheck(originalDomain)
 
 			// Create a test request simulating a redirect
 			req, _ := http.NewRequest("GET", "https://"+tt.redirectHost+"/path", nil)

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,4 +63,173 @@ func TestParseField(t *testing.T) {
 			require.Equal(t, tt.want, out)
 		})
 	}
+}
+
+func TestExtractRootDomain(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "simple domain",
+			host: "example.com",
+			want: "example.com",
+		},
+		{
+			name: "subdomain",
+			host: "api.example.com",
+			want: "example.com",
+		},
+		{
+			name: "multiple subdomains",
+			host: "v1.api.example.com",
+			want: "example.com",
+		},
+		{
+			name: "with port",
+			host: "example.com:8080",
+			want: "example.com",
+		},
+		{
+			name: "subdomain with port",
+			host: "api.example.com:8080",
+			want: "example.com",
+		},
+		{
+			name: "localhost",
+			host: "localhost",
+			want: "localhost",
+		},
+		{
+			name: "localhost with port",
+			host: "localhost:8080",
+			want: "localhost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractRootDomain(tt.host)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRedirectCheck(t *testing.T) {
+	tests := []struct {
+		name           string
+		originalHost   string
+		redirectHost   string
+		expectUseLastResponse bool
+	}{
+		{
+			name:           "same domain",
+			originalHost:   "api.example.com",
+			redirectHost:   "www.example.com",
+			expectUseLastResponse: false,
+		},
+		{
+			name:           "different domain",
+			originalHost:   "api.example.com",
+			redirectHost:   "api.another.com",
+			expectUseLastResponse: true,
+		},
+		{
+			name:           "localhost to domain",
+			originalHost:   "localhost:8080",
+			redirectHost:   "example.com",
+			expectUseLastResponse: true,
+		},
+		{
+			name:           "domain to localhost",
+			originalHost:   "example.com",
+			redirectHost:   "localhost:8080",
+			expectUseLastResponse: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalDomain := extractRootDomain(tt.originalHost)
+
+			// Create the redirect check function like in the main code
+			redirectCheck := func(req *http.Request, via []*http.Request) error {
+				// Check if this is a redirect to a different domain
+				currentDomain := extractRootDomain(req.URL.Host)
+				if originalDomain != currentDomain {
+					return http.ErrUseLastResponse
+				}
+
+				// Standard Go redirect policy (max 10 redirects)
+				if len(via) >= 10 {
+					return http.ErrUseLastResponse
+				}
+				return nil
+			}
+
+			// Create a test request simulating a redirect
+			req, _ := http.NewRequest("GET", "https://"+tt.redirectHost+"/path", nil)
+
+			// Run the redirect check
+			err := redirectCheck(req, []*http.Request{})
+
+			// Check the result
+			if tt.expectUseLastResponse {
+				require.Equal(t, http.ErrUseLastResponse, err,
+					"Expected ErrUseLastResponse for cross-domain redirect")
+			} else {
+				require.NoError(t, err,
+					"Expected nil error for same-domain redirect")
+			}
+		})
+	}
+}
+
+func TestHandleRedirect(t *testing.T) {
+	// Create a test context
+	ctx := context.Background()
+
+	// Create an original request with auth header
+	originalReq, _ := http.NewRequest("GET", "https://api.example.com/path", nil)
+	originalReq.Header.Set("Authorization", "Bearer token123")
+	originalReq.Header.Set("User-Agent", "test-agent")
+
+	// Create a mock original response
+	originalRes := &http.Response{
+		StatusCode: 302,
+		Header:     http.Header{},
+	}
+	originalRes.Header.Set("Location", "https://other-domain.com/newpath")
+
+	// Mock a response from the redirect target
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Ensure auth header is not present
+		if r.Header.Get("Authorization") != "" {
+			t.Error("Auth header was incorrectly passed to redirect target")
+		}
+
+		// Ensure other headers were preserved
+		if r.Header.Get("User-Agent") != "test-agent" {
+			t.Error("Other headers were not preserved in redirect")
+		}
+
+		w.Write([]byte("Redirect target content"))
+	}))
+	defer mockServer.Close()
+
+	// Test the handleRedirect function with the mock server
+	redirectRes, err := handleRedirect(ctx, originalReq, originalRes, mockServer.URL, false)
+
+	// Verify the result
+	require.NoError(t, err)
+	require.NotNil(t, redirectRes)
+
+	// Read the response body
+	body, err := io.ReadAll(redirectRes.Body)
+	require.NoError(t, err)
+	redirectRes.Body.Close()
+
+	// Verify the response content
+	require.Equal(t, "Redirect target content", string(body))
 }


### PR DESCRIPTION
Requests like `pscale api /organizations/$org/databases/$db/branches/$branch/query-patterns` get redirected to an S3 bearer URL.  `pscale api` follows those redirects.  It needs to not include the `Authorization` header when talking to S3, because including that header is a security leak, and also causes S3 to reject the request.

The fix is to teach the OAuth2 http client to not follow redirects that go to a new root domain (e.g., somewhere other than planetscale.com).  Instead of following the redirect automatically in the OAuth2 http client, now we construct a new, clean http client without the Authorization header.

This PR fixes a security leak, in which a client's OAuth2 bearer token would be forwarded to S3.  That's probably harmless: it was https, and there's no reason to think S3 would store or use those tokens.  This PR also fixes a bug, in which `.../query-patterns` requests just didn't work at all.