### PR TITLE
fix: improve error message when role command returns 404

### DIFF
--- a/internal/cmd/role/create.go
+++ b/internal/cmd/role/create.go
@@ -54,7 +54,10 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("database %s or branch %s does not exist in organization %s",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						cmd.Context(), cmd, ch.Config, ch.Client, err,
+						"create_branch_password or create_production_branch_password",
+						"database %s or branch %s does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/delete.go
+++ b/internal/cmd/role/delete.go
@@ -83,7 +83,10 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("role %s does not exist in branch %s of database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"delete_branch_password or delete_production_branch_password",
+						"role %s does not exist in branch %s of database %s (organization: %s)",
 						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/get.go
+++ b/internal/cmd/role/get.go
@@ -38,7 +38,10 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("role %s does not exist in branch %s of database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"read_branch",
+						"role %s does not exist in branch %s of database %s (organization: %s)",
 						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/list.go
+++ b/internal/cmd/role/list.go
@@ -60,7 +60,10 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 				if err != nil {
 					switch cmdutil.ErrCode(err) {
 					case ps.ErrNotFound:
-						return fmt.Errorf("database %s or branch %s does not exist in organization %s",
+						return cmdutil.HandleNotFoundWithServiceTokenCheck(
+							ctx, cmd, ch.Config, ch.Client, err,
+							"read_branch",
+							"database %s or branch %s does not exist in organization %s",
 							printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
 					default:
 						return cmdutil.HandleError(err)

--- a/internal/cmd/role/reassign.go
+++ b/internal/cmd/role/reassign.go
@@ -86,7 +86,10 @@ func ReassignCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("role %s does not exist in branch %s of database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"delete_branch_password or delete_production_branch_password",
+						"role %s does not exist in branch %s of database %s (organization: %s)",
 						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/renew.go
+++ b/internal/cmd/role/renew.go
@@ -39,7 +39,10 @@ func RenewCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("role %s does not exist in branch %s of database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"create_branch_password or create_production_branch_password",
+						"role %s does not exist in branch %s of database %s (organization: %s)",
 						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/reset.go
+++ b/internal/cmd/role/reset.go
@@ -80,7 +80,10 @@ func ResetCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("role %s does not exist in branch %s of database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"delete_branch_password or delete_production_branch_password",
+						"role %s does not exist in branch %s of database %s (organization: %s)",
 						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -78,7 +78,10 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("database %s or branch %s does not exist in organization %s",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						cmd.Context(), cmd, ch.Config, ch.Client, err,
+						"delete_branch_password or delete_production_branch_password",
+						"database %s or branch %s does not exist in organization %s",
 						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/role/update.go
+++ b/internal/cmd/role/update.go
@@ -47,7 +47,10 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
-					return fmt.Errorf("role %s does not exist in branch %s of database %s (organization: %s)",
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"create_branch_password or create_production_branch_password",
+						"role %s does not exist in branch %s of database %s (organization: %s)",
 						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)


### PR DESCRIPTION
## Changes
- `role create` - updated error message
- `role list` - updated error message  
- `role reset-default` - updated error message

## Before
```
pscale role create typo-database main app
Error: branch main does not exist in database typo-database (organization: my-org)
```

## After
```
pscale role create typo-database main app
Error: database typo-database or branch main does not exist in organization my-org
```

## Question:
This follows the pattern used in `keyspace/create.go` and `keyspace/list.go`. 

An alternative approach would be to first check if the database exists (like `branch/show.go` does), which would allow more precise error messages. However, that adds an extra API call on the error path. Happy to implement that approach if preferred.