### PR TITLE
use ubuntu-based image for goreleaser

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,7 @@
-FROM alpine:latest  
-RUN apk --no-cache add ca-certificates mysql-client openssh-client
+FROM ubuntu:noble
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates mysql-client openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 EXPOSE 3306
 
 ENTRYPOINT ["/usr/bin/pscale"] 


### PR DESCRIPTION
Closes https://github.com/planetscale/cli/issues/929

We were bundling MariaDB instead with alpine, which is less than stellar. 