### PR TITLE
feat(dump): support dumping only specified columns

### DIFF
--- a/internal/cmd/database/dump_test.go
+++ b/internal/cmd/database/dump_test.go
@@ -1,0 +1,102 @@
+package database
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestParseColumnIncludes(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		columns     []string
+		want        map[string]map[string]bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "single table single column",
+			columns: []string{"users:id"},
+			want: map[string]map[string]bool{
+				"users": {"id": true},
+			},
+		},
+		{
+			name:    "single table multiple columns",
+			columns: []string{"users:id,name,email"},
+			want: map[string]map[string]bool{
+				"users": {"id": true, "name": true, "email": true},
+			},
+		},
+		{
+			name:    "multiple tables",
+			columns: []string{"users:id,name", "orders:id,total"},
+			want: map[string]map[string]bool{
+				"users":  {"id": true, "name": true},
+				"orders": {"id": true, "total": true},
+			},
+		},
+		{
+			name:    "columns with whitespace",
+			columns: []string{"users: id , name , email "},
+			want: map[string]map[string]bool{
+				"users": {"id": true, "name": true, "email": true},
+			},
+		},
+		{
+			name:    "same table specified multiple times merges columns",
+			columns: []string{"users:id", "users:name,email"},
+			want: map[string]map[string]bool{
+				"users": {"id": true, "name": true, "email": true},
+			},
+		},
+		{
+			name:    "empty input",
+			columns: []string{},
+			want:    map[string]map[string]bool{},
+		},
+		{
+			name:        "missing colon",
+			columns:     []string{"users-id,name"},
+			wantErr:     true,
+			errContains: "expected 'table:col1,col2' format",
+		},
+		{
+			name:        "empty table name",
+			columns:     []string{":id,name"},
+			wantErr:     true,
+			errContains: "table name cannot be empty",
+		},
+		{
+			name:        "empty column list",
+			columns:     []string{"users:"},
+			wantErr:     true,
+			errContains: "at least one column must be specified",
+		},
+		{
+			name:        "only whitespace columns",
+			columns:     []string{"users: , , "},
+			wantErr:     true,
+			errContains: "at least one column must be specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseColumnIncludes(tt.columns)
+
+			if tt.wantErr {
+				c.Assert(err, qt.IsNotNil)
+				if tt.errContains != "" {
+					c.Assert(err.Error(), qt.Contains, tt.errContains)
+				}
+				return
+			}
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new `--columns` flag to `pscale database dump` that allows specifying which columns to include when dumping specific tables                                
- Supports multiple tables with format: `--columns 'users:id,name' --columns 'orders:id,total'`
- The schema dump will include the complete schema. 

Resolves https://github.com/planetscale/cli/issues/891

## Testing

Added unit tests, but also manual verification against a live database.

```bash
$ go run cmd/pscale/main.go \
  database dump hp-msql-ps-10 main --columns "users:email" --columns "products:sku"

tarting to dump all tables from database hp-msql-ps-10 to folder /Users/hirad/code/planetscale/cli/pscale_dump_hp-msql-ps-10_main_20260120_193324
Dumping is finished! (elapsed time: 726.003583ms)

$ cat pscale_dump_hp-msql-ps-10_main_20260120_193324/hp-msql-ps-10.users.00001.sql
INSERT INTO `users`(`email`) VALUES
("bar@baz.test"),
("beta@gamma.test"),
("green@blue.test"),
("banana@cherry.test"),
("moon@star.test"),
("dog@bird.test"),
("south@east.test"),
("paper@scissors.test"),
("pong@ball.test"),
("world@test.test");

$ cat pscale_dump_hp-msql-ps-10_main_20260120_193324/hp-msql-ps-10.products.00001.sql
INSERT INTO `products`(`sku`) VALUES
("abc-123"),
("def-456"),
("ghi-789"),
("jkl-012"),
("mno-345"),
("pqr-678"),
("stu-901"),
("vwx-234"),
("yza-567"),
("bcd-890");
```