### PR TITLE
Add multiple output formats to `database dump` command

### DIFF
--- a/internal/dumper/csv_writer.go
+++ b/internal/dumper/csv_writer.go
@@ -1,0 +1,84 @@
+package dumper
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+type csvWriter struct {
+	cfg        *Config
+	fieldNames []string
+	csvBuffer  bytes.Buffer
+	writer     *csv.Writer
+	chunkbytes int
+}
+
+func newCSVWriter(cfg *Config) *csvWriter {
+	return &csvWriter{
+		cfg: cfg,
+	}
+}
+
+func (w *csvWriter) Initialize(fieldNames []string) error {
+	w.fieldNames = fieldNames
+	w.csvBuffer.Reset()
+	w.writer = csv.NewWriter(&w.csvBuffer)
+
+	if err := w.writer.Write(fieldNames); err != nil {
+		return err
+	}
+	w.writer.Flush()
+	return nil
+}
+
+func (w *csvWriter) WriteRow(row []sqltypes.Value) (int, error) {
+	csvRow := make([]string, len(row))
+	for i, v := range row {
+		if v.Raw() == nil {
+			csvRow[i] = ""
+		} else {
+			csvRow[i] = v.String()
+		}
+	}
+
+	if err := w.writer.Write(csvRow); err != nil {
+		return 0, err
+	}
+	w.writer.Flush()
+
+	rowBytes := w.csvBuffer.Len()
+	bytesAdded := rowBytes - w.chunkbytes
+	w.chunkbytes = rowBytes
+	return bytesAdded, nil
+}
+
+func (w *csvWriter) ShouldFlush() bool {
+	return (w.chunkbytes / 1024 / 1024) >= w.cfg.ChunksizeInMB
+}
+
+func (w *csvWriter) Flush(outdir, database, table string, fileNo int) error {
+	file := fmt.Sprintf("%s/%s.%s.%05d.csv", outdir, database, table, fileNo)
+	err := writeFile(file, w.csvBuffer.String())
+	if err != nil {
+		return err
+	}
+
+	w.csvBuffer.Reset()
+	w.writer = csv.NewWriter(&w.csvBuffer)
+	if err := w.writer.Write(w.fieldNames); err != nil {
+		return err
+	}
+	w.writer.Flush()
+	w.chunkbytes = 0
+	return nil
+}
+
+func (w *csvWriter) Close(outdir, database, table string, fileNo int) error {
+	if w.csvBuffer.Len() > 0 {
+		return w.Flush(outdir, database, table, fileNo)
+	}
+	return nil
+}

--- a/internal/dumper/json_writer.go
+++ b/internal/dumper/json_writer.go
@@ -1,0 +1,74 @@
+package dumper
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+type jsonWriter struct {
+	cfg        *Config
+	fieldNames []string
+	jsonLines  []string
+	chunkbytes int
+}
+
+func newJSONWriter(cfg *Config) *jsonWriter {
+	return &jsonWriter{
+		cfg:       cfg,
+		jsonLines: make([]string, 0, 256),
+	}
+}
+
+func (w *jsonWriter) Initialize(fieldNames []string) error {
+	w.fieldNames = fieldNames
+	return nil
+}
+
+func (w *jsonWriter) WriteRow(row []sqltypes.Value) (int, error) {
+	rowMap := make(map[string]interface{})
+	for i, v := range row {
+		if v.Raw() == nil {
+			rowMap[w.fieldNames[i]] = nil
+		} else {
+			rowMap[w.fieldNames[i]] = v.String()
+		}
+	}
+
+	jsonBytes, err := json.Marshal(rowMap)
+	if err != nil {
+		return 0, err
+	}
+
+	jsonLine := string(jsonBytes) + "\n"
+	w.jsonLines = append(w.jsonLines, jsonLine)
+
+	lineBytes := len(jsonLine)
+	w.chunkbytes += lineBytes
+	return lineBytes, nil
+}
+
+func (w *jsonWriter) ShouldFlush() bool {
+	return (w.chunkbytes / 1024 / 1024) >= w.cfg.ChunksizeInMB
+}
+
+func (w *jsonWriter) Flush(outdir, database, table string, fileNo int) error {
+	file := fmt.Sprintf("%s/%s.%s.%05d.json", outdir, database, table, fileNo)
+	err := writeFile(file, strings.Join(w.jsonLines, ""))
+	if err != nil {
+		return err
+	}
+
+	w.jsonLines = w.jsonLines[:0]
+	w.chunkbytes = 0
+	return nil
+}
+
+func (w *jsonWriter) Close(outdir, database, table string, fileNo int) error {
+	if len(w.jsonLines) > 0 {
+		return w.Flush(outdir, database, table, fileNo)
+	}
+	return nil
+}

