### PR TITLE
Fix branch create help message

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -106,9 +106,9 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 
 	opts := &ApiOpts{}
 	cmd.Flags().StringVarP(&opts.Method, "method", "X", "GET", "HTTP method to use for the request.  Defaults to GET for requests without a body, or POST when a body is specified with --field/-F or --input/-I")
-	cmd.Flags().StringArrayVarP(&opts.Query, "query", "Q", nil, "query to append to the URL path, in key=value format")
+	cmd.Flags().StringArrayVarP(&opts.Query, "query", "Q", nil, "query to append to the URL path, in `key=value` format")
 	cmd.Flags().StringArrayVarP(&opts.Header, "header", "H", nil, "HTTP headers to add to the request")
-	cmd.Flags().StringArrayVarP(&opts.Field, "field", "F", nil, "HTTP body to send with the request, in key=value format where value is a JSON entity, unless value starts with a @ in which case the string after @ represents a file that will be read. Nested types are represented as 'root.depth1.depth2=value'")
+	cmd.Flags().StringArrayVarP(&opts.Field, "field", "F", nil, "HTTP body to send with the request, in `key=value` format where value is a JSON entity, unless value starts with a @ in which case the string after @ represents a file that will be read. Nested types are represented as 'root.depth1.depth2=value'")
 	cmd.Flags().StringVarP(&opts.Input, "input", "I", "", "HTTP body to send with the request, as a file that will be read and then sent.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -105,10 +105,10 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 	cmd.PersistentFlags().StringVar(&ch.Config.Branch, "branch", ch.Config.Branch, "The branch this project is using")
 
 	opts := &ApiOpts{}
-	cmd.Flags().StringVarP(&opts.Method, "method", "X", "GET", "HTTP method to use for the request.  Defaults to GET for requests without a body, or POST when a body is specified with `--field/-F` or `--input/-I`")
-	cmd.Flags().StringArrayVarP(&opts.Query, "query", "Q", nil, "query to append to the URL path, in `key=value` format")
+	cmd.Flags().StringVarP(&opts.Method, "method", "X", "GET", "HTTP method to use for the request.  Defaults to GET for requests without a body, or POST when a body is specified with --field/-F or --input/-I")
+	cmd.Flags().StringArrayVarP(&opts.Query, "query", "Q", nil, "query to append to the URL path, in key=value format")
 	cmd.Flags().StringArrayVarP(&opts.Header, "header", "H", nil, "HTTP headers to add to the request")
-	cmd.Flags().StringArrayVarP(&opts.Field, "field", "F", nil, "HTTP body to send with the request, in `key=value` format where `value` is a JSON entity, unless `value` starts with a `@` in which case the string after `@` represents a file that will be read. Nested types are represented as `root.depth1.depth2=value``")
+	cmd.Flags().StringArrayVarP(&opts.Field, "field", "F", nil, "HTTP body to send with the request, in key=value format where value is a JSON entity, unless value starts with a @ in which case the string after @ represents a file that will be read. Nested types are represented as 'root.depth1.depth2=value'")
 	cmd.Flags().StringVarP(&opts.Input, "input", "I", "", "HTTP body to send with the request, as a file that will be read and then sent.")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -126,7 +126,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "Region for the branch to be created in.")
 	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "ID of Backup to restore into branch.")
-	cmd.Flags().StringVar(&createReq.ClusterSize, "cluster-size", "PS-10", "Cluster size for branches being created from a backup or seeded with data. Use `pscale size cluster list` to see the valid sizes.")
+	cmd.Flags().StringVar(&createReq.ClusterSize, "cluster-size", "PS-10", "Cluster size for branches being created from a backup or seeded with data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
 	cmd.MarkFlagsMutuallyExclusive("from", "restore")


### PR DESCRIPTION
I'm not sure why but the backticks change the description of the `-cluster-size` flag in a confusing way.

On 0.241.0 

```
$ pscale branch create
Error: missing arguments <source-database, branch>

Usage:
  pscale branch create <source-database> <branch> [options] [flags]

Aliases:
  create, b

Flags:
      --cluster-size pscale size cluster list   Cluster size for branches being created from a backup or seeded with data. Use pscale size cluster list to see the valid sizes. (default "PS-10")
      --from string                             Parent branch to create the new branch from. Cannot be used with --restore
...
```