### PR TITLE
Add `webhook` `create` and `update` commands

### DIFF
--- a/internal/cmd/webhook/create.go
+++ b/internal/cmd/webhook/create.go
@@ -1,0 +1,70 @@
+package webhook
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		url     string
+		events  []string
+		enabled bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create <database>",
+		Short: "Create a webhook for a database",
+		Args:  cmdutil.RequiredArgs("database"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			req := &planetscale.CreateWebhookRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				URL:          flags.url,
+				Events:       flags.events,
+			}
+
+			if cmd.Flags().Changed("enabled") {
+				req.Enabled = &flags.enabled
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating webhook for %s", printer.BoldBlue(database)))
+			defer end()
+
+			webhook, err := client.Webhooks.Create(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			return ch.Printer.PrintResource(toWebhook(webhook))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.url, "url", "", "The URL to send webhook events to (required)")
+	cmd.Flags().StringSliceVar(&flags.events, "events", nil, "Comma-separated list of events to subscribe to")
+	cmd.Flags().BoolVar(&flags.enabled, "enabled", true, "Whether the webhook is enabled")
+
+	cmd.MarkFlagRequired("url") // nolint:errcheck
+
+	return cmd
+}

--- a/internal/cmd/webhook/create_test.go
+++ b/internal/cmd/webhook/create_test.go
@@ -1,0 +1,99 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestWebhook_CreateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	url := "https://example.com/webhook"
+	events := []string{"branch.created", "branch.deleted"}
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	webhook := &ps.Webhook{
+		ID:        "webhook-123",
+		URL:       url,
+		Enabled:   true,
+		Events:    events,
+		CreatedAt: createdAt,
+	}
+
+	svc := &mock.WebhooksService{
+		CreateFn: func(ctx context.Context, req *ps.CreateWebhookRequest) (*ps.Webhook, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.URL, qt.Equals, url)
+			c.Assert(req.Events, qt.DeepEquals, events)
+			return webhook, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Webhooks: svc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, "--url", url, "--events", "branch.created,branch.deleted"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+
+	res := &Webhook{orig: webhook}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestWebhook_CreateCmd_RequiresURL(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "required flag")
+}

--- a/internal/cmd/webhook/update.go
+++ b/internal/cmd/webhook/update.go
@@ -1,0 +1,85 @@
+package webhook
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		url     string
+		events  []string
+		enabled bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <database> <webhook-id>",
+		Short: "Update a webhook for a database",
+		Args:  cmdutil.RequiredArgs("database", "webhook-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			webhookID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			req := &planetscale.UpdateWebhookRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           webhookID,
+			}
+
+			changed := false
+
+			if cmd.Flags().Changed("url") {
+				req.URL = &flags.url
+				changed = true
+			}
+
+			if cmd.Flags().Changed("events") {
+				req.Events = flags.events
+				changed = true
+			}
+
+			if cmd.Flags().Changed("enabled") {
+				req.Enabled = &flags.enabled
+				changed = true
+			}
+
+			if !changed {
+				return fmt.Errorf("at least one of --url, --events, or --enabled must be provided")
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating webhook %s for %s", printer.BoldBlue(webhookID), printer.BoldBlue(database)))
+			defer end()
+
+			webhook, err := client.Webhooks.Update(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("webhook %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(webhookID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			return ch.Printer.PrintResource(toWebhook(webhook))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.url, "url", "", "The URL to send webhook events to")
+	cmd.Flags().StringSliceVar(&flags.events, "events", nil, "Comma-separated list of events to subscribe to")
+	cmd.Flags().BoolVar(&flags.enabled, "enabled", true, "Whether the webhook is enabled")
+
+	return cmd
+}

--- a/internal/cmd/webhook/update_test.go
+++ b/internal/cmd/webhook/update_test.go
@@ -1,0 +1,151 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestWebhook_UpdateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	webhookID := "webhook-123"
+	newURL := "https://example.com/new-webhook"
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	webhook := &ps.Webhook{
+		ID:        webhookID,
+		URL:       newURL,
+		Enabled:   true,
+		Events:    []string{"branch.created"},
+		CreatedAt: createdAt,
+	}
+
+	svc := &mock.WebhooksService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateWebhookRequest) (*ps.Webhook, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.ID, qt.Equals, webhookID)
+			c.Assert(*req.URL, qt.Equals, newURL)
+			return webhook, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Webhooks: svc,
+			}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, webhookID, "--url", newURL})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+
+	res := &Webhook{orig: webhook}
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestWebhook_UpdateCmd_EnabledFlag(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	webhookID := "webhook-123"
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	webhook := &ps.Webhook{
+		ID:        webhookID,
+		URL:       "https://example.com/webhook",
+		Enabled:   false,
+		Events:    []string{"branch.created"},
+		CreatedAt: createdAt,
+	}
+
+	svc := &mock.WebhooksService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateWebhookRequest) (*ps.Webhook, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.ID, qt.Equals, webhookID)
+			c.Assert(*req.Enabled, qt.IsFalse)
+			return webhook, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Webhooks: svc,
+			}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, webhookID, "--enabled=false"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestWebhook_UpdateCmd_RequiresAtLeastOneFlag(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	webhookID := "webhook-123"
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, webhookID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "at least one of")
+}

--- a/internal/cmd/webhook/webhook.go
+++ b/internal/cmd/webhook/webhook.go
@@ -14,14 +14,16 @@ import (
 func WebhookCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "webhook <command>",
-		Short:             "List webhooks",
+		Short:             "Create, list, and manage webhooks",
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
 
 	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 
+	cmd.AddCommand(CreateCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
+	cmd.AddCommand(UpdateCmd(ch))
 
 	return cmd
 }
@@ -33,6 +35,7 @@ type Webhook struct {
 	Events    string `header:"events" json:"events"`
 	Enabled   bool   `header:"enabled" json:"enabled"`
 	CreatedAt int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
+	UpdatedAt int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
 
 	orig *ps.Webhook
 }
@@ -49,6 +52,7 @@ func toWebhook(webhook *ps.Webhook) *Webhook {
 		Events:    strings.Join(webhook.Events, ", "),
 		Enabled:   webhook.Enabled,
 		CreatedAt: printer.GetMilliseconds(webhook.CreatedAt),
+		UpdatedAt: printer.GetMilliseconds(webhook.UpdatedAt),
 		orig:      webhook,
 	}
 }


### PR DESCRIPTION
This implements the `create` and `update` commands for webhooks, which allow creating and modifying a webhook a `url`, `enabled` flag, and a set of `events`.

```shell
pscale webhook create <database> --org <org> --url https://example.com/webhook --events branch.created,branch.deleted
pscale webhook update <database> <webhook-id> --org <org> --url https://new-url.com/webhook
pscale webhook update <database> <webhook-id> --org <org> --enabled=false
```
