### PR TITLE
Upgrade MCP Go library to v0.30.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-version v1.7.0
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
-	github.com/mark3labs/mcp-go v0.27.0
+	github.com/mark3labs/mcp-go v0.30.1
 	github.com/matoous/go-nanoid/v2 v2.1.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mark3labs/mcp-go v0.27.0 h1:iok9kU4DUIU2/XVLgFS2Q9biIDqstC0jY4EQTK2Erzc=
 github.com/mark3labs/mcp-go v0.27.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.30.1 h1:3R1BPvNT/rC1iPpLx+EMXFy+gvux/Mz/Nio3c6XEU9E=
+github.com/mark3labs/mcp-go v0.30.1/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/matoous/go-nanoid/v2 v2.1.0 h1:P64+dmq21hhWdtvZfEAofnvJULaRR1Yib0+PnU669bE=
 github.com/matoous/go-nanoid/v2 v2.1.0/go.mod h1:KlbGNQ+FhrUNIHUxZdL63t7tl4LaPkZNpUULS8H4uVM=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/internal/cmd/mcp/server_handlers.go
+++ b/internal/cmd/mcp/server_handlers.go
@@ -103,8 +103,10 @@ func HandleListBranches(ctx context.Context, request mcp.CallToolRequest, ch *cm
 		return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
 	}
 
+	args := request.GetArguments()
+
 	// Get the required database parameter
-	dbArg, ok := request.Params.Arguments["database"]
+	dbArg, ok := args["database"]
 	if !ok || dbArg == "" {
 		return nil, fmt.Errorf("database parameter is required")
 	}
@@ -158,15 +160,17 @@ func HandleListKeyspaces(ctx context.Context, request mcp.CallToolRequest, ch *c
 		return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
 	}
 
+	args := request.GetArguments()
+
 	// Get the required database parameter
-	dbArg, ok := request.Params.Arguments["database"]
+	dbArg, ok := args["database"]
 	if !ok || dbArg == "" {
 		return nil, fmt.Errorf("database parameter is required")
 	}
 	database := dbArg.(string)
 
 	// Get the required branch parameter
-	branchArg, ok := request.Params.Arguments["branch"]
+	branchArg, ok := args["branch"]
 	if !ok || branchArg == "" {
 		return nil, fmt.Errorf("branch parameter is required")
 	}
@@ -215,8 +219,10 @@ func HandleListKeyspaces(ctx context.Context, request mcp.CallToolRequest, ch *c
 
 // HandleRunQuery implements the run_query tool
 func HandleRunQuery(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
 	// Get the required query parameter
-	queryArg, ok := request.Params.Arguments["query"]
+	queryArg, ok := args["query"]
 	if !ok || queryArg == "" {
 		return nil, fmt.Errorf("query parameter is required")
 	}
@@ -292,8 +298,10 @@ func HandleListTables(ctx context.Context, request mcp.CallToolRequest, ch *cmdu
 
 // HandleGetSchema implements the get_schema tool
 func HandleGetSchema(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
 	// Get the required tables parameter
-	tablesArg, ok := request.Params.Arguments["tables"]
+	tablesArg, ok := args["tables"]
 	if !ok || tablesArg == "" {
 		return nil, fmt.Errorf("tables parameter is required")
 	}
@@ -377,14 +385,16 @@ func HandleGetSchema(ctx context.Context, request mcp.CallToolRequest, ch *cmdut
 
 // HandleGetInsights implements the get_insights tool
 func HandleGetInsights(ctx context.Context, request mcp.CallToolRequest, ch *cmdutil.Helper) (*mcp.CallToolResult, error) {
+	args := request.GetArguments()
+
 	// Get the required parameters
-	dbArg, ok := request.Params.Arguments["database"]
+	dbArg, ok := args["database"]
 	if !ok || dbArg == "" {
 		return nil, fmt.Errorf("database parameter is required")
 	}
 	database := dbArg.(string)
 
-	branchArg, ok := request.Params.Arguments["branch"]
+	branchArg, ok := args["branch"]
 	if !ok || branchArg == "" {
 		return nil, fmt.Errorf("branch parameter is required")
 	}

--- a/internal/cmd/mcp/server_helpers.go
+++ b/internal/cmd/mcp/server_helpers.go
@@ -28,9 +28,11 @@ type DatabaseConnection struct {
 
 // getOrganization extracts the organization from the request parameters or falls back to defaults
 func getOrganization(request mcp.CallToolRequest, ch *cmdutil.Helper) (string, error) {
+	args := request.GetArguments()
+	
 	// Get the organization from the parameters or use the default
 	var orgName string
-	if org, ok := request.Params.Arguments["org"].(string); ok && org != "" {
+	if org, ok := args["org"].(string); ok && org != "" {
 		orgName = org
 	} else {
 		// Try to load from default config file
@@ -59,22 +61,24 @@ func createDatabaseConnection(ctx context.Context, request mcp.CallToolRequest, 
 		return nil, fmt.Errorf("failed to initialize PlanetScale client: %w", err)
 	}
 
+	args := request.GetArguments()
+
 	// Extract the required database parameter
-	dbArg, ok := request.Params.Arguments["database"]
+	dbArg, ok := args["database"]
 	if !ok || dbArg == "" {
 		return nil, fmt.Errorf("database parameter is required")
 	}
 	database := dbArg.(string)
 
 	// Extract the required branch parameter
-	branchArg, ok := request.Params.Arguments["branch"]
+	branchArg, ok := args["branch"]
 	if !ok || branchArg == "" {
 		return nil, fmt.Errorf("branch parameter is required")
 	}
 	branch := branchArg.(string)
 
 	// Extract the required keyspace parameter
-	keyspaceArg, ok := request.Params.Arguments["keyspace"]
+	keyspaceArg, ok := args["keyspace"]
 	if !ok || keyspaceArg == "" {
 		return nil, fmt.Errorf("keyspace parameter is required")
 	}


### PR DESCRIPTION
## Summary
- Upgrades `github.com/mark3labs/mcp-go` from v0.27.0 to v0.30.1
- Fixes breaking API changes by replacing direct argument access with `GetArguments()` method calls

## Test plan
- [x] Verify all Go files compile successfully
- [x] Verify main binary builds without errors
- [x] Updated all MCP handlers to use new API patterns

🤖 Generated with [Claude Code](https://claude.ai/code)