### PR TITLE
Implement `pscale shell` for Postgres

### DIFF
--- a/internal/cmd/role/create.go
+++ b/internal/cmd/role/create.go
@@ -76,4 +76,3 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	return cmd
 }
-

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -20,6 +20,8 @@ import (
 	"github.com/planetscale/cli/internal/printer"
 	"github.com/planetscale/cli/internal/promptutil"
 	"github.com/planetscale/cli/internal/proxyutil"
+	"github.com/planetscale/cli/internal/roleutil"
+	"vitess.io/vitess/go/mysql"
 )
 
 func ShellCmd(ch *cmdutil.Helper, sigc chan os.Signal, signals ...os.Signal) *cobra.Command {
@@ -34,11 +36,12 @@ func ShellCmd(ch *cmdutil.Helper, sigc chan os.Signal, signals ...os.Signal) *co
 		Use: "shell [database] [branch]",
 		// we only require database, because we deduct branch automatically
 		Args:  cmdutil.RequiredArgs("database"),
-		Short: "Open a MySQL shell instance to a database and branch",
-		Long:  "Open a MySQL shell instance to a database and branch.\n\nThis command is only supported for Vitess databases.",
-		Example: `The shell subcommand opens a secure MySQL shell instance to your database.
+		Short: "Open a shell instance to a database and branch",
+		Example: `The shell subcommand opens a secure shell instance to your database.
 
-It uses the MySQL command-line client ("mysql"), which needs to be installed.
+For MySQL databases, it uses the MySQL command-line client ("mysql").
+For Postgres databases, it uses the Postgres command-line client ("psql").
+
 By default, if no branch names are given and there is only one branch, it
 automatically opens a shell to that branch:
 
@@ -64,14 +67,45 @@ second argument:
 				runForeground = false
 			}
 
-			mysqlPath, authMethod, err := cmdutil.MySQLClientPath()
+			client, err := ch.Client()
 			if err != nil {
 				return err
 			}
 
