### PR TITLE
Extend timeout for database branch readiness checks

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -231,7 +231,12 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	ticker := time.NewTicker(time.Second)
+	startTime := time.Now()
+	var ticker *time.Ticker
+
+	// Start with 5-second interval for the first minute
+	ticker = time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -249,6 +254,13 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 			if resp.Ready {
 				return nil
 			}
+
+			elapsed := time.Since(startTime)
+			if elapsed > time.Minute {
+				// Switch to 10-second interval after 1 minute
+				ticker.Stop()
+				ticker = time.NewTicker(10 * time.Second)
+			}
 		}
 	}
 }
@@ -257,7 +269,12 @@ func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *pri
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	ticker := time.NewTicker(time.Second)
+	startTime := time.Now()
+	var ticker *time.Ticker
+
+	// Start with 5-second interval for the first minute
+	ticker = time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 
 	for {
 		select {
@@ -274,6 +291,13 @@ func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *pri
 
 			if resp.Ready {
 				return nil
+			}
+
+			elapsed := time.Since(startTime)
+			if elapsed > time.Minute {
+				// Switch to 10-second interval after 1 minute
+				ticker.Stop()
+				ticker = time.NewTicker(10 * time.Second)
 			}
 		}
 	}

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -226,9 +226,9 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	return cmd
 }
 
-// waitUntilReady waits until the given database branch is ready. It times out after 3 minutes.
+// waitUntilReady waits until the given database branch is ready. It times out after 10 minutes.
 func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetDatabaseBranchRequest) error {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	ticker := time.NewTicker(time.Second)
@@ -254,7 +254,7 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 }
 
 func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetPostgresBranchRequest) error {
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	ticker := time.NewTicker(time.Second)


### PR DESCRIPTION
Increase to 10 minutes to handle for larger multi keyspace branches