### PR TITLE
Fixes `auth check` for service tokens

### DIFF
--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -19,7 +19,7 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			errorMessage := "You are not authenticated. Please run `pscale auth login` to authenticate."
 
-			if ch.Config.AccessToken == "" {
+			if err := ch.Config.IsAuthenticated(); err != nil {
 				return &cmdutil.Error{
 					Msg:      errorMessage,
 					ExitCode: cmdutil.ActionRequestedExitCode,

--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -19,10 +19,12 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var errorMessage string
 
-			if ch.Config.UsingServiceToken() {
+			if ch.Config.ServiceTokenIsSet() {
 				errorMessage = "You are not authenticated. Please ensure your service token is valid and properly configured."
-			} else {
+			} else if ch.Config.AccessToken != "" {
 				errorMessage = "You are not authenticated. Please run `pscale auth login` to authenticate."
+			} else {
+				errorMessage = "You are not authenticated. Please run `pscale auth login` to authenticate or set a service token."
 			}
 			if err := ch.Config.IsAuthenticated(); err != nil {
 				return &cmdutil.Error{

--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -17,8 +17,13 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Check if you are authenticated",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			errorMessage := "You are not authenticated. Please run `pscale auth login` to authenticate."
+			var errorMessage string
 
+			if ch.Config.UsingServiceToken() {
+				errorMessage = "You are not authenticated. Please ensure your service token is valid and properly configured."
+			} else {
+				errorMessage = "You are not authenticated. Please run `pscale auth login` to authenticate."
+			}
 			if err := ch.Config.IsAuthenticated(); err != nil {
 				return &cmdutil.Error{
 					Msg:      errorMessage,


### PR DESCRIPTION
Currently `auth check` only works for user auth. This fixes it to work for both service tokens and user auth.