### PR TITLE
feat(size): Improve cluster list with engine, configuration, and replicas columns

### DIFF
--- a/internal/cmd/size/cluster.go
+++ b/internal/cmd/size/cluster.go
@@ -234,7 +234,7 @@ func formatClusterFields(sku *planetscale.ClusterSKU, rateOverride *int64) (name
 
 // toClusterSKUs converts cluster SKUs to the full format with all columns including engine.
 // PostgreSQL clusters appear twice (highly available and single node).
-// MySQL clusters are always highly available with 3 replicas.
+// MySQL clusters are always highly available with 2 replicas.
 func toClusterSKUs(items []clusterSKUWithEngine, onlyMetal bool) []*ClusterSKU {
 	clusters := make([]*ClusterSKU, 0, len(items)*2)
 
@@ -280,7 +280,7 @@ func toClusterSKUs(items []clusterSKUWithEngine, onlyMetal bool) []*ClusterSKU {
 				})
 			}
 		} else {
-			// MySQL clusters: always highly available with 3 replicas
+			// MySQL clusters: always highly available with 2 replicas
 			name, cpu, memory, storage, price := formatClusterFields(item.sku, nil)
 			clusters = append(clusters, &ClusterSKU{
 				Name:          name,
@@ -290,7 +290,7 @@ func toClusterSKUs(items []clusterSKUWithEngine, onlyMetal bool) []*ClusterSKU {
 				Price:         price,
 				Engine:        engineStr,
 				Configuration: "highly available",
-				Replicas:      "3",
+				Replicas:      "2",
 				orig:          item.sku,
 			})
 		}
@@ -301,7 +301,7 @@ func toClusterSKUs(items []clusterSKUWithEngine, onlyMetal bool) []*ClusterSKU {
 
 // toClusterSKUsSingleEngine converts cluster SKUs to the single-engine format (no engine column).
 // PostgreSQL clusters appear twice (highly available and single node).
-// MySQL clusters are always highly available with 3 replicas.
+// MySQL clusters are always highly available with 2 replicas.
 func toClusterSKUsSingleEngine(items []clusterSKUWithEngine, onlyMetal bool) []*ClusterSKUSingleEngine {
 	clusters := make([]*ClusterSKUSingleEngine, 0, len(items)*2)
 
@@ -340,7 +340,7 @@ func toClusterSKUsSingleEngine(items []clusterSKUWithEngine, onlyMetal bool) []*
 				})
 			}
 		} else {
-			// MySQL clusters: always highly available with 3 replicas
+			// MySQL clusters: always highly available with 2 replicas
 			name, cpu, memory, storage, price := formatClusterFields(item.sku, nil)
 			clusters = append(clusters, &ClusterSKUSingleEngine{
 				Name:          name,
@@ -349,7 +349,7 @@ func toClusterSKUsSingleEngine(items []clusterSKUWithEngine, onlyMetal bool) []*
 				Storage:       storage,
 				Price:         price,
 				Configuration: "highly available",
-				Replicas:      "3",
+				Replicas:      "2",
 				orig:          item.sku,
 			})
 		}

--- a/internal/cmd/size/cluster_test.go
+++ b/internal/cmd/size/cluster_test.go
@@ -367,10 +367,10 @@ func TestToClusterSKUsSingleEngine_MySQL(t *testing.T) {
 
 	clusters := toClusterSKUsSingleEngine(items, false)
 
-	// MySQL should have 1 entry: always highly available with 3 replicas
+	// MySQL should have 1 entry: always highly available with 2 replicas
 	c.Assert(len(clusters), qt.Equals, 1)
 	c.Assert(clusters[0].Configuration, qt.Equals, "highly available")
-	c.Assert(clusters[0].Replicas, qt.Equals, "3")
+	c.Assert(clusters[0].Replicas, qt.Equals, "2")
 	c.Assert(clusters[0].Price, qt.Equals, "$39")
 }
 
@@ -443,12 +443,12 @@ func TestMySQLClustersHaveCorrectReplicas(t *testing.T) {
 	clusters := toClusterSKUs(items, false)
 	c.Assert(len(clusters), qt.Equals, 1)
 	c.Assert(clusters[0].Configuration, qt.Equals, "highly available")
-	c.Assert(clusters[0].Replicas, qt.Equals, "3")
+	c.Assert(clusters[0].Replicas, qt.Equals, "2")
 	c.Assert(clusters[0].Engine, qt.Equals, "mysql")
 
 	// Test with single engine format
 	clustersSingle := toClusterSKUsSingleEngine(items, false)
 	c.Assert(len(clustersSingle), qt.Equals, 1)
 	c.Assert(clustersSingle[0].Configuration, qt.Equals, "highly available")
-	c.Assert(clustersSingle[0].Replicas, qt.Equals, "3")
+	c.Assert(clustersSingle[0].Replicas, qt.Equals, "2")
 }


