### PR TITLE
Bump `go` to `1.24.6`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5 AS build
+FROM golang:1.24.6 AS build
 WORKDIR /app
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 REPO=planetscale
 NAME=pscale
 BUILD_PKG=github.com/planetscale/cli/cmd/pscale
-GORELEASE_CROSS_VERSION ?= v1.24.5
+GORELEASE_CROSS_VERSION ?= v1.24.6
 SYFT_VERSION ?= 1.9.0
 
 .PHONY: all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   app:
-    image: golang:1.24.5
+    image: golang:1.24.6
     volumes:
       - .:/work
     working_dir: /work

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-ARG GORELEASE_CROSS_VERSION=v1.24.5
+ARG GORELEASE_CROSS_VERSION=v1.24.6
 FROM ghcr.io/goreleaser/goreleaser-cross:${GORELEASE_CROSS_VERSION}
 
 RUN apt-get update --allow-releaseinfo-change || apt-get update; apt-get install -y openssh-client

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/planetscale/cli
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
> go1.24.6 (released 2025-08-06) includes security fixes to the database/sql and os/exec packages, as well as bug fixes to the runtime. See the [Go 1.24.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.6+label%3ACherryPickApproved) on our issue tracker for details.

https://go.dev/doc/devel/release#go1.24.minor