### PR TITLE
Implement commands for Postgres branches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.133.0
+	github.com/planetscale/planetscale-go v0.134.0
 	github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7
 	github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.133.0 h1:0DGjTcCXxe+xEKfk1gtRhH87DpnwSBKHOeD2EJrR9YU=
-github.com/planetscale/planetscale-go v0.133.0/go.mod h1:/n7PU99UvYaajJlTbMWMOOlHmkEuN7SFjvLNDSgMQOk=
+github.com/planetscale/planetscale-go v0.134.0 h1:RDl5c3bPbvnPBXBvwG/nQ42uaJ2HOVHkkvNNEQzJdyI=
+github.com/planetscale/planetscale-go v0.134.0/go.mod h1:/n7PU99UvYaajJlTbMWMOOlHmkEuN7SFjvLNDSgMQOk=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7 h1:dxdoFKWVDlV1gq8UQC8NWCofLjCEjEHw47gfeojgs28=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6 h1:/Ox1ZTAdk+soSngzzKoJh5voOzptrpPrux11o30rIaw=

--- a/internal/cmd/backup/restore_test.go
+++ b/internal/cmd/backup/restore_test.go
@@ -40,6 +40,14 @@ func TestBackup_RestoreCmd(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -48,6 +56,63 @@ func TestBackup_RestoreCmd(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
+			}, nil
+		},
+	}
+
+	cmd := RestoreCmd(ch)
+	cmd.SetArgs([]string{db, branch, backup, "--cluster-size", "PS-20"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBackup_RestoreCmd_PostgreSQL(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "restore-branch"
+	backup := "mybackup"
+
+	res := &ps.PostgresBranch{Name: "restore-branch"}
+
+	svc := &mock.PostgresBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Name, qt.Equals, branch)
+			c.Assert(req.BackupID, qt.Equals, backup)
+			c.Assert(req.ClusterName, qt.Equals, "PS-20")
+			return res, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "postgres"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}

--- a/internal/cmd/backup/restore_test.go
+++ b/internal/cmd/backup/restore_test.go
@@ -100,7 +100,7 @@ func TestBackup_RestoreCmd_PostgreSQL(t *testing.T) {
 		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
-			return &ps.Database{Kind: "postgres"}, nil
+			return &ps.Database{Kind: "postgresql"}, nil
 		},
 	}
 

--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -86,3 +86,47 @@ func toDatabaseBranches(branches []*ps.DatabaseBranch) []*DatabaseBranch {
 
 	return bs
 }
