### PR TITLE
Publish multi-arch Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,12 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Configure Git
         run: |
           git config user.name "planetscale-cli[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
       - name: Configure Git
         run: |
           git config user.name "planetscale-cli[bot]"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,16 +58,40 @@ builds:
     binary: "pscale"   
 dockers:
   - image_templates:
-    - "planetscale/pscale:latest"
-    - "planetscale/pscale:{{ .Tag }}"
+    - "planetscale/pscale:{{ .Tag }}-amd64"
+    use: buildx
+    goarch: amd64
     build_flag_templates:
     - "--pull"
+    - "--platform=linux/amd64"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--label=org.opencontainers.image.source={{.GitURL}}"
     dockerfile: Dockerfile.goreleaser
+  - image_templates:
+    - "planetscale/pscale:{{ .Tag }}-arm64"
+    use: buildx
+    goarch: arm64
+    build_flag_templates:
+    - "--pull"
+    - "--platform=linux/arm64"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    - "--label=org.opencontainers.image.source={{.GitURL}}"
+    dockerfile: Dockerfile.goreleaser
+docker_manifests:
+  - name_template: "planetscale/pscale:{{ .Tag }}"
+    image_templates:
+      - "planetscale/pscale:{{ .Tag }}-amd64"
+      - "planetscale/pscale:{{ .Tag }}-arm64"
+  - name_template: "planetscale/pscale:latest"
+    image_templates:
+      - "planetscale/pscale:{{ .Tag }}-amd64"
+      - "planetscale/pscale:{{ .Tag }}-arm64"
 aurs:
   -
     name: pscale-cli-bin

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -6,6 +6,7 @@ RUN apt-get update --allow-releaseinfo-change || apt-get update; apt-get install
 ARG SYFT_VERSION=1.38.0
 RUN wget -O syft.deb https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.deb && dpkg -i syft.deb
 
+RUN mv /entrypoint.sh /base-entrypoint.sh
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -5,3 +5,7 @@ RUN apt-get update --allow-releaseinfo-change || apt-get update; apt-get install
 
 ARG SYFT_VERSION=1.38.0
 RUN wget -O syft.deb https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.deb && dpkg -i syft.deb
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+docker buildx inspect goreleaser >/dev/null 2>&1 \
+  || docker buildx create --name goreleaser --driver docker-container --use
+docker buildx use goreleaser
+
+exec goreleaser "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,4 +5,4 @@ docker buildx inspect goreleaser >/dev/null 2>&1 \
   || docker buildx create --name goreleaser --driver docker-container --use
 docker buildx use goreleaser
 
-exec goreleaser "$@"
+exec /base-entrypoint.sh "$@"


### PR DESCRIPTION
## Summary

- Extends the goreleaser `dockers` block into two arch-specific builds (amd64 + arm64) and combines them with a `docker_manifests` block so `planetscale/pscale:latest` and `planetscale/pscale:{{ .Tag }}` become multi-arch manifests.
- Adds `docker/setup-qemu-action` + `docker/setup-buildx-action` to the release workflow so the host has QEMU emulators and a buildx builder registered before goreleaser invokes `docker buildx` over the mounted socket.

## Why

The image has been amd64-only since it was first published, which forces arm64 users (Apple Silicon laptops, Graviton hosts, arm64 CI runners) to run it under emulation — slow, and it breaks entirely in environments that block cross-arch execution. The linux/arm64 binary has been produced by goreleaser for a while, so the binary is essentially free; only the Docker publish path was missing.

`Dockerfile.goreleaser` is already arch-neutral (just `COPY`s the binary into `ubuntu:noble`, which has both amd64 and arm64 images), so no Dockerfile changes were needed.

Fixes #1252