### PR TITLE
Add `webhook test` command

### DIFF
--- a/internal/cmd/webhook/test.go
+++ b/internal/cmd/webhook/test.go
@@ -1,0 +1,59 @@
+package webhook
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func TestCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test <database> <webhook-id>",
+		Short: "Send a test event to a webhook",
+		Args:  cmdutil.RequiredArgs("database", "webhook-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			webhookID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Sending test event to webhook %s for %s", printer.BoldBlue(webhookID), printer.BoldBlue(database)))
+			defer end()
+
+			err = client.Webhooks.Test(ctx, &planetscale.TestWebhookRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           webhookID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("webhook %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(webhookID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Test event was successfully sent to webhook %s.\n", printer.BoldBlue(webhookID))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "test event sent",
+			})
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/webhook/test_test.go
+++ b/internal/cmd/webhook/test_test.go
@@ -1,0 +1,133 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestWebhook_TestCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	webhookID := "webhook-123"
+
+	svc := &mock.WebhooksService{
+		TestFn: func(ctx context.Context, req *ps.TestWebhookRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.ID, qt.Equals, webhookID)
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Webhooks: svc,
+			}, nil
+		},
+	}
+
+	cmd := TestCmd(ch)
+	cmd.SetArgs([]string{db, webhookID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.TestFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{"result": "test event sent"})
+}
+
+func TestWebhook_TestCmd_Human(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	webhookID := "webhook-123"
+
+	svc := &mock.WebhooksService{
+		TestFn: func(ctx context.Context, req *ps.TestWebhookRequest) error {
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Webhooks: svc,
+			}, nil
+		},
+	}
+
+	cmd := TestCmd(ch)
+	cmd.SetArgs([]string{db, webhookID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.TestFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, "successfully sent")
+}
+
+func TestWebhook_TestCmd_NotFound(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	webhookID := "webhook-123"
+
+	svc := &mock.WebhooksService{
+		TestFn: func(ctx context.Context, req *ps.TestWebhookRequest) error {
+			return &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Webhooks: svc,
+			}, nil
+		},
+	}
+
+	cmd := TestCmd(ch)
+	cmd.SetArgs([]string{db, webhookID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+}

--- a/internal/cmd/webhook/webhook.go
+++ b/internal/cmd/webhook/webhook.go
@@ -25,6 +25,7 @@ func WebhookCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
+	cmd.AddCommand(TestCmd(ch))
 	cmd.AddCommand(UpdateCmd(ch))
 
 	return cmd


### PR DESCRIPTION
This implements the `webhook test` command using the https://planetscale.com/docs/api/reference/test_webhook API to send a test event to a webhook.

```shell
pscale webhook test my_database 4s6paohoa14k                                        
Test event was successfully sent to webhook 4s6paohoa14k.
```