### PR TITLE
Import commands deprecation

### DIFF
--- a/internal/cmd/dataimports/dataimports.go
+++ b/internal/cmd/dataimports/dataimports.go
@@ -11,6 +11,7 @@ func DataImportsCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:               "data-imports <command>",
 		Short:             "Create, list, and delete branch data imports",
 		Long:              "Create, list, and delete branch data imports.\n\nThis command is only supported for Vitess databases.",
+		Deprecated:        "Vitess workflows are now available in the PlanetScale dashboard. See https://planetscale.com/docs/vitess/imports/database-imports for more information.",
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
 


### PR DESCRIPTION
Mark the `data-imports` command as deprecated to guide users towards Vitess workflows for imports.

---
[Slack Thread](https://planetscale.slack.com/archives/C01FU073PLK/p1768330417422689?thread_ts=1768330417.422689&cid=C01FU073PLK)

<a href="https://cursor.com/background-agent?bcId=bc-8d0d38b2-f0f8-48ed-a91d-38bbabdea62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d0d38b2-f0f8-48ed-a91d-38bbabdea62a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