-			client, err := ch.Client()
+			// Get database info to determine the database kind
+			dbInfo, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
 			if err != nil {
-				return err
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			// Check database kind and get appropriate client path
+			var clientPath string
+			var authMethod mysql.AuthMethodDescription
+			var isPostgreSQL bool
+
+			switch dbInfo.Kind {
+			case "mysql":
+				clientPath, authMethod, err = cmdutil.MySQLClientPath()
+				if err != nil {
+					return err
+				}
+			case "postgresql", "horizon":
+				clientPath, err = cmdutil.PostgreSQLClientPath()
+				if err != nil {
+					return err
+				}
+				isPostgreSQL = true
+			default:
+				return fmt.Errorf("unsupported database kind: %s. Only 'mysql' and 'postgresql' are supported", dbInfo.Kind)
 			}
 
 			var branch string
@@ -132,104 +166,11 @@ second argument:
 			if !dbBranch.Ready {
 				return errors.New("database branch is not ready yet")
 			}
-			pw, err := passwordutil.New(ctx, client, passwordutil.Options{
-				Organization: ch.Config.Organization,
-				Database:     database,
-				Branch:       branch,
-				Role:         role,
-				Name:         passwordutil.GenerateName("pscale-cli-shell"),
-				TTL:          5 * time.Minute,
-				Replica:      replica,
-			})
-			if err != nil {
-				return cmdutil.HandleError(err)
-			}
-			defer func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
 
-				if err := pw.Cleanup(ctx); err != nil {
-					ch.Printer.Println("failed to delete credentials: ", err)
-				}
-			}()
-
-			localAddr := "127.0.0.1:0"
-			if flags.localAddr != "" {
-				localAddr = flags.localAddr
-			}
-
-			remoteAddr := flags.remoteAddr
-			if remoteAddr == "" {
-				remoteAddr = pw.Password.Hostname
-			}
-
-			proxy := proxyutil.New(proxyutil.Config{
-				Logger:       cmdutil.NewZapLogger(ch.Debug()),
-				UpstreamAddr: remoteAddr,
-				Username:     pw.Password.Username,
-				Password:     pw.Password.PlainText,
-			})
-			defer proxy.Close()
-
-			l, err := net.Listen("tcp", localAddr)
-			if err != nil {
-				return cmdutil.HandleError(err)
-			}
-			defer l.Close()
-
-			proxyAddr := l.Addr().String()
-			host, port, err := net.SplitHostPort(proxyAddr)
-			if err != nil {
-				return cmdutil.HandleError(err)
-			}
-
-			mysqlArgs := []string{
-				"-u",
-				"root",
-				"-c", // allow comments to pass to the server
-				"-s",
-				"-t", // the -s (silent) flag disables tabular output, re-enable it.
-				"-h", host,
-				"-P", port,
-			}
-			if replica {
-				mysqlArgs = append([]string{"--no-defaults"}, mysqlArgs...)
+			if isPostgreSQL {
+				return startShellForPostgres(ctx, ch, client, database, branch, dbBranch, clientPath, role, replica, flags, sigc, signals, runForeground)
 			} else {
-				mysqlArgs = append(mysqlArgs, "-D", "@primary")
-			}
-
-			historyFile := historyFilePath(ch.Config.Organization, database, branch)
-			styledBranch := formatMySQLBranch(database, dbBranch)
-
-			m := &mysql{
-				mysqlPath:    mysqlPath,
-				historyFile:  historyFile,
-				styledBranch: styledBranch,
-				debug:        ch.Debug(),
-				printer:      ch.Printer,
-			}
-
-			errCh := make(chan error, 1)
-			go func() {
-				errCh <- proxy.Serve(l, authMethod)
-			}()
-
-			go func() {
-				errCh <- m.Run(ctx, sigc, signals, runForeground, mysqlArgs...)
-			}()
-
-			go func() {
-				errCh <- pw.Renew(ctx)
-			}()
-
-			select {
-			case <-ctx.Done():
-				return nil
-			case err := <-errCh:
-				if err == nil {
-					return nil
-				}
-				return cmdutil.HandleError(err)
+				return startShellForMySQL(ctx, ch, client, database, branch, dbBranch, clientPath, authMethod, role, replica, flags, sigc, signals, runForeground)
 			}
 		},
 	}
@@ -248,7 +189,7 @@ second argument:
 	return cmd
 }
 