--- a/internal/dumper/sql_writer.go
+++ b/internal/dumper/sql_writer.go
@@ -1,0 +1,96 @@
+package dumper
+
+import (
+	"fmt"
+	"strings"
+
+	querypb "github.com/xelabs/go-mysqlstack/sqlparser/depends/query"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+type sqlWriter struct {
+	cfg        *Config
+	table      string
+	fields     []string
+	rows       []string
+	inserts    []string
+	stmtsize   int
+	chunkbytes int
+}
+
+func newSQLWriter(cfg *Config, table string) *sqlWriter {
+	return &sqlWriter{
+		cfg:     cfg,
+		table:   table,
+		rows:    make([]string, 0, 256),
+		inserts: make([]string, 0, 256),
+	}
+}
+
+func (w *sqlWriter) Initialize(fieldNames []string) error {
+	w.fields = make([]string, len(fieldNames))
+	for i, name := range fieldNames {
+		w.fields[i] = fmt.Sprintf("`%s`", name)
+	}
+	return nil
+}
+
+func (w *sqlWriter) WriteRow(row []sqltypes.Value) (int, error) {
+	values := make([]string, 0, 16)
+	for _, v := range row {
+		if v.Raw() == nil {
+			values = append(values, "NULL")
+		} else {
+			str := v.String()
+			switch {
+			case v.IsSigned(), v.IsUnsigned(), v.IsFloat(), v.IsIntegral(), v.Type() == querypb.Type_DECIMAL:
+				values = append(values, str)
+			default:
+				values = append(values, fmt.Sprintf("\"%s\"", escapeBytes(v.Raw())))
+			}
+		}
+	}
+	r := "(" + strings.Join(values, ",") + ")"
+	w.rows = append(w.rows, r)
+
+	rowBytes := len(r)
+	w.stmtsize += rowBytes
+	w.chunkbytes += rowBytes
+
+	if w.stmtsize >= w.cfg.StmtSize {
+		insertone := fmt.Sprintf("INSERT INTO `%s`(%s) VALUES\n%s", w.table, strings.Join(w.fields, ","), strings.Join(w.rows, ",\n"))
+		w.inserts = append(w.inserts, insertone)
+		w.rows = w.rows[:0]
+		w.stmtsize = 0
+	}
+
+	return rowBytes, nil
+}
+
+func (w *sqlWriter) ShouldFlush() bool {
+	return (w.chunkbytes / 1024 / 1024) >= w.cfg.ChunksizeInMB
+}
+
+func (w *sqlWriter) Flush(outdir, database, table string, fileNo int) error {
+	query := strings.Join(w.inserts, ";\n") + ";\n"
+	file := fmt.Sprintf("%s/%s.%s.%05d.sql", outdir, database, table, fileNo)
+	err := writeFile(file, query)
+	if err != nil {
+		return err
+	}
+
+	w.inserts = w.inserts[:0]
+	w.chunkbytes = 0
+	return nil
+}
+
+func (w *sqlWriter) Close(outdir, database, table string, fileNo int) error {
+	if w.chunkbytes > 0 {
+		if len(w.rows) > 0 {
+			insertone := fmt.Sprintf("INSERT INTO `%s`(%s) VALUES\n%s", w.table, strings.Join(w.fields, ","), strings.Join(w.rows, ",\n"))
+			w.inserts = append(w.inserts, insertone)
+		}
+		return w.Flush(outdir, database, table, fileNo)
+	}
+	return nil
+}

--- a/internal/dumper/writer.go
+++ b/internal/dumper/writer.go
@@ -1,0 +1,11 @@
+package dumper
+
+import "github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+
+type TableWriter interface {
+	Initialize(fieldNames []string) error
+	WriteRow(row []sqltypes.Value) (bytesAdded int, err error)
+	ShouldFlush() bool
+	Flush(outdir, database, table string, fileNo int) error
+	Close(outdir, database, table string, fileNo int) error
+}


### PR DESCRIPTION
Took inspiration from this tool for one of my projects, so I thought I'd contribute back. This adds support for multiple output formats via the new `--output-format` flag for the `database dump` command:

  - `sql` (default) - MySQL `INSERT` statements, for Postgres use `pg_dump`
  - `json` - JSONL (one line per JSON object)
  - `csv` - CSV with headers

Closes #892 (except Parquet support)