### PR TITLE
Add `role reset-default` command for Postgres branches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.137.0
+	github.com/planetscale/planetscale-go v0.138.0
 	github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7
 	github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.137.0 h1:q1aqlk5g/jqp70JyEfzZZPpHtVKUoIZRuGsipRaAmcs=
-github.com/planetscale/planetscale-go v0.137.0/go.mod h1:/n7PU99UvYaajJlTbMWMOOlHmkEuN7SFjvLNDSgMQOk=
+github.com/planetscale/planetscale-go v0.138.0 h1:gugBOD83GlYGrFtxJXUL9Kv+Eq2fRjbO5erKX1WPMPc=
+github.com/planetscale/planetscale-go v0.138.0/go.mod h1:/n7PU99UvYaajJlTbMWMOOlHmkEuN7SFjvLNDSgMQOk=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7 h1:dxdoFKWVDlV1gq8UQC8NWCofLjCEjEHw47gfeojgs28=
 github.com/planetscale/psdb v0.0.0-20240109164348-6848e728f6e7/go.mod h1:WZmi4gw3rOK+ryd1inGxgfKwoFV04O7xBCqzWzv0/0U=
 github.com/planetscale/psdbproxy v0.0.0-20250117221522-0c8e2b0e36e6 h1:/Ox1ZTAdk+soSngzzKoJh5voOzptrpPrux11o30rIaw=

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -1,0 +1,85 @@
+package role
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		force bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "reset-default",
+		Short: "Reset the credentials for the default `postgres` role",
+		Long:  "This command resets the credentials for the default `postgres` role in the database, allowing you to reconfigure access. Any connections using the `postgres` role will need to be updated with the new credentials.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := ch.Config.Organization
+			database := args[0]
+			branch := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Resetting default postgres role for %s/%s...", printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			role, err := client.PostgresRoles.ResetDefaultRole(cmd.Context(), &ps.ResetDefaultRoleRequest{
+				Organization: org,
+				Database:     database,
+				Branch:       branch,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again")
+
+				ch.Printer.Printf("Role was successfully reset for %s in %s.\n%s\n\n", printer.BoldBlue(branch), printer.BoldBlue(database), saveWarning)
+			}
+
+			return ch.Printer.PrintResource(toPostgresRole(role))
+		},
+	}
+
+	cmd.Flags().BoolVar(&flags.force, "force", false, "Force reset without confirmation")
+
+	return cmd
+}
+
+type PostgresRole struct {
+	PublicID      string `header:"id" json:"id"`
+	Name          string `header:"name" json:"name"`
+	Username      string `header:"username" json:"username"`
+	Password      string `header:"password" json:"password"`
+	AccessHostURL string `header:"access_host_url" json:"access_host_url"`
+
+	orig *ps.PostgresRole
+}
+
+func toPostgresRole(role *ps.PostgresRole) *PostgresRole {
+	return &PostgresRole{
+		PublicID:      role.ID,
+		Name:          role.Name,
+		Username:      role.Username,
+		Password:      role.Password,
+		AccessHostURL: role.AccessHostURL,
+		orig:          role,
+	}
+}

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -50,7 +50,7 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if ch.Printer.Format() == printer.Human {
-				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again")
+				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again. We recommend using these credentials only for creating usernames and passwords for accesssing your database.")
 
 				ch.Printer.Printf("Role was successfully reset for %s in %s.\n%s\n\n", printer.BoldBlue(branch), printer.BoldBlue(database), saveWarning)
 			}

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -18,6 +18,7 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "reset-default",
 		Short: "Reset the credentials for the default `postgres` role",
 		Long:  "This command resets the credentials for the default `postgres` role in the database, allowing you to reconfigure access. Any connections using the `postgres` role will need to be updated with the new credentials.",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			org := ch.Config.Organization
 			database := args[0]

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -50,7 +50,7 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if ch.Printer.Format() == printer.Human {
-				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again. We recommend using these credentials only for creating usernames and passwords for accesssing your database.")
+				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again. We recommend using these credentials only for creating usernames and passwords for accessing your database.")
 
 				ch.Printer.Printf("Role was successfully reset for %s in %s.\n%s\n\n", printer.BoldBlue(branch), printer.BoldBlue(database), saveWarning)
 			}

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -15,7 +15,7 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "reset-default",
+		Use:   "reset-default <database> <branch>",
 		Short: "Reset the credentials for the default `postgres` role",
 		Long:  "This command resets the credentials for the default `postgres` role in the database, allowing you to reconfigure access. Any connections using the `postgres` role will need to be updated with the new credentials.",
 		Args:  cmdutil.RequiredArgs("database", "branch"),