-type mysql struct {
+type mysqlClient struct {
 	mysqlPath    string
 	dir          string
 	styledBranch string
@@ -257,8 +198,18 @@ type mysql struct {
 	printer      *printer.Printer
 }
 
+type postgresql struct {
+	psqlPath     string
+	dir          string
+	styledBranch string
+	historyFile  string
+	debug        bool
+	printer      *printer.Printer
+	password     string
+}
+
 // Run runs the `mysql` client with the given arguments.
-func (m *mysql) Run(ctx context.Context, sigc chan os.Signal, signals []os.Signal, runForeground bool, args ...string) error {
+func (m *mysqlClient) Run(ctx context.Context, sigc chan os.Signal, signals []os.Signal, runForeground bool, args ...string) error {
 	c := exec.CommandContext(ctx, m.mysqlPath, args...)
 	if m.dir != "" {
 		c.Dir = m.dir
@@ -285,7 +236,36 @@ func (m *mysql) Run(ctx context.Context, sigc chan os.Signal, signals []os.Signa
 	return c.Run()
 }
 
-func formatMySQLBranch(database string, branch *ps.DatabaseBranch) string {
+// Run runs the `psql` client with the given arguments.
+func (p *postgresql) Run(ctx context.Context, sigc chan os.Signal, signals []os.Signal, runForeground bool, args ...string) error {
+	c := exec.CommandContext(ctx, p.psqlPath, args...)
+	if p.dir != "" {
+		c.Dir = p.dir
+	}
+
+	c.Env = append(os.Environ(),
+		fmt.Sprintf("PSQL_HISTORY=%s", p.historyFile),
+		fmt.Sprintf("PGPASSWORD=%s", p.password),
+	)
+
+	c.Env = append(c.Env, fmt.Sprintf("PSQL_PROMPT1=%s", p.styledBranch))
+
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+
+	if runForeground {
+		c.SysProcAttr = sysProcAttr()
+		cancel := setupSignals(ctx, c, sigc, signals)
+		if cancel != nil {
+			defer cancel()
+		}
+	}
+
+	return c.Run()
+}
+
+func formatBranch(database string, branch *ps.DatabaseBranch) string {
 	branchStr := branch.Name
 
 	if branch.Production {
@@ -329,4 +309,223 @@ func historyFilePath(org, db, branch string) string {
 	}
 
 	return historyFile
+}
+
+type shellFlags struct {
+	localAddr  string
+	remoteAddr string
+	role       string
+	replica    bool
+}
+
+func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, role cmdutil.PasswordRole, replica bool, flags shellFlags, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {
+	// Postgres connects directly, no local proxy needed
+	if flags.localAddr != "" {
+		return errors.New("--local-addr flag is not supported for Postgres databases")
+	}
+
+	// Map role flags to Postgres role inheritance
+	var inheritedRoles []string
+	var successor string
+
+	switch role {
+	case cmdutil.ReaderRole:
+		inheritedRoles = []string{"pg_read_all_data"}
+	case cmdutil.WriterRole:
+		inheritedRoles = []string{"pg_write_all_data"}
+	case cmdutil.ReadWriterRole:
+		inheritedRoles = []string{"pg_read_all_data", "pg_write_all_data"}
+	case cmdutil.AdministratorRole:
+		inheritedRoles = []string{"postgres"}
+		successor = "postgres"
+	default:
+		// Default to empty array for unknown roles
+		inheritedRoles = []string{}
+	}
+
+	// Create a temporary role for Postgres
+	pgRole, err := roleutil.New(ctx, client, roleutil.Options{
+		Organization:   ch.Config.Organization,
+		Database:       database,
+		Branch:         branch,
+		Name:           roleutil.GenerateName("pscale-cli-shell"),
+		TTL:            300 * time.Second, // 300s = 5 minutes
+		InheritedRoles: inheritedRoles,
+	})
+	if err != nil {
+		return cmdutil.HandleError(err)
+	}
+
+	username := pgRole.Role.Username
+	if replica {
+		username = username + "|replica"
+	}
+	password := pgRole.Role.Password
+
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := pgRole.Cleanup(ctx, successor); err != nil {
+			ch.Printer.Println("failed to delete role: ", err)
+		}
+	}()
+
+	remoteAddr := flags.remoteAddr
+	if remoteAddr == "" {
+		remoteAddr = pgRole.Role.AccessHostURL
+	}
+
+	// For PostgreSQL, connect directly to the remote host without proxy
+	remoteHost, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		// If remoteAddr doesn't have port, use it as is
+		remoteHost = remoteAddr
+	}
+
+	psqlArgs := []string{
+		"-h", remoteHost,
+		"-p", "5432",
+		"-U", username,
+		"-d", "postgres",
+	}
+
+	historyFile := historyFilePath(ch.Config.Organization, database, branch)
+	styledBranch := formatBranch(database, dbBranch)
+
+	psql := &postgresql{
+		psqlPath:     clientPath,
+		historyFile:  historyFile,
+		styledBranch: styledBranch,
+		debug:        ch.Debug(),
+		printer:      ch.Printer,
+		password:     password,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- psql.Run(ctx, sigc, signals, runForeground, psqlArgs...)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-errCh:
+		if err == nil {
+			return nil
+		}
+		return cmdutil.HandleError(err)
+	}
+}
+
+func startShellForMySQL(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, authMethod mysql.AuthMethodDescription, role cmdutil.PasswordRole, replica bool, flags shellFlags, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {
+	// Create a password for MySQL
+	pw, err := passwordutil.New(ctx, client, passwordutil.Options{
+		Organization: ch.Config.Organization,
+		Database:     database,
+		Branch:       branch,
+		Role:         role,
+		Name:         passwordutil.GenerateName("pscale-cli-shell"),
+		TTL:          5 * time.Minute,
+		Replica:      replica,
+	})
+	if err != nil {
+		return cmdutil.HandleError(err)
+	}
+
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := pw.Cleanup(ctx); err != nil {
+			ch.Printer.Println("failed to delete credentials: ", err)
+		}
+	}()
+
+	username := pw.Password.Username
+	password := pw.Password.PlainText
+
+	localAddr := "127.0.0.1:0"
+	if flags.localAddr != "" {
+		localAddr = flags.localAddr
+	}
+
+	remoteAddr := flags.remoteAddr
+	if remoteAddr == "" {
+		remoteAddr = pw.Password.Hostname
+	}
+
+	proxyConfig := proxyutil.Config{
+		Logger:       cmdutil.NewZapLogger(ch.Debug()),
+		UpstreamAddr: remoteAddr,
+		Username:     username,
+		Password:     password,
+	}
+
+	// MySQL mode - create proxy
+	proxy := proxyutil.New(proxyConfig)
+	defer proxy.Close()
+
+	l, err := net.Listen("tcp", localAddr)
+	if err != nil {
+		return cmdutil.HandleError(err)
+	}
+	defer l.Close()
+
+	proxyAddr := l.Addr().String()
+	host, port, err := net.SplitHostPort(proxyAddr)
+	if err != nil {
+		return cmdutil.HandleError(err)
+	}
+
+	mysqlArgs := []string{
+		"-u",
+		"root",
+		"-c", // allow comments to pass to the server
+		"-s",
+		"-t", // the -s (silent) flag disables tabular output, re-enable it.
+		"-h", host,
+		"-P", port,
+	}
+	if replica {
+		mysqlArgs = append([]string{"--no-defaults"}, mysqlArgs...)
+	} else {
+		mysqlArgs = append(mysqlArgs, "-D", "@primary")
+	}
+
+	historyFile := historyFilePath(ch.Config.Organization, database, branch)
+	styledBranch := formatBranch(database, dbBranch)
+
+	m := &mysqlClient{
+		mysqlPath:    clientPath,
+		historyFile:  historyFile,
+		styledBranch: styledBranch,
+		debug:        ch.Debug(),
+		printer:      ch.Printer,
+	}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- proxy.Serve(l, authMethod)
+	}()
+
+	go func() {
+		errCh <- m.Run(ctx, sigc, signals, runForeground, mysqlArgs...)
+	}()
+
+	// Renew passwords for MySQL databases (Postgres roles have fixed TTL)
+	go func() {
+		errCh <- pw.Renew(ctx)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-errCh:
+		if err == nil {
+			return nil
+		}
+		return cmdutil.HandleError(err)
+	}
 }

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -248,8 +248,6 @@ func (p *postgresql) Run(ctx context.Context, sigc chan os.Signal, signals []os.
 		fmt.Sprintf("PGPASSWORD=%s", p.password),
 	)
 
-	c.Env = append(c.Env, fmt.Sprintf("PSQL_PROMPT1=%s", p.styledBranch))
-
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Stdin = os.Stdin
@@ -378,15 +376,16 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 		remotePort = "5432"
 	}
 
+	historyFile := historyFilePath(ch.Config.Organization, database, branch)
+	styledBranch := formatBranch(database, dbBranch)
+
 	psqlArgs := []string{
 		"-h", remoteHost,
 		"-p", remotePort,
 		"-U", username,
 		"-d", "postgres",
+		"-v", fmt.Sprintf("PROMPT1=%s", styledBranch),
 	}
-
-	historyFile := historyFilePath(ch.Config.Organization, database, branch)
-	styledBranch := formatBranch(database, dbBranch)
 
 	psql := &postgresql{
 		psqlPath:     clientPath,

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -397,20 +397,11 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 		password:     password,
 	}
 
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- psql.Run(ctx, sigc, signals, runForeground, psqlArgs...)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil
-	case err := <-errCh:
-		if err == nil {
-			return nil
-		}
+	err = psql.Run(ctx, sigc, signals, runForeground, psqlArgs...)
+	if err != nil {
 		return cmdutil.HandleError(err)
 	}
+	return nil
 }
 
 func startShellForMySQL(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, authMethod mysql.AuthMethodDescription, role cmdutil.PasswordRole, flags shellFlags, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -341,7 +341,7 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 		Organization:   ch.Config.Organization,
 		Database:       database,
 		Branch:         branch,
-		Name:           roleutil.GenerateName("pscale-cli-shell"),
+		Name:           passwordutil.GenerateName("pscale-cli-shell"),
 		TTL:            5 * time.Minute,
 		InheritedRoles: inheritedRoles,
 	})

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -167,10 +167,15 @@ second argument:
 				return errors.New("database branch is not ready yet")
 			}
 
