### PR TITLE
Default to PS-DEV for new, empty branches

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -93,13 +93,22 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
+			clusterSize := flags.clusterSize
+			if clusterSize == "" {
+				if flags.backupID != "" || flags.dataBranching {
+					clusterSize = "PS-10"
+				} else {
+					clusterSize = "PS_DEV"
+				}
+			}
+
 			if db.Kind == "mysql" {
 				createReq := &ps.CreateDatabaseBranchRequest{
 					Organization: ch.Config.Organization,
 					Database:     source,
 					Name:         branch,
 					Region:       flags.region,
-					ClusterSize:  flags.clusterSize,
+					ClusterSize:  clusterSize,
 					ParentBranch: flags.parentBranch,
 					BackupID:     flags.backupID,
 				}
@@ -156,7 +165,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 					Database:     source,
 					Name:         branch,
 					Region:       flags.region,
-					ClusterName:  flags.clusterSize,
+					ClusterName:  clusterSize,
 					ParentBranch: flags.parentBranch,
 					BackupID:     flags.backupID,
 					MajorVersion: flags.majorVersion,
@@ -211,7 +220,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
 	cmd.Flags().StringVar(&flags.region, "region", "", "Region for the branch to be created in.")
 	cmd.Flags().StringVar(&flags.backupID, "restore", "", "ID of Backup to restore into branch.")
-	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "PS-10", "Cluster size for branches being created from a backup or seeded with data. Use 'pscale size cluster list' to see the valid sizes.")
+	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "", "Cluster size for the branch. Defaults to PS_DEV for regular branches, or PS-10 for branches created from a backup or with seed-data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
 	cmd.Flags().StringVar(&flags.majorVersion, "major-version", "", "For PostgreSQL databases, the PostgreSQL major version to use for the branch. Defaults to the major version of the parent branch if it exists or the database's default branch major version. Ignored for branches restored from backups.")

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -34,6 +34,7 @@ func TestBranch_CreateCmd(t *testing.T) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Region, qt.Equals, "us-east")
 			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.ClusterSize, qt.Equals, "PS_DEV")
 
 			return res, nil
 		},
@@ -204,6 +205,7 @@ func TestBranch_CreateCmdWithSeedData(t *testing.T) {
 			c.Assert(req.Region, qt.Equals, "us-east")
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.SeedData, qt.Equals, "last_successful_backup")
+			c.Assert(req.ClusterSize, qt.Equals, "PS-10")
 
 			return res, nil
 		},
@@ -260,6 +262,7 @@ func TestBranch_CreateCmdWithMajorVersion(t *testing.T) {
 			c.Assert(req.Region, qt.Equals, "us-east")
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.MajorVersion, qt.Equals, "17")
+			c.Assert(req.ClusterName, qt.Equals, "PS_DEV")
 
 			return res, nil
 		},


### PR DESCRIPTION
We're updating the branch creation API to allow specifying the cluster size for new, fresh branches that are not restored from a backup or with seed data. Previously, those branches would always be created as a `PS-DEV` despite the CLI passing a `PS-10` for the cluster size.

To preserve that behavior and allow setting the cluster size, the API will continue to default to `PS-DEV` if `PS-10` is set by older versions of the CLI. New versions of the CLI will not have that behavior, so we need to explicitly send the cluster size we expect (`PS-DEV`).