### PR TITLE
More helpful error for non-interactive shell

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -58,7 +58,7 @@ second argument:
 			runForeground := true
 			if !printer.IsTTY || ch.Printer.Format() != printer.Human {
 				if _, exists := os.LookupEnv("PSCALE_ALLOW_NONINTERACTIVE_SHELL"); !exists {
-					return errors.New("pscale shell only works in interactive mode")
+					return errors.New("pscale shell only works in interactive mode unless PSCALE_ALLOW_NONINTERACTIVE_SHELL is set")
 				}
 				runForeground = false
 			}


### PR DESCRIPTION
Point people in the right direction if they try to pipe a file in to `pscale shell`