+			shellFlags := shellFlags{
+				localAddr:  flags.localAddr,
+				remoteAddr: flags.remoteAddr,
+			}
+
 			if isPostgreSQL {
-				return startShellForPostgres(ctx, ch, client, database, branch, dbBranch, clientPath, role, replica, flags, sigc, signals, runForeground)
+				return startShellForPostgres(ctx, ch, client, database, branch, dbBranch, clientPath, role, replica, shellFlags, sigc, signals, runForeground)
 			} else {
-				return startShellForMySQL(ctx, ch, client, database, branch, dbBranch, clientPath, authMethod, role, replica, flags, sigc, signals, runForeground)
+				return startShellForMySQL(ctx, ch, client, database, branch, dbBranch, clientPath, authMethod, role, replica, shellFlags, sigc, signals, runForeground)
 			}
 		},
 	}
@@ -314,8 +319,6 @@ func historyFilePath(org, db, branch string) string {
 type shellFlags struct {
 	localAddr  string
 	remoteAddr string
-	role       string
-	replica    bool
 }
 
 func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, role cmdutil.PasswordRole, replica bool, flags shellFlags, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {

--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -342,7 +342,7 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 		Database:       database,
 		Branch:         branch,
 		Name:           roleutil.GenerateName("pscale-cli-shell"),
-		TTL:            300 * time.Second, // 300s = 5 minutes
+		TTL:            5 * time.Minute,
 		InheritedRoles: inheritedRoles,
 	})
 	if err != nil {
@@ -370,15 +370,17 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 	}
 
 	// For PostgreSQL, connect directly to the remote host without proxy