--- a/internal/cmd/role/reset_default_test.go
+++ b/internal/cmd/role/reset_default_test.go
@@ -1,0 +1,73 @@
+package role
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestResetDefaultCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "testdb"
+	branch := "main"
+
+	expectedRole := &ps.PostgresRole{
+		ID:            "role-123",
+		Name:          "postgres",
+		Username:      "postgres",
+		Password:      "new-password-123",
+		AccessHostURL: "pg.psdb.cloud",
+	}
+
+	svc := &mock.PostgresRolesService{
+		ResetDefaultRoleFn: func(ctx context.Context, req *ps.ResetDefaultRoleRequest) (*ps.PostgresRole, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			return expectedRole, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresRoles: svc,
+			}, nil
+		},
+	}
+
+	cmd := ResetDefaultCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ResetDefaultRoleFnInvoked, qt.IsTrue)
+
+	expectedOutput := map[string]string{
+		"id":              "role-123",
+		"name":            "postgres",
+		"username":        "postgres",
+		"password":        "new-password-123",
+		"access_host_url": "pg.psdb.cloud",
+	}
+	c.Assert(buf.String(), qt.JSONEquals, expectedOutput)
+}

--- a/internal/cmd/role/role.go
+++ b/internal/cmd/role/role.go
@@ -1,0 +1,20 @@
+package role
+
+import (
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func RoleCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "role",
+		Short:             "Manage database roles for a Postgres database branch",
+		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
+	}
+
+	cmd.AddCommand(
+		ResetDefaultCmd(ch),
+	)
+
+	return cmd
+}

--- a/internal/cmd/role/role.go
+++ b/internal/cmd/role/role.go
@@ -12,6 +12,9 @@ func RoleCmd(ch *cmdutil.Helper) *cobra.Command {
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
 
+	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
+	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
+
 	cmd.AddCommand(
 		ResetDefaultCmd(ch),
 	)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/planetscale/cli/internal/cmd/dataimports"
 	"github.com/planetscale/cli/internal/cmd/mcp"
+	"github.com/planetscale/cli/internal/cmd/role"
 	"github.com/planetscale/cli/internal/cmd/size"
 	"github.com/planetscale/cli/internal/cmd/workflow"
 
@@ -232,6 +233,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.AddCommand(token.TokenCmd(ch))
 	rootCmd.AddCommand(version.VersionCmd(ch, ver, commit, buildDate))
 	rootCmd.AddCommand(workflow.WorkflowCmd(ch))
+	rootCmd.AddCommand(role.RoleCmd(ch))
 
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/internal/mock/postgres_roles.go
+++ b/internal/mock/postgres_roles.go
@@ -1,0 +1,17 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+type PostgresRolesService struct {
+	ResetDefaultRoleFn        func(context.Context, *ps.ResetDefaultRoleRequest) (*ps.PostgresRole, error)
+	ResetDefaultRoleFnInvoked bool
+}
+
+func (s *PostgresRolesService) ResetDefaultRole(ctx context.Context, req *ps.ResetDefaultRoleRequest) (*ps.PostgresRole, error) {
+	s.ResetDefaultRoleFnInvoked = true
+	return s.ResetDefaultRoleFn(ctx, req)
+}


### PR DESCRIPTION
This pull request implements a command called `reset-default` that resets the default user role for a Postgres branch. Given that it can be a disruptive action, I've also added in a confirmation step as well as a guardrail.