### PR TITLE
Add tenant-id to movetables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.162.0
+	github.com/planetscale/planetscale-go v0.163.0
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.162.0 h1:uOpqOeIikRXu+5AxwUBitvImhPtRca6Kfmt6ahmXzDs=
-github.com/planetscale/planetscale-go v0.162.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.163.0 h1:LsMWsnrDUncbstRBMdYLCTyu5nQzNyQc60ytXaHuezQ=
+github.com/planetscale/planetscale-go v0.163.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/vtctld/move_tables.go
+++ b/internal/cmd/branch/vtctld/move_tables.go
@@ -49,6 +49,7 @@ func MoveTablesCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		onDDL                        string
 		shardedAutoIncrementHandling string
 		sourceTimeZone               string
+		tenantID                     string
 		cells                        []string
 		tabletTypes                  []string
 		excludeTables                []string
@@ -84,6 +85,7 @@ func MoveTablesCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				OnDDL:                        flags.onDDL,
 				ShardedAutoIncrementHandling: flags.shardedAutoIncrementHandling,
 				SourceTimeZone:               flags.sourceTimeZone,
+				TenantID:                     flags.tenantID,
 				Cells:                        flags.cells,
 				TabletTypes:                  flags.tabletTypes,
 				ExcludeTables:                flags.excludeTables,
@@ -131,6 +133,7 @@ func MoveTablesCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.onDDL, "on-ddl", "", "DDL handling strategy (IGNORE, STOP, EXEC, EXEC_IGNORE)")
 	cmd.Flags().StringVar(&flags.shardedAutoIncrementHandling, "sharded-auto-increment-handling", "", "Auto increment handling for sharded keyspaces")
 	cmd.Flags().StringVar(&flags.sourceTimeZone, "source-time-zone", "", "Source time zone")
+	cmd.Flags().StringVar(&flags.tenantID, "tenant-id", "", "Tenant ID")
 	cmd.Flags().StringSliceVar(&flags.cells, "cells", nil, "Cells to restrict the workflow to (comma-separated)")
 	cmd.Flags().StringSliceVar(&flags.tabletTypes, "tablet-types", nil, "Tablet types to use for the workflow (comma-separated)")
 	cmd.Flags().StringSliceVar(&flags.excludeTables, "exclude-tables", nil, "Tables to exclude from the move (comma-separated)")

--- a/internal/cmd/branch/vtctld/move_tables_test.go
+++ b/internal/cmd/branch/vtctld/move_tables_test.go
@@ -82,6 +82,7 @@ func TestMoveTablesCreate(t *testing.T) {
 			c.Assert(req.Cells, qt.IsNil)
 			c.Assert(req.TabletTypes, qt.IsNil)
 			c.Assert(req.ExcludeTables, qt.IsNil)
+			c.Assert(req.TenantID, qt.Equals, "")
 			c.Assert(req.AtomicCopy, qt.IsNil)
 			return &ps.VtctldOperationReference{ID: "create-op"}, nil
 		},
@@ -181,6 +182,7 @@ func TestMoveTablesCreateWithAllFlags(t *testing.T) {
 			c.Assert(req.Cells, qt.DeepEquals, []string{"us-east-1", "us-west-2"})
 			c.Assert(req.TabletTypes, qt.DeepEquals, []string{"PRIMARY", "REPLICA"})
 			c.Assert(req.ExcludeTables, qt.DeepEquals, []string{"t1", "t2"})
+			c.Assert(req.TenantID, qt.Equals, "tenant-123")
 			c.Assert(req.AtomicCopy, qt.IsNotNil)
 			c.Assert(*req.AtomicCopy, qt.IsTrue)
 			c.Assert(req.AllTables, qt.IsNotNil)
@@ -212,6 +214,7 @@ func TestMoveTablesCreateWithAllFlags(t *testing.T) {
 		"--cells", "us-east-1,us-west-2",
 		"--tablet-types", "PRIMARY,REPLICA",
 		"--exclude-tables", "t1,t2",
+		"--tenant-id", "tenant-123",
 		"--atomic-copy",
 	})
 	err := cmd.Execute()


### PR DESCRIPTION
Adding `--tenant-id` to movetables.

https://vitess.io/docs/archive/22.0/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_create/