-	remoteHost, _, err := net.SplitHostPort(remoteAddr)
+	remoteHost, remotePort, err := net.SplitHostPort(remoteAddr)
 	if err != nil {
-		// If remoteAddr doesn't have port, use it as is
+		// If remoteAddr doesn't have port, treat it as just a hostname and
+		// default to port 5432
 		remoteHost = remoteAddr
+		remotePort = "5432"
 	}
 
 	psqlArgs := []string{
 		"-h", remoteHost,
-		"-p", "5432",
+		"-p", remotePort,
 		"-U", username,
 		"-d", "postgres",
 	}

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -174,8 +174,10 @@ func HasHomebrew() bool {
 	return err == nil
 }
 
-var versionRegex = regexp.MustCompile(`Ver ([0-9]+)\.([0-9]+)\.([0-9]+)`)
-var psqlVersionRegex = regexp.MustCompile(`psql \(PostgreSQL\) ([0-9]+)\.([0-9]+)`)
+var (
+	versionRegex     = regexp.MustCompile(`Ver ([0-9]+)\.([0-9]+)\.([0-9]+)`)
+	psqlVersionRegex = regexp.MustCompile(`psql \(PostgreSQL\) ([0-9]+)\.([0-9]+)`)
+)
 
 // MySQLClientPath checks whether the 'mysql' client exists and returns the
 // path to the binary. The returned error contains instructions to install the

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -174,10 +174,7 @@ func HasHomebrew() bool {
 	return err == nil
 }
 