### PR DESCRIPTION
## Summary

Enhances `pscale size cluster list` to provide better discoverability for PostgreSQL cluster configurations, particularly making it clear how to create single-node vs highly-available databases.

Watch: https://www.loom.com/share/8ad213e275af4199a80963e48d6cfca4

## What to review

The single-node pricing I've copied from `app-bb` which takes the price of a cluster size and divides it by 3 ... this seems odd to me as I'd expect the pricing to be verified from the API? I don't like that it's now calculated on the fly in more than one place. Maybe beyond the scope of this...

## Changes

**Default behavior changed:** Now shows all engines (MySQL + PostgreSQL) by default instead of MySQL only. Use `--engine mysql` or `--engine postgresql` to filter.

**Adaptive column display** based on context:

| Filter | Columns |
|--------|---------|
| None (all engines) | name, cost, cpu, memory, storage, **engine**, **configuration**, **replicas** |
| `--engine mysql` | name, cost, cpu, memory, storage |
| `--engine postgresql` | name, cost, cpu, memory, storage, **configuration**, **replicas** |

**PostgreSQL-specific features:**
- Each cluster size appears twice: "highly available" (replicas=2) and "single node" (replicas=0)
- Single node pricing is 1/3 of the HA price
- Metal clusters only show HA option (single node not available)
- The `replicas` column maps directly to the `--replicas` flag on `database create`

## Why

An AI or user looking at cluster sizes couldn't previously determine how to create a single-node PostgreSQL database. The configuration showed "single node" vs "highly available", but the actual mechanism (`--replicas 0` vs `--replicas 2`) wasn't discoverable from the output. The new `replicas` column makes this mapping explicit.

## Example Output

without filter

```
NAME (177)                          COST     CPU          MEMORY   STORAGE     ENGINE       CONFIGURATION      REPLICAS  
----------------------------------- -------- ------------ -------- ----------- ------------ ------------------ ---------- 
PS-10                               $39      1/8 vCPUs    1 GB     ∞           mysql                                     
PS-20                               $59      1/4 vCPUs    2 GB     ∞           mysql                                     
PS-40                               $99      1/2 vCPUs    4 GB     ∞           mysql                                     
...
PS-5-AWS-X86                        $15      1/16 vCPUs   512 MB   ∞           postgresql   highly available   2         
PS-5-AWS-X86                        $5       1/16 vCPUs   512 MB   ∞           postgresql   single node        0         
PS-10-AWS-ARM                       $30      1/8 vCPUs    1 GB     ∞           postgresql   highly available   2         
PS-10-AWS-ARM                       $10      1/8 vCPUs    1 GB     ∞           postgresql   single node        0         
```

with `--engine mysql`

```
NAME (45)               COST     CPU         MEMORY   STORAGE   
----------------------- -------- ----------- -------- ---------- 
PS-10                   $39      1/8 vCPUs   1 GB     ∞         
PS-20                   $59      1/4 vCPUs   2 GB     ∞         
PS-40                   $99      1/2 vCPUs   4 GB     ∞         
PS-80                   $179     1 vCPUs     8 GB     ∞         
PS-160                  $349     2 vCPUs     16 GB    ∞         
```

with `--engine postgresql`

```
NAME (132)                          COST     CPU          MEMORY   STORAGE     CONFIGURATION      REPLICAS  
----------------------------------- -------- ------------ -------- ----------- ------------------ ---------- 
PS-5-AWS-X86                        $15      1/16 vCPUs   512 MB   ∞           highly available   2         
PS-5-AWS-X86                        $5       1/16 vCPUs   512 MB   ∞           single node        0         
PS-10-AWS-ARM                       $30      1/8 vCPUs    1 GB     ∞           highly available   2         
PS-10-AWS-ARM                       $10      1/8 vCPUs    1 GB     ∞           single node        0         
PS-20-AWS-X86                       $59      1/4 vCPUs    2 GB     ∞           highly available   2         
PS-20-AWS-X86                       $20      1/4 vCPUs    2 GB     ∞           single node        0         
```