### PR TITLE
Add MCP tools for docs

### DIFF
--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -145,6 +145,16 @@ func getToolDefinitions() []ToolDef {
 			),
 			handler: HandleListDocs,
 		},
+		{
+			tool: mcp.NewTool("get_doc",
+				mcp.WithDescription("Get a specific documentation page"),
+				mcp.WithString("path",
+					mcp.Description("The path to the documentation page"),
+					mcp.Required(),
+				),
+			),
+			handler: HandleGetDoc,
+		},
 	}
 }
 

--- a/internal/cmd/mcp/server.go
+++ b/internal/cmd/mcp/server.go
@@ -139,6 +139,12 @@ func getToolDefinitions() []ToolDef {
 			),
 			handler: HandleRunQuery,
 		},
+		{
+			tool: mcp.NewTool("list_docs",
+				mcp.WithDescription("List available documentation"),
+			),
+			handler: HandleListDocs,
+		},
 	}
 }
 

--- a/internal/cmd/mcp/server_handlers.go
+++ b/internal/cmd/mcp/server_handlers.go
@@ -376,50 +376,50 @@ func HandleGetSchema(ctx context.Context, request mcp.CallToolRequest, ch *cmdut
 func HandleListDocs(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
 	// Create an HTTP client
 	client := &http.Client{}
-	
+
 	// Base URL for the docs API
 	baseURL := "https://planetscale.com/mcp/docs"
-	
+
 	// Slice to hold all doc entries from all pages
 	var allDocs []map[string]interface{}
-	
+
 	// Start with page 1
 	currentPage := 1
 	totalPages := 1 // Will be updated after first request
-	
+
 	// Loop through all pages
 	for currentPage <= totalPages {
 		// Construct the URL with page parameter
 		urlStr := fmt.Sprintf("%s?page=%d", baseURL, currentPage)
-		
+
 		// Create the request
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 		if err != nil {
 			return nil, fmt.Errorf("creating HTTP request: %w", err)
 		}
-		
+
 		// Add headers
 		req.Header.Set("User-Agent", "pscale-cli-mcp")
 		req.Header.Set("Accept", "application/json")
-		
+
 		// Send the request
 		resp, err := client.Do(req)
 		if err != nil {
 			return nil, fmt.Errorf("sending HTTP request to %s: %w", urlStr, err)
 		}
 		defer resp.Body.Close()
-		
+
 		// Read the response body
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("reading HTTP response body: %w", err)
 		}
-		
+
 		// Check for errors (anything above 299 is an error)
 		if resp.StatusCode > 299 {
 			return nil, fmt.Errorf("HTTP %s: %s", resp.Status, string(body))
 		}
-		
+
 		// Parse the JSON response
 		var response struct {
 			Data       []map[string]interface{} `json:"docs"`
@@ -427,29 +427,29 @@ func HandleListDocs(ctx context.Context, request mcp.CallToolRequest, ch *cmduti
 				TotalPages int `json:"totalPages"`
 			} `json:"pagination"`
 		}
-		
+
 		if err := json.Unmarshal(body, &response); err != nil {
 			return nil, fmt.Errorf("parsing JSON response: %w", err)
 		}
-		
+
 		// Update total pages from the first response
 		if currentPage == 1 {
 			totalPages = response.Pagination.TotalPages
 		}
-		
+
 		// Append the docs from this page to our collection
 		allDocs = append(allDocs, response.Data...)
-		
+
 		// Move to the next page
 		currentPage++
 	}
-	
+
 	// Convert to JSON for the response
 	resultJSON, err := json.MarshalIndent(allDocs, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("marshaling result to JSON: %w", err)
 	}
-	
+
 	return mcp.NewToolResultText(string(resultJSON)), nil
 }
 
@@ -461,63 +461,63 @@ func HandleGetDoc(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.
 		return nil, fmt.Errorf("path parameter is required")
 	}
 	docPath := pathArg.(string)
-	
+
 	// Ensure the path starts with a slash if not already
 	if !strings.HasPrefix(docPath, "/") {
 		docPath = "/" + docPath
 	}
-	
+
 	// Validate that the path starts with /mcp/docs/
 	if !strings.HasPrefix(docPath, "/mcp/docs/") {
 		return nil, fmt.Errorf("path must start with /mcp/docs/")
 	}
-	
+
 	// Validate that the path does not contain ? characters
 	if strings.Contains(docPath, "?") {
 		return nil, fmt.Errorf("path must not contain ? characters")
 	}
-	
+
 	// Validate that the path does not contain .. sequences
 	if strings.Contains(docPath, "..") {
 		return nil, fmt.Errorf("path must not contain .. sequences")
 	}
-	
+
 	// Base URL for the documentation
 	baseURL := "https://planetscale.com"
-	
+
 	// Construct the full URL
 	urlStr := baseURL + docPath
-	
+
 	// Create an HTTP client
 	client := &http.Client{}
-	
+
 	// Create the request
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
-	
+
 	// Add headers
 	req.Header.Set("User-Agent", "pscale-cli-mcp")
-	
+
 	// Send the request
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("sending HTTP request to %s: %w", urlStr, err)
 	}
 	defer resp.Body.Close()
-	
+
 	// Read the response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading HTTP response body: %w", err)
 	}
-	
+
 	// Check for errors (anything above 299 is an error)
 	if resp.StatusCode > 299 {
 		return nil, fmt.Errorf("HTTP %s: %s", resp.Status, string(body))
 	}
-	
+
 	// Return the response body unchanged
 	return mcp.NewToolResultText(string(body)), nil
 }

--- a/internal/cmd/mcp/server_handlers.go
+++ b/internal/cmd/mcp/server_handlers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"

--- a/internal/cmd/mcp/server_handlers.go
+++ b/internal/cmd/mcp/server_handlers.go
@@ -467,6 +467,21 @@ func HandleGetDoc(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.
 		docPath = "/" + docPath
 	}
 	
+	// Validate that the path starts with /mcp/docs/
+	if !strings.HasPrefix(docPath, "/mcp/docs/") {
+		return nil, fmt.Errorf("path must start with /mcp/docs/")
+	}
+	
+	// Validate that the path does not contain ? characters
+	if strings.Contains(docPath, "?") {
+		return nil, fmt.Errorf("path must not contain ? characters")
+	}
+	
+	// Validate that the path does not contain .. sequences
+	if strings.Contains(docPath, "..") {
+		return nil, fmt.Errorf("path must not contain .. sequences")
+	}
+	
 	// Base URL for the documentation
 	baseURL := "https://planetscale.com"
 	


### PR DESCRIPTION
This adds two new tools to `pscale mcp server`:
 - `list_docs` lists [all available docs on planetscale.com/docs](https://planetscale.com/docs)
 - `get_doc` retrieves one doc from the output of `list_docs`, in Markdown format

The funny thing is, I can't get Claude to bother with this tool at all.  Here's a sample conversation:

> Give me an example of how to add a vector index with cosine distance to a PlanetScale database

It hallucinates something based on vector syntax from several other MySQL-style databases.

> That's wrong.  Check the docs.

It searches the web and provides a correct answer.

> How much memory does my instance need to build a vector index with a million rows?  Check the planetscale docs.

It searches the web and provides a correct answer.

> In the PlanetScale docs, how do I create a Metal database?

It searches the web and provides a correct answer.

---

So, I'm not convinced `list_docs` and `get_docs` are necessary -- an LLM that knows how to use those probably knows how to search the web, which accomplishes the same purpose without the ongoing costs of maintaining docs-related MCP tools and endpoints.

I really just opened this for discussion.  cc @ayrton 