### PR TITLE
Add connection URL output when creating or resetting Postgres roles

### DIFF
--- a/internal/cmd/role/create.go
+++ b/internal/cmd/role/create.go
@@ -66,6 +66,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again")
 				ch.Printer.Printf("Role %s was successfully created in %s/%s.\n%s\n\n",
 					printer.BoldBlue(role.Name), printer.BoldBlue(database), printer.BoldBlue(branch), saveWarning)
+				printPostgresRoleCredentials(ch.Printer, toPostgresRole(role))
+				return nil
 			}
 
 			return ch.Printer.PrintResource(toPostgresRole(role))

--- a/internal/cmd/role/reset.go
+++ b/internal/cmd/role/reset.go
@@ -90,8 +90,10 @@ func ResetCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("Password for role %s was successfully reset in %s/%s.\n",
+				ch.Printer.Printf("Password for role %s was successfully reset in %s/%s.\n\n",
 					printer.BoldBlue(roleID), printer.BoldBlue(database), printer.BoldBlue(branch))
+				printPostgresRoleCredentials(ch.Printer, toPostgresRole(role))
+				return nil
 			}
 
 			return ch.Printer.PrintResource(toPostgresRole(role))

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -3,6 +3,8 @@ package role
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -90,7 +92,9 @@ func ResetDefaultCmd(ch *cmdutil.Helper) *cobra.Command {
 			if ch.Printer.Format() == printer.Human {
 				saveWarning := printer.BoldRed("Please save the values below as they will not be shown again. We recommend using these credentials only for creating usernames and passwords for accessing your database.")
 
-				ch.Printer.Printf("Role was successfully reset for %s in %s.\n%s\n\n", printer.BoldBlue(branch), printer.BoldBlue(database), saveWarning)
+				ch.Printer.Printf("Role was successfully reset in %s/%s.\n%s\n\n", printer.BoldBlue(database), printer.BoldBlue(branch), saveWarning)
+				printPostgresRoleCredentials(ch.Printer, toPostgresRole(role))
+				return nil
 			}
 
 			return ch.Printer.PrintResource(toPostgresRole(role))
@@ -108,6 +112,7 @@ type PostgresRole struct {
 	Username      string `header:"username" json:"username"`
 	Password      string `header:"password" json:"password"`
 	AccessHostURL string `header:"access_host_url" json:"access_host_url"`
+	DatabaseURL   string `header:"database_url" json:"database_url"`
 
 	orig *ps.PostgresRole
 }
@@ -119,6 +124,34 @@ func toPostgresRole(role *ps.PostgresRole) *PostgresRole {
 		Username:      role.Username,
 		Password:      role.Password,
 		AccessHostURL: role.AccessHostURL,
+		DatabaseURL:   buildPostgresConnectionURL(role.Username, role.Password, role.AccessHostURL),
 		orig:          role,
 	}
+}
+
+// printPostgresRoleCredentials prints role credentials in a vertical layout.
+func printPostgresRoleCredentials(p *printer.Printer, role *PostgresRole) {
+	p.Printf("%-17s  %s\n", "ID", role.PublicID)
+	p.Printf("%-17s  %s\n", "NAME", role.Name)
+	p.Printf("%-17s  %s\n", "USERNAME", role.Username)
+	p.Printf("%-17s  %s\n", "PASSWORD", role.Password)
+	p.Printf("%-17s  %s\n", "ACCESS HOST URL", role.AccessHostURL)
+	p.Printf("%-17s  %s\n", "DATABASE URL", role.DatabaseURL)
+}
+
+// buildPostgresConnectionURL constructs a PostgreSQL connection URL from role credentials.
+func buildPostgresConnectionURL(username, password, accessHostURL string) string {
+	host, port, err := net.SplitHostPort(accessHostURL)
+	if err != nil {
+		// If no port specified, use the host as-is and default to 5432
+		host = accessHostURL
+		port = "5432"
+	}
+
+	return fmt.Sprintf("postgresql://%s:%s@%s:%s/postgres?sslmode=verify-full",
+		url.PathEscape(username),
+		url.PathEscape(password),
+		host,
+		port,
+	)
 }

--- a/internal/cmd/role/reset_default_test.go
+++ b/internal/cmd/role/reset_default_test.go
@@ -68,6 +68,7 @@ func TestResetDefaultCmd(t *testing.T) {
 		"username":        "postgres",
 		"password":        "new-password-123",
 		"access_host_url": "pg.psdb.cloud",
+		"database_url":    "postgresql://postgres:new-password-123@pg.psdb.cloud:5432/postgres?sslmode=verify-full",
 	}
 	c.Assert(buf.String(), qt.JSONEquals, expectedOutput)
 }


### PR DESCRIPTION
## Summary

- Display credentials in a vertical layout when creating a role or resetting a role's password
- Add `DATABASE URL` field with a ready-to-use PostgreSQL connection string
- Makes it easier for users to copy credentials without having to construct the URL manually

## Changes

Updates three commands:
- `pscale role create`
- `pscale role reset`
- `pscale role reset-default`

## Example Output

```
Role my-role was successfully created in mydb/main.
Please save the values below as they will not be shown again

ID                 role-abc123
NAME               my-role
USERNAME           my-role_abc123
PASSWORD           secretpass123
ACCESS HOST URL    pg.psdb.cloud
DATABASE URL       postgresql://my-role_abc123:secretpass123@pg.psdb.cloud:5432/postgres?sslmode=verify-full
```

## Notes

- JSON/CSV output includes the new `database_url` field
- Uses `sslmode=verify-full` for maximum security
- URL-encodes username and password to handle special characters
- Defaults to port 5432 if not specified in the access host URL