### PR TITLE
Add a `get_insights` MCP tool

### DIFF
--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -139,6 +139,23 @@ func getToolDefinitions() []ToolDef {
 			),
 			handler: HandleRunQuery,
 		},
+		{
+			tool: mcp.NewTool("get_insights",
+				mcp.WithDescription("Get recent performance data for a database branch"),
+				mcp.WithString("database",
+					mcp.Description("The database name"),
+					mcp.Required(),
+				),
+				mcp.WithString("branch",
+					mcp.Description("The branch name"),
+					mcp.Required(),
+				),
+				mcp.WithString("org",
+					mcp.Description("The organization name (uses default organization if not specified)"),
+				),
+			),
+			handler: HandleGetInsights,
+		},
 	}
 }
 

--- a/internal/cmd/mcp/server_handlers.go
+++ b/internal/cmd/mcp/server_handlers.go
@@ -495,12 +495,12 @@ func HandleGetInsights(ctx context.Context, request mcp.CallToolRequest, ch *cmd
 			}
 		}
 	}
-	
+
 	// Convert to JSON for the response
 	resultJSON, err := json.MarshalIndent(topEntries, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshaling result to JSON: %w", err)
 	}
-	
+
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }


### PR DESCRIPTION
This extends `pscale mcp server` to include a new tool, `get_insights`.  `get_insights` lists the top queries for a given database branch by five metrics: total time, total rows read, rows read per row returned, p99 latency, and rows affected.