### PR TITLE
Add a 14 day dependency cooldown to the Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
As a mitigation against supply-chain attacks, we're adopting a 14 day cooldown on dependency updates. This covers a lot of the supply chain attacks via compromised dependencies that have been seen in the wild so far, where the compromised version is only available for less than a day.

This isn't perfect, or the whole story, but it's a good next step for us to take.

## Related Issue(s)

https://github.com/planetscale/renovate-config/pull/91

## Security Impact

Reduce risk of supply-chain attacks.