### PR TITLE
MCP server_helpers.go: don't hardcode a replica

### DIFF
--- a/internal/cmd/mcp/server_helpers.go
+++ b/internal/cmd/mcp/server_helpers.go
@@ -122,7 +122,6 @@ func createDatabaseConnection(ctx context.Context, request mcp.CallToolRequest, 
 		Role:         cmdutil.ReaderRole, // Use reader role for safety
 		Name:         passwordutil.GenerateName("pscale-cli-mcp-query"),
 		TTL:          5 * time.Minute,
-		Replica:      true, // Use replica for read-only queries
 	})
 	if err != nil {
 		handledErr := cmdutil.HandleError(err)

--- a/internal/cmd/mcp/server_helpers.go
+++ b/internal/cmd/mcp/server_helpers.go
@@ -29,7 +29,7 @@ type DatabaseConnection struct {
 // getOrganization extracts the organization from the request parameters or falls back to defaults
 func getOrganization(request mcp.CallToolRequest, ch *cmdutil.Helper) (string, error) {
 	args := request.GetArguments()
-	
+
 	// Get the organization from the parameters or use the default
 	var orgName string
 	if org, ok := args["org"].(string); ok && org != "" {
@@ -122,6 +122,7 @@ func createDatabaseConnection(ctx context.Context, request mcp.CallToolRequest, 
 		Role:         cmdutil.ReaderRole, // Use reader role for safety
 		Name:         passwordutil.GenerateName("pscale-cli-mcp-query"),
 		TTL:          5 * time.Minute,
+		Replica:      dbBranch.Production, // Use replica if branch is production
 	})
 	if err != nil {
 		handledErr := cmdutil.HandleError(err)


### PR DESCRIPTION
Closes https://github.com/planetscale/cli/issues/1052

This requires that all branches used have a replica, which won't always be the case for dev branches. For now, we can send them to the primary. 