### PR TITLE
Add `current` to `org list` output

### DIFF
--- a/internal/cmd/org/list.go
+++ b/internal/cmd/org/list.go
@@ -30,7 +30,9 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toOrgs(orgs))
+			currentOrgName := getCurrentOrganization(ch)
+
+			return ch.Printer.PrintResource(toOrgs(orgs, currentOrgName, ch.Printer.Format()))
 		},
 	}
 

--- a/internal/cmd/org/list_test.go
+++ b/internal/cmd/org/list_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"testing/fstest"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
@@ -33,11 +34,18 @@ func TestOrganization_ListCmd(t *testing.T) {
 		},
 	}
 
+	fs := fstest.MapFS{
+		".pscale.yml": &fstest.MapFile{
+			Data: []byte("org: " + org + "\n"),
+		},
+	}
+
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
 			Organization: org,
 		},
+		ConfigFS: config.NewConfigFS(fs),
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
 				Organizations: svc,
@@ -52,8 +60,157 @@ func TestOrganization_ListCmd(t *testing.T) {
 	c.Assert(svc.ListFnInvoked, qt.IsTrue)
 
 	orgs := []*organization{
-		{Name: "foo"},
-		{Name: "bar"},
+		{Name: "foo", Current: false},
+		{Name: "bar", Current: false},
+	}
+	c.Assert(buf.String(), qt.JSONEquals, orgs)
+}
+
+func TestOrganization_ListCmd_WithCurrentOrg(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	currentOrg := "foo"
+
+	svc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{
+				{Name: "foo"},
+				{Name: "bar"},
+			}, nil
+		},
+	}
+
+	fs := fstest.MapFS{
+		".pscale.yml": &fstest.MapFile{
+			Data: []byte("org: " + currentOrg + "\n"),
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: currentOrg,
+		},
+		ConfigFS: config.NewConfigFS(fs),
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Organizations: svc,
+			}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+
+	orgs := []*organization{
+		{Name: "foo", Current: true},
+		{Name: "bar", Current: false},
+	}
+	c.Assert(buf.String(), qt.JSONEquals, orgs)
+}
+
+func TestOrganization_ListCmd_HumanFormat(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	currentOrg := "foo"
+
+	svc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{
+				{Name: "foo"},
+				{Name: "bar"},
+			}, nil
+		},
+	}
+
+	fs := fstest.MapFS{
+		".pscale.yml": &fstest.MapFile{
+			Data: []byte("org: " + currentOrg + "\n"),
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: currentOrg,
+		},
+		ConfigFS: config.NewConfigFS(fs),
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Organizations: svc,
+			}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+
+	// For human format, the current org should have an asterisk prefix
+	output := buf.String()
+	c.Assert(output, qt.Contains, "* foo")
+	c.Assert(output, qt.Contains, "bar")
+
+	c.Assert(output, qt.Not(qt.Contains), "* bar")
+}
+
+func TestOrganization_ListCmd_NoConfig(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationsService{
+		ListFn: func(ctx context.Context) ([]*ps.Organization, error) {
+			return []*ps.Organization{
+				{Name: "foo"},
+				{Name: "bar"},
+			}, nil
+		},
+	}
+
+	// Create an empty filesystem (no config file)
+	fs := fstest.MapFS{}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: "",
+		},
+		ConfigFS: config.NewConfigFS(fs),
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Organizations: svc,
+			}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+
+	orgs := []*organization{
+		{Name: "foo", Current: false},
+		{Name: "bar", Current: false},
 	}
 	c.Assert(buf.String(), qt.JSONEquals, orgs)
 }

--- a/internal/cmd/org/org.go
+++ b/internal/cmd/org/org.go
@@ -2,6 +2,7 @@ package org
 
 import (
 	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
@@ -26,23 +27,56 @@ type organization struct {
 	Name      string `header:"name" json:"name"`
 	CreatedAt int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
 	UpdatedAt int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+	Current   bool   `header:"current" json:"current"`
 }
 
 // toOrgs returns a slice of printable orgs.
-func toOrgs(organizations []*ps.Organization) []*organization {
+func toOrgs(organizations []*ps.Organization, currentOrgName string, format printer.Format) []*organization {
 	orgs := make([]*organization, 0, len(organizations))
 
 	for _, org := range organizations {
-		orgs = append(orgs, toOrg(org))
+		orgs = append(orgs, toOrg(org, currentOrgName, format))
 	}
 
 	return orgs
 }
 
-func toOrg(org *ps.Organization) *organization {
+func toOrg(org *ps.Organization, currentOrgName string, format printer.Format) *organization {
+	isCurrent := org.Name == currentOrgName
+	name := org.Name
+
+	if isCurrent && format == printer.Human {
+		name = "* " + org.Name
+	}
+
 	return &organization{
-		Name:      org.Name,
+		Name:      name,
 		CreatedAt: printer.GetMilliseconds(org.CreatedAt),
 		UpdatedAt: printer.GetMilliseconds(org.UpdatedAt),
+		Current:   isCurrent,
 	}
+}
+
+func getCurrentOrganization(ch *cmdutil.Helper) string {
+	if ch.Config.Organization != "" {
+		return ch.Config.Organization
+	}
+
+	configPath, err := config.ProjectConfigPath()
+	if err == nil {
+		cfg, err := ch.ConfigFS.NewFileConfig(configPath)
+		if err == nil && cfg.Organization != "" {
+			return cfg.Organization
+		}
+	}
+
+	configPath, err = config.DefaultConfigPath()
+	if err == nil {
+		cfg, err := ch.ConfigFS.NewFileConfig(configPath)
+		if err == nil && cfg.Organization != "" {
+			return cfg.Organization
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
Closes: https://github.com/planetscale/cli/issues/1145

Allows the user to see which org is currently selected by adding `current` to the output.

Human format:
```bash
  NAME (25)               CREATED AT     UPDATED AT     CURRENT
 ----------------------- -------------- -------------- ---------
  * mike                  4 years ago    2 years ago    Yes
  mikes-cool-org          4 years ago    2 years ago    No
```

JSON format:
```json
  {
    "name": "mike",
    "created_at": 1610391461709,
    "updated_at": 1710356459058,
    "current": true
  },
  {
    "name": "mikes-cool-org",
    "created_at": 1612538280956,
    "updated_at": 1690478112026,
    "current": false
  },
```