+
+type PostgresBranch struct {
+	ID           string `header:"id" json:"id"`
+	Name         string `header:"name" json:"name"`
+	ParentBranch string `header:"parent branch,n/a" json:"parent_branch"`
+	Region       string `header:"region" json:"region"`
+	Production   bool   `header:"production" json:"production"`
+	Ready        bool   `header:"ready" json:"ready"`
+	CreatedAt    int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
+	UpdatedAt    int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+	orig         *ps.PostgresBranch
+}
+
+func ToPostgresBranch(b *ps.PostgresBranch) *PostgresBranch {
+	return &PostgresBranch{
+		ID:           b.ID,
+		Name:         b.Name,
+		ParentBranch: b.ParentBranch,
+		Region:       b.Region.Slug,
+		Production:   b.Production,
+		Ready:        b.Ready,
+		CreatedAt:    b.CreatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
+		UpdatedAt:    b.UpdatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
+		orig:         b,
+	}
+}
+
+func toPostgresBranches(branches []*ps.PostgresBranch) []*PostgresBranch {
+	bs := make([]*PostgresBranch, 0, len(branches))
+
+	for _, db := range branches {
+		bs = append(bs, ToPostgresBranch(db))
+	}
+
+	return bs
+}
+
+func (p *PostgresBranch) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(p.orig, "", "  ")
+}
+
+func (p *PostgresBranch) MarshalCSVValue() interface{} {
+	return []*PostgresBranch{p}
+}

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -13,11 +13,13 @@ import (
 )
 
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
-	createReq := &ps.CreateDatabaseBranchRequest{}
-
 	var flags struct {
 		wait          bool
 		dataBranching bool
+		region        string
+		parentBranch  string
+		clusterSize   string
+		backupID      string
 	}
 
 	cmd := &cobra.Command{
@@ -66,14 +68,6 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			source := args[0]
 			branch := args[1]
 
-			if flags.dataBranching {
-				createReq.SeedData = "last_successful_backup"
-			}
-
-			createReq.Database = source
-			createReq.Name = branch
-			createReq.Organization = ch.Config.Organization
-
 			client, err := ch.Client()
 			if err != nil {
 				return err
@@ -81,56 +75,141 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating branch from %s...", printer.BoldBlue(source)))
 			defer end()
-			dbBranch, err := client.DatabaseBranches.Create(cmd.Context(), createReq)
+
+			db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
+				Organization: ch.Config.Organization,
+				Database:     source,
+			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					if createReq.ParentBranch != "" {
-						return cmdutil.HandleNotFoundWithServiceTokenCheck(
-							ctx, cmd, ch.Config, ch.Client, err, "create_branch",
-							"source branch %s or database %s does not exist (organization: %s)",
-							printer.BoldBlue(createReq.ParentBranch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
-					} else {
-						return cmdutil.HandleNotFoundWithServiceTokenCheck(
-							ctx, cmd, ch.Config, ch.Client, err, "create_branch",
-							"source database %s does not exist in organization %s",
-							printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
-					}
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+						"branch %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(branch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)
 				}
 			}
 
-			end()
-
-			// wait and check until the DB is ready
-			if flags.wait {
-				end := ch.Printer.PrintProgress(fmt.Sprintf("Waiting until branch %s is ready...", printer.BoldBlue(branch)))
-				defer end()
-				getReq := &ps.GetDatabaseBranchRequest{
+			if db.Kind == "mysql" {
+				createReq := &ps.CreateDatabaseBranchRequest{
 					Organization: ch.Config.Organization,
 					Database:     source,
-					Branch:       branch,
+					Name:         branch,
+					Region:       flags.region,
+					ClusterSize:  flags.clusterSize,
+					ParentBranch: flags.parentBranch,
+					BackupID:     flags.backupID,
 				}
-				if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
-					return err
+
+				if flags.dataBranching {
+					createReq.SeedData = "last_successful_backup"
 				}
+
+				dbBranch, err := client.DatabaseBranches.Create(cmd.Context(), createReq)
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case ps.ErrNotFound:
+						if createReq.ParentBranch != "" {
+							return cmdutil.HandleNotFoundWithServiceTokenCheck(
+								ctx, cmd, ch.Config, ch.Client, err, "create_branch",
+								"source branch %s or database %s does not exist (organization: %s)",
+								printer.BoldBlue(createReq.ParentBranch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+						} else {
+							return cmdutil.HandleNotFoundWithServiceTokenCheck(
+								ctx, cmd, ch.Config, ch.Client, err, "create_branch",
+								"source database %s does not exist in organization %s",
+								printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+						}
+					default:
+						return cmdutil.HandleError(err)
+					}
+				}
+
 				end()
-			}
 
-			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Branch %s was successfully created.\n\nView this branch in the browser: %s\n", printer.BoldBlue(dbBranch.Name), printer.BoldBlue(dbBranch.HtmlURL))
-				return nil
-			}
+				// wait and check until the DB is ready
+				if flags.wait {
+					end := ch.Printer.PrintProgress(fmt.Sprintf("Waiting until branch %s is ready...", printer.BoldBlue(branch)))
+					defer end()
+					getReq := &ps.GetDatabaseBranchRequest{
+						Organization: ch.Config.Organization,
+						Database:     source,
+						Branch:       branch,
+					}
+					if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+						return err
+					}
+					end()
+				}
+				if ch.Printer.Format() == printer.Human {
+					ch.Printer.Printf("Branch %s was successfully created.\n\nView this branch in the browser: %s\n", printer.BoldBlue(dbBranch.Name), printer.BoldBlue(dbBranch.HtmlURL))
+					return nil
+				}
 
-			return ch.Printer.PrintResource(ToDatabaseBranch(dbBranch))
+				return ch.Printer.PrintResource(ToDatabaseBranch(dbBranch))
+			} else {
+				createReq := &ps.CreatePostgresBranchRequest{
+					Organization: ch.Config.Organization,
+					Database:     source,
+					Name:         branch,
+					Region:       flags.region,
+					ClusterName:  flags.clusterSize,
+					ParentBranch: flags.parentBranch,
+					BackupID:     flags.backupID,
+				}
+
+				dbBranch, err := client.PostgresBranches.Create(cmd.Context(), createReq)
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case ps.ErrNotFound:
+						if createReq.ParentBranch != "" {
+							return cmdutil.HandleNotFoundWithServiceTokenCheck(
+								ctx, cmd, ch.Config, ch.Client, err, "create_branch",
+								"source branch %s or database %s does not exist (organization: %s)",
+								printer.BoldBlue(createReq.ParentBranch), printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+						} else {
+							return cmdutil.HandleNotFoundWithServiceTokenCheck(
+								ctx, cmd, ch.Config, ch.Client, err, "create_branch",
+								"source database %s does not exist in organization %s",
+								printer.BoldBlue(source), printer.BoldBlue(ch.Config.Organization))
+						}
+					default:
+						return cmdutil.HandleError(err)
+					}
+				}
+
+				end()
+
+				// wait and check until the DB is ready
+				if flags.wait {
+					end := ch.Printer.PrintProgress(fmt.Sprintf("Waiting until branch %s is ready...", printer.BoldBlue(branch)))
+					defer end()
+					getReq := &ps.GetPostgresBranchRequest{
+						Organization: ch.Config.Organization,
+						Database:     source,
+						Branch:       branch,
+					}
+					if err := waitUntilPostgresReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+						return err
+					}
+					end()
+				}
+				if ch.Printer.Format() == printer.Human {
+					ch.Printer.Printf("Branch %s was successfully created in %s.\n", printer.BoldBlue(dbBranch.Name), printer.BoldBlue(source))
+					return nil
+				}
+
+				return ch.Printer.PrintResource(ToPostgresBranch(dbBranch))
+			}
 		},
 	}
 
