### PR TITLE
Rename `kind` flag for database creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.136.0
+	github.com/planetscale/planetscale-go v0.137.0
 	github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7
 	github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.136.0 h1:l675oGFteUJLjF1vsUffF4XoPL1+PnsojpuSyMZ+pOk=
-github.com/planetscale/planetscale-go v0.136.0/go.mod h1:/n7PU99UvYaajJlTbMWMOOlHmkEuN7SFjvLNDSgMQOk=
+github.com/planetscale/planetscale-go v0.137.0 h1:q1aqlk5g/jqp70JyEfzZZPpHtVKUoIZRuGsipRaAmcs=
+github.com/planetscale/planetscale-go v0.137.0/go.mod h1:/n7PU99UvYaajJlTbMWMOOlHmkEuN7SFjvLNDSgMQOk=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7 h1:dxdoFKWVDlV1gq8UQC8NWCofLjCEjEHw47gfeojgs28=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6 h1:/Ox1ZTAdk+soSngzzKoJh5voOzptrpPrux11o30rIaw=

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -64,8 +64,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().String("cluster-size", "PS-10", "cluster size for Scaler Pro databases. Use `pscale size cluster list` to see the valid sizes.")
 
-	cmd.Flags().StringVar(&createReq.Kind, "kind", "mysql", "Kind of database to create. Supported values: mysql, postgresql. Defaults to mysql.")
-	cmd.RegisterFlagCompletionFunc("kind", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	cmd.Flags().StringVar(&createReq.Kind, "engine", "mysql", "The database engine for the database. Supported values: mysql, postgresql. Defaults to mysql.")
+	cmd.RegisterFlagCompletionFunc("engine", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		return []cobra.Completion{
 			cobra.CompletionWithDesc("mysql", "A Vitess database"),
 			cobra.CompletionWithDesc("postgresql", "The fastest cloud Postgres"),

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -15,6 +15,11 @@ import (
 func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	createReq := &ps.CreateDatabaseRequest{}
 
+	var flags struct {
+		clusterSize string
+		engine      string
+	}
+
 	cmd := &cobra.Command{
 		Use:   "create <database>",
 		Short: "Create a database instance",
@@ -25,12 +30,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			createReq.Organization = ch.Config.Organization
 			createReq.Name = args[0]
 
-			clusterSize, err := cmd.Flags().GetString("cluster-size")
-			if err != nil {
-				return err
-			}
-
-			createReq.ClusterSize = clusterSize
+			createReq.Kind = ps.DatabaseEngine(flags.engine)
 
 			client, err := ch.Client()
 			if err != nil {
@@ -62,9 +62,9 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&createReq.Region, "region", "", "region for the database")
 
-	cmd.Flags().String("cluster-size", "PS-10", "cluster size for Scaler Pro databases. Use `pscale size cluster list` to see the valid sizes.")
+	cmd.Flags().StringVar(&createReq.ClusterSize, "cluster-size", "", "cluster size for Scaler Pro databases. Use `pscale size cluster list` to see the valid sizes.")
 
-	cmd.Flags().StringVar(&createReq.Kind, "engine", "mysql", "The database engine for the database. Supported values: mysql, postgresql. Defaults to mysql.")
+	cmd.Flags().StringVar((*string)(&createReq.Kind), "engine", string(ps.DatabaseEngineMySQL), "The database engine for the database. Supported values: mysql, postgresql. Defaults to mysql.")
 	cmd.RegisterFlagCompletionFunc("engine", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
 		return []cobra.Completion{
 			cobra.CompletionWithDesc("mysql", "A Vitess database"),

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -65,3 +65,56 @@ func TestDatabase_CreateCmd(t *testing.T) {
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
+
+func TestDatabase_CreateCmdPostgres(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+
+	res := &ps.Database{Name: "foo"}
+
+	svc := &mock.DatabaseService{
+		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Name, qt.Equals, db)
+			c.Assert(req.Region, qt.Equals, "us-east")
+			c.Assert(req.Kind, qt.Equals, ps.DatabaseEnginePostgres)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases: svc,
+				Organizations: &mock.OrganizationsService{
+					GetFn: func(ctx context.Context, request *ps.GetOrganizationRequest) (*ps.Organization, error) {
+						return &ps.Organization{
+							RemainingFreeDatabases: 1,
+							Name:                   request.Organization,
+						}, nil
+					},
+				},
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, "--region", "us-east", "--engine", "postgresql"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}


### PR DESCRIPTION
This pull request renames the `kind` flag to `engine`, which has parity to how it's displayed in the UI. Also implements the database enum improvements that shipped in `planetscale-go`.