### PR TITLE
Improve service token auth error messages

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -86,10 +86,14 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
 					if createReq.ParentBranch != "" {
-						return fmt.Errorf("source branch %s or database %s does not exist (organization: %s)",
+						return cmdutil.HandleNotFoundWithServiceTokenCheck(
+							ctx, cmd, ch.Config, ch.Client, err, "create_branch",
+							"source branch %s or database %s does not exist (organization: %s)",
 							printer.BoldBlue(createReq.ParentBranch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
 					} else {
-						return fmt.Errorf("source database %s does not exist in organization %s",
+						return cmdutil.HandleNotFoundWithServiceTokenCheck(
+							ctx, cmd, ch.Config, ch.Client, err, "create_branch",
+							"source database %s does not exist in organization %s",
 							printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
 					}
 				default:

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -202,3 +202,110 @@ func TestBranch_CreateCmdWithSeedData(t *testing.T) {
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
+
+func TestBranch_CreateCmd_ServiceTokenAuthError(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	// Mock service that returns 404 for branch creation
+	branchSvc := &mock.DatabaseBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	// Mock organization service that returns error for auth check (simulating invalid service token)
+	orgSvc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization:   org,
+			ServiceTokenID: "test-token-id",
+			ServiceToken:   "test-token",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: branchSvc,
+				Organizations:    orgSvc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "Authentication failed")
+	c.Assert(err.Error(), qt.Contains, "service token appears to be invalid")
+	c.Assert(err.Error(), qt.Contains, "Service tokens can be provided in two ways")
+	c.Assert(branchSvc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(orgSvc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_CreateCmd_GenuineNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "nonexistent"
+	branch := "development"
+
+	// Mock service that returns 404 for branch creation
+	branchSvc := &mock.DatabaseBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	// Mock organization service that succeeds (simulating valid service token)
+	orgSvc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{{Name: org}}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization:   org,
+			ServiceTokenID: "valid-token-id",
+			ServiceToken:   "valid-token",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: branchSvc,
+				Organizations:    orgSvc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+	c.Assert(err.Error(), qt.Contains, "service token for authentication")
+	c.Assert(err.Error(), qt.Contains, "create_branch")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "Authentication failed")
+	c.Assert(branchSvc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(orgSvc.ListFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/branch/show.go
+++ b/internal/cmd/branch/show.go
@@ -51,7 +51,9 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
-					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+						"branch %s does not exist in database %s (organization: %s)",
 						printer.BoldBlue(branch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/show_test.go
+++ b/internal/cmd/branch/show_test.go
@@ -58,3 +58,208 @@ func TestBranch_ShowCmd(t *testing.T) {
 	c.Assert(svc.GetFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
+
+func TestBranch_ShowCmd_ServiceTokenAuthError(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	// Mock service that returns 404 for branch lookup
+	branchSvc := &mock.DatabaseBranchesService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	// Mock organization service that returns error for auth check (simulating invalid service token)
+	orgSvc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization:   org,
+			ServiceTokenID: "test-token-id",
+			ServiceToken:   "test-token",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: branchSvc,
+				Organizations:    orgSvc,
+			}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "Authentication failed")
+	c.Assert(err.Error(), qt.Contains, "service token appears to be invalid")
+	c.Assert(err.Error(), qt.Contains, "Service tokens can be provided in two ways")
+	c.Assert(branchSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(orgSvc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_ShowCmd_GenuineNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "nonexistent"
+
+	// Mock service that returns 404 for branch lookup
+	branchSvc := &mock.DatabaseBranchesService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	// Mock organization service that succeeds (simulating valid service token)
+	orgSvc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{{Name: org}}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization:   org,
+			ServiceTokenID: "valid-token-id",
+			ServiceToken:   "valid-token",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: branchSvc,
+				Organizations:    orgSvc,
+			}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+	c.Assert(err.Error(), qt.Contains, "service token for authentication")
+	c.Assert(err.Error(), qt.Contains, "read_branch")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "Authentication failed")
+	c.Assert(branchSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(orgSvc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_ShowCmd_GenuineNotFound_NoServiceToken(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "nonexistent"
+
+	// Mock service that returns 404 for branch lookup
+	branchSvc := &mock.DatabaseBranchesService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+			// No service token set - using regular authentication
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: branchSvc,
+			}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "service token for authentication")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "read_branch")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "Authentication failed")
+	c.Assert(branchSvc.GetFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_ShowCmd_GenuineNotFound_EmptyPermission(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "nonexistent"
+
+	// Mock service that returns 404 for branch lookup
+	branchSvc := &mock.DatabaseBranchesService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	// Mock organization service that succeeds (simulating valid service token)
+	orgSvc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{{Name: org}}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization:   org,
+			ServiceTokenID: "valid-token-id",
+			ServiceToken:   "valid-token",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: branchSvc,
+				Organizations:    orgSvc,
+			}, nil
+		},
+	}
+
+	// Manually call the function with empty permission to test this case
+	ctx := context.Background()
+	err := cmdutil.HandleNotFoundWithServiceTokenCheck(
+		ctx, nil, ch.Config, ch.Client, &ps.Error{Code: ps.ErrNotFound}, "",
+		"branch %s does not exist in database %s (organization: %s)",
+		printer.BoldBlue(branch), printer.BoldBlue(db), printer.BoldBlue(ch.Config.Organization))
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "service token for authentication")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "permission")
+}

--- a/internal/cmdutil/auth.go
+++ b/internal/cmdutil/auth.go
@@ -119,7 +119,7 @@ func HandleNotFoundWithServiceTokenCheck(ctx context.Context, cmd *cobra.Command
 
 	// If using service tokens and a required permission is specified, add permission guidance
 	if cfg.ServiceTokenIsSet() && requiredPermission != "" {
-		return fmt.Errorf("%s\n\nNote: You are using a service token for authentication. If this resource exists, your service token may not have the required '%s' permission to access it. Please check your service token permissions.", baseMsg, requiredPermission)
+		return fmt.Errorf("%s\n\nNote: You are using a service token for authentication. If this resource exists, your service token may not have the required '%s' permission to access it. Please check your service token permissions", baseMsg, requiredPermission)
 	}
 
 	return errors.New(baseMsg)

--- a/internal/cmdutil/auth.go
+++ b/internal/cmdutil/auth.go
@@ -1,0 +1,126 @@
+package cmdutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// ValidateServiceTokenOnNotFound checks if a 404 error might be due to invalid service token authentication.
+// It performs an additional authentication check when using service tokens to distinguish between
+// a genuine "not found" error and an authentication failure.
+//
+// This function should be called when:
+// 1. The API returns a 404 error
+// 2. The user is authenticated with a service token
+//
+// Returns:
+// - nil if the service token is valid (indicating a genuine 404)
+// - An authentication error if the service token is invalid
+// - The original error if not using service tokens or if the validation check fails
+func ValidateServiceTokenOnNotFound(ctx context.Context, cmd *cobra.Command, cfg *config.Config, clientFunc func() (*planetscale.Client, error), originalErr error) error {
+	// Only perform this check if we're using service token authentication
+	if !cfg.ServiceTokenIsSet() {
+		return originalErr
+	}
+
+	// Try to make a simple API call to validate the service token
+	client, err := clientFunc()
+	if err != nil {
+		// If we can't create a client, return the original error
+		return originalErr
+	}
+
+	// Try to list organizations as a simple authentication check
+	// This is the same check used in auth.CheckCmd
+	_, err = client.Organizations.List(ctx)
+	if err != nil {
+		// If this call fails, it's likely an authentication issue
+		return &Error{
+			Msg:      buildServiceTokenErrorMessage(cmd),
+			ExitCode: ActionRequestedExitCode,
+		}
+	}
+
+	// If the auth check passes, the original 404 is genuine
+	return originalErr
+}
+
+// buildServiceTokenErrorMessage creates a helpful error message based on how the user is authenticating
+func buildServiceTokenErrorMessage(cmd *cobra.Command) string {
+	// Check if service token values were set via environment variables
+	envTokenID := os.Getenv("PLANETSCALE_SERVICE_TOKEN_ID")
+	envToken := os.Getenv("PLANETSCALE_SERVICE_TOKEN")
+
+	// Check if flags were explicitly set via command line
+	var flagsUsed bool
+	if cmd != nil {
+		flagsUsed = cmd.Flags().Changed("service-token-id") || cmd.Flags().Changed("service-token")
+	}
+
+	var authMethod string
+	var specificGuidance string
+
+	if envTokenID != "" || envToken != "" {
+		authMethod = "environment variables"
+		specificGuidance = "Please check your PLANETSCALE_SERVICE_TOKEN_ID and PLANETSCALE_SERVICE_TOKEN environment variables."
+	} else if flagsUsed {
+		authMethod = "command-line flags"
+		specificGuidance = "Please check your --service-token-id and --service-token flag values."
+	} else {
+		// Fallback - we know service tokens are set but can't determine the source
+		authMethod = "service tokens"
+		specificGuidance = "Please check your service token credentials."
+	}
+
+	return fmt.Sprintf(`Authentication failed. Your service token appears to be invalid.
+
+You are currently authenticating using %s. %s
+
+Service tokens can be provided in two ways:
+  1. Environment variables: PLANETSCALE_SERVICE_TOKEN_ID and PLANETSCALE_SERVICE_TOKEN
+  2. Command-line flags: --service-token-id and --service-token
+
+To create a new service token, run: pscale service-token create
+To list existing service tokens, run: pscale service-token list`, authMethod, specificGuidance)
+}
+
+// HandleNotFoundWithServiceTokenCheck is a convenience function that combines the common pattern
+// of handling 404 errors with service token validation. It should be used in the ErrNotFound case
+// of error handling switch statements.
+//
+// The requiredPermission parameter is optional (can be empty string). When provided, it will be
+// included in the error message to help users understand what permission their service token needs.
+//
+// Usage example:
+//
+//	switch cmdutil.ErrCode(err) {
+//	case planetscale.ErrNotFound:
+//	    return cmdutil.HandleNotFoundWithServiceTokenCheck(
+//	        ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+//	        "branch %s does not exist in database %s (organization: %s)",
+//	        printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+//	default:
+//	    return cmdutil.HandleError(err)
+//	}
+func HandleNotFoundWithServiceTokenCheck(ctx context.Context, cmd *cobra.Command, cfg *config.Config, clientFunc func() (*planetscale.Client, error), originalErr error, requiredPermission string, notFoundMsgFormat string, args ...interface{}) error {
+	// First check if this might be a service token authentication issue
+	if authErr := ValidateServiceTokenOnNotFound(ctx, cmd, cfg, clientFunc, originalErr); authErr != originalErr {
+		return authErr
+	}
+
+	// If authentication is valid, return the formatted not found message
+	baseMsg := fmt.Sprintf(notFoundMsgFormat, args...)
+
+	// If using service tokens and a required permission is specified, add permission guidance
+	if cfg.ServiceTokenIsSet() && requiredPermission != "" {
+		return fmt.Errorf("%s\n\nNote: You are using a service token for authentication. If this resource exists, your service token may not have the required '%s' permission to access it. Please check your service token permissions.", baseMsg, requiredPermission)
+	}
+
+	return errors.New(baseMsg)
+}


### PR DESCRIPTION
This improves the handling of 404s when authenticated with a service token.

Since a 404 generally means the token does not have access to the resource, it's confusing that we say it's "not found".

`cmdutil.HandleNotFoundWithServiceTokenCheck(` can be added to more commands. Started with the two most common that trip people up (branch show and branch create).

## New error messages

**Invalid token:**
```
Error: Authentication failed. Your service token appears to be invalid.

You are currently authenticating using service tokens. Please check your service token credentials.

Service tokens can be provided in two ways:
  1. Environment variables: PLANETSCALE_SERVICE_TOKEN_ID and PLANETSCALE_SERVICE_TOKEN
  2. Command-line flags: --service-token-id and --service-token

To create a new service token, run: pscale service-token create
To list existing service tokens, run: pscale service-token list
```

**Missing permission:**
```
Error: branch mybranch does not exist in database mydb (organization: myorg)

Note: You are using a service token for authentication. If this resource exists, your service token may not have the required 'read_branch' permission to access it. Please check your service token permissions.
```