-	cmd.Flags().StringVar(&createReq.ParentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
-	cmd.Flags().StringVar(&createReq.Region, "region", "", "Region for the branch to be created in.")
-	cmd.Flags().StringVar(&createReq.BackupID, "restore", "", "ID of Backup to restore into branch.")
-	cmd.Flags().StringVar(&createReq.ClusterSize, "cluster-size", "PS-10", "Cluster size for branches being created from a backup or seeded with data. Use 'pscale size cluster list' to see the valid sizes.")
+	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
+	cmd.Flags().StringVar(&flags.region, "region", "", "Region for the branch to be created in.")
+	cmd.Flags().StringVar(&flags.backupID, "restore", "", "ID of Backup to restore into branch.")
+	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS-10", "Cluster size for branches being created from a backup or seeded with data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
 	cmd.MarkFlagsMutuallyExclusive("from", "restore")
@@ -160,6 +239,32 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 			return errors.New("branch creation timed out")
 		case <-ticker.C:
 			resp, err := client.DatabaseBranches.Get(ctx, getReq)
+			if err != nil {
+				if debug {
+					printer.Printf("fetching database branch %s/%s failed: %s", getReq.Database, getReq.Branch, err)
+				}
+				continue
+			}
+
+			if resp.Ready {
+				return nil
+			}
+		}
+	}
+}
+
+func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetPostgresBranchRequest) error {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("branch creation timed out")
+		case <-ticker.C:
+			resp, err := client.PostgresBranches.Get(ctx, getReq)
 			if err != nil {
 				if debug {
 					printer.Printf("fetching database branch %s/%s failed: %s", getReq.Database, getReq.Branch, err)

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -96,6 +96,14 @@ func TestBranch_CreateCmdWithRestore(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -104,6 +112,7 @@ func TestBranch_CreateCmdWithRestore(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -144,6 +153,14 @@ func TestBranch_CreateCmdWithRestoreNoSize(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -152,6 +169,7 @@ func TestBranch_CreateCmdWithRestoreNoSize(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -191,6 +209,14 @@ func TestBranch_CreateCmdWithSeedData(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -199,6 +225,7 @@ func TestBranch_CreateCmdWithSeedData(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -238,6 +265,14 @@ func TestBranch_CreateCmd_ServiceTokenAuthError(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -249,6 +284,7 @@ func TestBranch_CreateCmd_ServiceTokenAuthError(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
 				Organizations:    orgSvc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -291,6 +327,14 @@ func TestBranch_CreateCmd_GenuineNotFound(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -302,6 +346,7 @@ func TestBranch_CreateCmd_GenuineNotFound(t *testing.T) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
 				Organizations:    orgSvc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -39,6 +39,14 @@ func TestBranch_CreateCmd(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -47,6 +55,7 @@ func TestBranch_CreateCmd(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}

--- a/internal/cmd/branch/delete_test.go
+++ b/internal/cmd/branch/delete_test.go
@@ -156,7 +156,7 @@ func TestBranch_DeleteCmd_PostgreSQL(t *testing.T) {
 		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
-			return &ps.Database{Kind: "postgres"}, nil
+			return &ps.Database{Kind: "postgresql"}, nil
 		},
 	}
 

--- a/internal/cmd/branch/list_test.go
+++ b/internal/cmd/branch/list_test.go
@@ -160,7 +160,7 @@ func TestBranch_ListCmd_PostgreSQL(t *testing.T) {
 		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
-			return &ps.Database{Kind: "postgres"}, nil
+			return &ps.Database{Kind: "postgresql"}, nil
 		},
 	}
 

--- a/internal/cmd/branch/list_test.go
+++ b/internal/cmd/branch/list_test.go
@@ -40,6 +40,14 @@ func TestBranch_ListCmd(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -48,6 +56,7 @@ func TestBranch_ListCmd(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -79,6 +88,13 @@ func TestBranch_ListCmd_ServiceTokenPermissionError(t *testing.T) {
 		},
 	}
 
+	// Mock database service that succeeds
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	// Mock organization service that succeeds (simulating valid service token)
 	orgSvc := &mock.OrganizationsService{
 		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
@@ -96,6 +112,7 @@ func TestBranch_ListCmd_ServiceTokenPermissionError(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
+				Databases:        dbSvc,
 				Organizations:    orgSvc,
 			}, nil
 		},
@@ -111,4 +128,60 @@ func TestBranch_ListCmd_ServiceTokenPermissionError(t *testing.T) {
 	c.Assert(err.Error(), qt.Contains, "read_branch")
 	c.Assert(branchSvc.ListFnInvoked, qt.IsTrue)
 	c.Assert(orgSvc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_ListCmd_PostgreSQL(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	branches := []*ps.PostgresBranch{
+		{Name: branch},
+		{Name: "bar"},
+	}
+
+	svc := &mock.PostgresBranchesService{
+		ListFn: func(ctx context.Context, req *ps.ListPostgresBranchesRequest) ([]*ps.PostgresBranch, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+
+			return branches, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "postgres"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
+			}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, branches)
 }

--- a/internal/cmd/branch/schema_test.go
+++ b/internal/cmd/branch/schema_test.go
@@ -103,7 +103,7 @@ func TestBranchSchemaCmd_PostgreSQL(t *testing.T) {
 		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
-			return &ps.Database{Kind: "postgres"}, nil
+			return &ps.Database{Kind: "postgresql"}, nil
 		},
 	}
 

--- a/internal/cmd/branch/schema_test.go
+++ b/internal/cmd/branch/schema_test.go
@@ -41,6 +41,14 @@ func TestBranchSchemaCmd(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -49,6 +57,65 @@ func TestBranchSchemaCmd(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
+			}, nil
+		},
+	}
+
+	cmd := SchemaCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.SchemaFnInvoked, qt.IsTrue)
+
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranchSchemaCmd_PostgreSQL(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "feature"
+
+	res := []*ps.PostgresBranchSchema{
+		{Name: "foo", Raw: "CREATE TABLE foo (id INT);"},
+		{Name: "bar", Raw: "CREATE TABLE bar (id INT);"},
+	}
+
+	svc := &mock.PostgresBranchesService{
+		SchemaFn: func(ctx context.Context, req *ps.PostgresBranchSchemaRequest) ([]*ps.PostgresBranchSchema, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+
+			return res, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "postgres"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}

--- a/internal/cmd/branch/show_test.go
+++ b/internal/cmd/branch/show_test.go
@@ -333,7 +333,7 @@ func TestBranch_ShowCmd_PostgreSQL(t *testing.T) {
 		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
-			return &ps.Database{Kind: "postgres"}, nil
+			return &ps.Database{Kind: "postgresql"}, nil
 		},
 	}
 

--- a/internal/cmd/branch/show_test.go
+++ b/internal/cmd/branch/show_test.go
@@ -38,6 +38,14 @@ func TestBranch_ShowCmd(t *testing.T) {
 		},
 	}
 
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -46,6 +54,7 @@ func TestBranch_ShowCmd(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: svc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -78,6 +87,13 @@ func TestBranch_ShowCmd_ServiceTokenAuthError(t *testing.T) {
 		},
 	}
 
+	// Mock database service that succeeds
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	// Mock organization service that returns error for auth check (simulating invalid service token)
 	orgSvc := &mock.OrganizationsService{
 		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
@@ -95,6 +111,7 @@ func TestBranch_ShowCmd_ServiceTokenAuthError(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
+				Databases:        dbSvc,
 				Organizations:    orgSvc,
 			}, nil
 		},
@@ -131,6 +148,13 @@ func TestBranch_ShowCmd_GenuineNotFound(t *testing.T) {
 		},
 	}
 
+	// Mock database service that succeeds
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	// Mock organization service that succeeds (simulating valid service token)
 	orgSvc := &mock.OrganizationsService{
 		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
@@ -148,6 +172,7 @@ func TestBranch_ShowCmd_GenuineNotFound(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
+				Databases:        dbSvc,
 				Organizations:    orgSvc,
 			}, nil
 		},
@@ -185,6 +210,13 @@ func TestBranch_ShowCmd_GenuineNotFound_NoServiceToken(t *testing.T) {
 		},
 	}
 
+	// Mock database service that succeeds
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
@@ -194,6 +226,7 @@ func TestBranch_ShowCmd_GenuineNotFound_NoServiceToken(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
+				Databases:        dbSvc,
 			}, nil
 		},
 	}
@@ -229,6 +262,13 @@ func TestBranch_ShowCmd_GenuineNotFound_EmptyPermission(t *testing.T) {
 		},
 	}
 
+	// Mock database service that succeeds
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
 	// Mock organization service that succeeds (simulating valid service token)
 	orgSvc := &mock.OrganizationsService{
 		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
@@ -246,6 +286,7 @@ func TestBranch_ShowCmd_GenuineNotFound_EmptyPermission(t *testing.T) {
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				DatabaseBranches: branchSvc,
+				Databases:        dbSvc,
 				Organizations:    orgSvc,
 			}, nil
 		},
@@ -262,4 +303,58 @@ func TestBranch_ShowCmd_GenuineNotFound_EmptyPermission(t *testing.T) {
 	c.Assert(err.Error(), qt.Contains, "does not exist")
 	c.Assert(err.Error(), qt.Not(qt.Contains), "service token for authentication")
 	c.Assert(err.Error(), qt.Not(qt.Contains), "permission")
+}
+
+func TestBranch_ShowCmd_PostgreSQL(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	res := &ps.PostgresBranch{Name: branch}
+
+	svc := &mock.PostgresBranchesService{
+		GetFn: func(ctx context.Context, req *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+
+			return res, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "postgres"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
+			}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
 }

--- a/internal/mock/branch.go
+++ b/internal/mock/branch.go
@@ -127,3 +127,53 @@ func (d *DatabaseBranchesService) ListClusterSKUs(ctx context.Context, req *ps.L
 	d.ListClusterSKUsFnInvoked = true
 	return d.ListClusterSKUsFn(ctx, req, opts...)
 }
+
+type PostgresBranchesService struct {
+	CreateFn        func(context.Context, *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error)
+	CreateFnInvoked bool
+
+	ListFn        func(context.Context, *ps.ListPostgresBranchesRequest) ([]*ps.PostgresBranch, error)
+	ListFnInvoked bool
+
+	GetFn        func(context.Context, *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error)
+	GetFnInvoked bool
+
+	DeleteFn        func(context.Context, *ps.DeletePostgresBranchRequest) error
+	DeleteFnInvoked bool
+
+	SchemaFn        func(context.Context, *ps.PostgresBranchSchemaRequest) ([]*ps.PostgresBranchSchema, error)
+	SchemaFnInvoked bool
+
+	ListClusterSKUsFn        func(context.Context, *ps.ListBranchClusterSKUsRequest, ...ps.ListOption) ([]*ps.ClusterSKU, error)
+	ListClusterSKUsFnInvoked bool
+}
+
+func (p *PostgresBranchesService) Create(ctx context.Context, req *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+	p.CreateFnInvoked = true
+	return p.CreateFn(ctx, req)
+}
+
+func (p *PostgresBranchesService) List(ctx context.Context, req *ps.ListPostgresBranchesRequest) ([]*ps.PostgresBranch, error) {
+	p.ListFnInvoked = true
+	return p.ListFn(ctx, req)
+}
+
+func (p *PostgresBranchesService) Get(ctx context.Context, req *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error) {
+	p.GetFnInvoked = true
+	return p.GetFn(ctx, req)
+}
+
+func (p *PostgresBranchesService) Delete(ctx context.Context, req *ps.DeletePostgresBranchRequest) error {
+	p.DeleteFnInvoked = true
+	return p.DeleteFn(ctx, req)
+}
+
+func (p *PostgresBranchesService) Schema(ctx context.Context, req *ps.PostgresBranchSchemaRequest) ([]*ps.PostgresBranchSchema, error) {
+	p.SchemaFnInvoked = true
+	return p.SchemaFn(ctx, req)
+}
+
+func (p *PostgresBranchesService) ListClusterSKUs(ctx context.Context, req *ps.ListBranchClusterSKUsRequest, opts ...ps.ListOption) ([]*ps.ClusterSKU, error) {
+	p.ListClusterSKUsFnInvoked = true
+	return p.ListClusterSKUsFn(ctx, req, opts...)
+}


### PR DESCRIPTION
This pull request implements handling of the Postgres branches in our backup restore and branch commands, since the shape of the `PostgresBranch` model differs from that of `DatabaseBranch`.