### PR TITLE
fix: update force flag references from -force to --force

### DIFF
--- a/internal/cmd/backup/delete.go
+++ b/internal/cmd/backup/delete.go
@@ -36,12 +36,12 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot delete backup with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete backup with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				confirmationName := fmt.Sprintf("%s/%s/%s", database, branch, backup)
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm deletion of backup %q (run with -force to override)", confirmationName)
+					return fmt.Errorf("cannot confirm deletion of backup %q (run with --force to override)", confirmationName)
 				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"), printer.BoldBlue(confirmationName), printer.Bold("to confirm:"))

--- a/internal/cmd/branch/delete.go
+++ b/internal/cmd/branch/delete.go
@@ -50,7 +50,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot delete branch with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete branch with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				if db.Kind == "mysql" {
@@ -91,7 +91,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				confirmationName := fmt.Sprintf("%s/%s", source, branch)
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm deletion of branch %q (run with -force to override)", confirmationName)
+					return fmt.Errorf("cannot confirm deletion of branch %q (run with --force to override)", confirmationName)
 				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"),

--- a/internal/cmd/database/delete.go
+++ b/internal/cmd/database/delete.go
@@ -36,11 +36,11 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot delete database with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete database with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm deletion of database %q (run with -force to override)", name)
+					return fmt.Errorf("cannot confirm deletion of database %q (run with --force to override)", name)
 				}
 
 				_, err := client.Databases.Get(ctx, &planetscale.GetDatabaseRequest{

--- a/internal/cmd/password/delete.go
+++ b/internal/cmd/password/delete.go
@@ -102,7 +102,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot delete password with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete password with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				var confirmationName string
@@ -112,7 +112,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 					confirmationName = fmt.Sprintf("%s/%s/%s", database, branch, passwordId)
 				}
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm deletion of password %q (run with -force to override)", confirmationName)
+					return fmt.Errorf("cannot confirm deletion of password %q (run with --force to override)", confirmationName)
 				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"), printer.BoldBlue(confirmationName), printer.Bold("to confirm:"))

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -35,12 +35,12 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !flags.force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot delete password with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot delete password with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				confirmationName := fmt.Sprintf("%s/%s", database, branch)
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm deletion of branch %q (run with -force to override)", confirmationName)
+					return fmt.Errorf("cannot confirm deletion of branch %q (run with --force to override)", confirmationName)
 				}
 
 				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"),

--- a/internal/cmd/workflow/cancel.go
+++ b/internal/cmd/workflow/cancel.go
@@ -40,11 +40,11 @@ marks it as cancelled, allowing you to start a new workflow if needed.`,
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot cancel workflow with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot cancel workflow with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm cancellation (run with -force to override)")
+					return fmt.Errorf("cannot confirm cancellation (run with --force to override)")
 				}
 
 				prompt := &survey.Confirm{

--- a/internal/cmd/workflow/cutover.go
+++ b/internal/cmd/workflow/cutover.go
@@ -39,11 +39,11 @@ func CutoverCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot cutover with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot cutover with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm cutover (run with -force to override)")
+					return fmt.Errorf("cannot confirm cutover (run with --force to override)")
 				}
 
 				workflow, err := client.Workflows.Get(ctx, &ps.GetWorkflowRequest{

--- a/internal/cmd/workflow/switch_traffic.go
+++ b/internal/cmd/workflow/switch_traffic.go
@@ -44,11 +44,11 @@ By default, this command will route all queries for primary, replica, and read-o
 
 			if !force {
 				if ch.Printer.Format() != printer.Human {
-					return fmt.Errorf("cannot switch query traffic with the output format %q (run with -force to override)", ch.Printer.Format())
+					return fmt.Errorf("cannot switch query traffic with the output format %q (run with --force to override)", ch.Printer.Format())
 				}
 
 				if !printer.IsTTY {
-					return fmt.Errorf("cannot confirm switching query traffic (run with -force to override)")
+					return fmt.Errorf("cannot confirm switching query traffic (run with --force to override)")
 				}
 
 				confirmationMessage := "Are you sure you want to enable primary mode for this database?"

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -199,11 +199,11 @@ func (p *Printer) PrintResource(v interface{}) error {
 
 func (p *Printer) ConfirmCommand(confirmationName, commandShortName, confirmFailedName string) error {
 	if p.Format() != Human {
-		return fmt.Errorf("cannot %s with the output format %q (run with -force to override)", commandShortName, p.Format())
+		return fmt.Errorf("cannot %s with the output format %q (run with --force to override)", commandShortName, p.Format())
 	}
 
 	if !IsTTY {
-		return fmt.Errorf("cannot confirm %s %q (run with -force to override)", confirmFailedName, confirmationName)
+		return fmt.Errorf("cannot confirm %s %q (run with --force to override)", confirmFailedName, confirmationName)
 	}
 
 	confirmationMessage := fmt.Sprintf("%s %s %s", Bold("Please type"), BoldBlue(confirmationName), Bold("to confirm:"))


### PR DESCRIPTION
All force flags are defined as long flags (--force), but error messages were incorrectly referencing them with a single dash (-force). This commit updates all error messages across the codebase to use the correct --force format.

Currently:
<img width="478" height="437" alt="Screenshot 2026-01-06 at 14 54 36" src="https://github.com/user-attachments/assets/f6e25aea-1464-4d63-aff5-ed4467086fa0" />
