### PR TITLE
Support setting a major version when creating databases and branches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.146.0
+	github.com/planetscale/planetscale-go v0.147.0
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.146.0 h1:cc65OzW4hkbhNLDApQlVAFG1680obE/OvQzEKPPsT+U=
-github.com/planetscale/planetscale-go v0.146.0/go.mod h1:PheYDHAwF14wfCBak1M0J64AdPW8NUeyvgPgWqe7zpI=
+github.com/planetscale/planetscale-go v0.147.0 h1:dof3HNIlEhJPN+gAM7BJlUCiuhVsf8mX2wlGtjVbp6U=
+github.com/planetscale/planetscale-go v0.147.0/go.mod h1:PheYDHAwF14wfCBak1M0J64AdPW8NUeyvgPgWqe7zpI=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -20,6 +20,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		parentBranch  string
 		clusterSize   string
 		backupID      string
+		majorVersion  string
 	}
 
 	cmd := &cobra.Command{
@@ -158,6 +159,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 					ClusterName:  flags.clusterSize,
 					ParentBranch: flags.parentBranch,
 					BackupID:     flags.backupID,
+					MajorVersion: flags.majorVersion,
 				}
 
 				dbBranch, err := client.PostgresBranches.Create(cmd.Context(), createReq)
@@ -212,6 +214,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS-10", "Cluster size for branches being created from a backup or seeded with data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
+	cmd.Flags().StringVar(&flags.majorVersion, "major-version", "", "For PostgreSQL databases, the PostgreSQL major version to use for the branch. Defaults to the major version of the parent branch if it exists or the database's default branch major version. Ignored for branches restored from backups.")
 	cmd.MarkFlagsMutuallyExclusive("from", "restore")
 	cmd.MarkFlagsMutuallyExclusive("restore", "seed-data")
 
@@ -221,6 +224,12 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.RegisterFlagCompletionFunc("cluster-size", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.ClusterSizesCompletionFunc(ch, cmd, args, toComplete)
+	})
+
+	cmd.RegisterFlagCompletionFunc("major-version", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		return []cobra.Completion{
+			cobra.CompletionWithDesc("17", "PostgreSQL 17"),
+		}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	return cmd

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -19,10 +19,11 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	createReq := &ps.CreateDatabaseRequest{}
 
 	var flags struct {
-		clusterSize string
-		engine      string
-		wait        bool
-		replicas    *int
+		clusterSize  string
+		engine       string
+		wait         bool
+		replicas     *int
+		majorVersion string
 	}
 
 	cmd := &cobra.Command{
@@ -44,6 +45,10 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if cmd.Flags().Changed("replicas") {
 				createReq.Replicas = flags.replicas
+			}
+
+			if flags.majorVersion != "" {
+				createReq.MajorVersion = flags.majorVersion
 			}
 
 			client, err := ch.Client()
@@ -98,6 +103,13 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		return []cobra.Completion{
 			cobra.CompletionWithDesc("mysql", "A Vitess database"),
 			cobra.CompletionWithDesc("postgresql", "The fastest cloud Postgres"),
+		}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	cmd.Flags().StringVar(&flags.majorVersion, "major-version", "", "For PostgreSQL databases, the PostgreSQL major version to use for the database. Defaults to the latest available major version.")
+	cmd.RegisterFlagCompletionFunc("major-version", func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+		return []cobra.Completion{
+			cobra.CompletionWithDesc("17", "PostgreSQL 17"),
 		}, cobra.ShellCompDirectiveNoFileComp
 	})
 

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -227,3 +227,57 @@ func TestDatabase_CreateCmdWithReplicas(t *testing.T) {
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
+
+func TestDatabase_CreateCmdPostgresWithMajorVersion(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+
+	res := &ps.Database{Name: "foo"}
+
+	svc := &mock.DatabaseService{
+		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Name, qt.Equals, db)
+			c.Assert(req.Region, qt.Equals, "us-east")
+			c.Assert(req.Kind, qt.Equals, ps.DatabaseEnginePostgres)
+			c.Assert(req.MajorVersion, qt.Equals, "17")
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases: svc,
+				Organizations: &mock.OrganizationsService{
+					GetFn: func(ctx context.Context, request *ps.GetOrganizationRequest) (*ps.Organization, error) {
+						return &ps.Organization{
+							RemainingFreeDatabases: 1,
+							Name:                   request.Organization,
+						}, nil
+					},
+				},
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, "--region", "us-east", "--engine", "postgresql", "--major-version", "17"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}


### PR DESCRIPTION
- https://github.com/planetscale/planetscale-go/pull/277

The create database and create branch APIs now allow specifying a `major_version` for PostgreSQL databases

* https://planetscale.com/docs/api/reference/create_database
* https://planetscale.com/docs/api/reference/create_branch

This adds a `--major-version` to `pscale database create` and `pscale branch create` to use that new parameter. Currently only PG 17 is supported (the default), but newer versions will be supported in the future.