-var (
-	versionRegex     = regexp.MustCompile(`Ver ([0-9]+)\.([0-9]+)\.([0-9]+)`)
-	psqlVersionRegex = regexp.MustCompile(`psql \(PostgreSQL\) ([0-9]+)\.([0-9]+)`)
-)
+var versionRegex = regexp.MustCompile(`Ver ([0-9]+)\.([0-9]+)\.([0-9]+)`)
 
 // MySQLClientPath checks whether the 'mysql' client exists and returns the
 // path to the binary. The returned error contains instructions to install the

--- a/internal/roleutil/roleutil.go
+++ b/internal/roleutil/roleutil.go
@@ -1,0 +1,63 @@
+package roleutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+// Options represents the options to create a new Postgres role
+type Options struct {
+	Organization   string
+	Database       string
+	Branch         string
+	Name           string
+	TTL            time.Duration
+	InheritedRoles []string
+}
+
+// Role represents a Postgres role with cleanup capabilities
+type Role struct {
+	Role   *ps.PostgresRole
+	client *ps.Client
+	opts   Options
+}
+
+// New creates a new temporary Postgres role
+func New(ctx context.Context, client *ps.Client, opts Options) (*Role, error) {
+	role, err := client.PostgresRoles.Create(ctx, &ps.CreatePostgresRoleRequest{
+		Organization:   opts.Organization,
+		Database:       opts.Database,
+		Branch:         opts.Branch,
+		Name:           opts.Name,
+		TTL:            int(opts.TTL.Seconds()),
+		InheritedRoles: opts.InheritedRoles,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role: %w", err)
+	}
+
+	return &Role{
+		Role:   role,
+		client: client,
+		opts:   opts,
+	}, nil
+}
+
+// Cleanup deletes the temporary role with an optional successor
+func (r *Role) Cleanup(ctx context.Context, successor string) error {
+	return r.client.PostgresRoles.Delete(ctx, &ps.DeletePostgresRoleRequest{
+		Organization: r.opts.Organization,
+		Database:     r.opts.Database,
+		Branch:       r.opts.Branch,
+		RoleId:       r.Role.ID,
+		Successor:    successor, // Empty string for no successor
+	})
+}
+
+// GenerateName generates a name for a temporary role with the given prefix
+func GenerateName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().Unix())
+}

--- a/internal/roleutil/roleutil.go
+++ b/internal/roleutil/roleutil.go
@@ -56,8 +56,3 @@ func (r *Role) Cleanup(ctx context.Context, successor string) error {
 		Successor:    successor, // Empty string for no successor
 	})
 }
-
-// GenerateName generates a name for a temporary role with the given prefix
-func GenerateName(prefix string) string {
-	return fmt.Sprintf("%s-%d", prefix, time.Now().Unix())
-}


### PR DESCRIPTION
`pscale shell` works for Postgres databases now.  Unlike Vitess, for Postgres, we just use `psql` to connect directly to the database, with no local proxy required.

`--replica` connects to a read-only replica.  `--role` allows `reader`, `writer`, `readwriter`, and `admin` roles, the same as Vitess.

We always connect to :5432, rather than the pooler on port :6432.  We're creating an ephemeral account, and poolers have to give each different account its own connection, so we'd never get pooled.  Why pay the extra hop for no benefit?

<img width="888" height="583" alt="Screenshot 2025-08-12 at 2 54 22 PM" src="https://github.com/user-attachments/assets/8af77eba-fc7d-4f63-9a2a-5b515788d6bb" />
