### PR TITLE
Add hex-blob support for database dumps and implement hex encoding for BLOB columns

### DIFF
--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -39,6 +39,7 @@ type dumpFlags struct {
 	threads      int
 	schemaOnly   bool
 	outputFormat string
+	hexBlob      bool
 }
 
 // DumpCmd encapsulates the commands for dumping a database
@@ -73,7 +74,7 @@ func DumpCmd(ch *cmdutil.Helper) *cobra.Command {
 		"Output format for data: sql (for MySQL, default), json, or csv.")
 	cmd.PersistentFlags().StringArrayVar(&f.columns, "columns", nil,
 		"Columns to include for specific tables (format: 'table:col1,col2'). Can be specified multiple times for different tables.")
-
+	cmd.PersistentFlags().BoolVar(&f.hexBlob, "hex-blob", false, "Hex-encodes binary columns in SQL dumps")
 	return cmd
 }
 
@@ -251,6 +252,7 @@ func dump(ch *cmdutil.Helper, cmd *cobra.Command, flags *dumpFlags, args []strin
 	cfg.Outdir = dir
 	cfg.SchemaOnly = flags.schemaOnly
 	cfg.OutputFormat = flags.outputFormat
+	cfg.HexBlob = flags.hexBlob
 
 	if flags.shard != "" {
 		if flags.replica {

--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -56,7 +56,7 @@ type Config struct {
 	Selects                   map[string]map[string]string
 	Filters                   map[string]map[string]string
 	ColumnIncludes            map[string]map[string]bool
-
+	HexBlob                   bool
 	// Interval in millisecond.
 	IntervalMs int
 	Debug      bool
@@ -286,6 +286,11 @@ func (d *Dumper) dumpTable(ctx context.Context, conn *Connection, database strin
 	dumpCtx, err := d.tableDumpContext(conn, table)
 	if err != nil {
 		return err
+	}
+
+	// Wrap with hex-blob encoder if enabled
+	if d.cfg.HexBlob {
+		writer = NewHexBlobWrapper(writer, dumpCtx.fieldNames)
 	}
 
 	if err := writer.Initialize(dumpCtx.fieldNames); err != nil {

--- a/internal/dumper/hex_dumper.go
+++ b/internal/dumper/hex_dumper.go
@@ -1,0 +1,78 @@
+package dumper
+
+import (
+	"encoding/hex"
+
+	querypb "github.com/xelabs/go-mysqlstack/sqlparser/depends/query"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+// hexBlobWrapper wraps a TableWriter and hex-encodes BLOB columns
+type hexBlobWrapper struct {
+	underlying TableWriter
+	fieldNames []string
+}
+
+// NewHexBlobWrapper creates a wrapper that hex-encodes BLOB columns for the underlying writer
+func NewHexBlobWrapper(underlying TableWriter, fieldNames []string) *hexBlobWrapper {
+	return &hexBlobWrapper{
+		underlying: underlying,
+		fieldNames: fieldNames,
+	}
+}
+
+// Initialize passes through to the underlying writer
+func (w *hexBlobWrapper) Initialize(fieldNames []string) error {
+	w.fieldNames = fieldNames
+	return w.underlying.Initialize(fieldNames)
+}
+
+// WriteRow hex-encodes BLOB values before passing to the underlying writer
+func (w *hexBlobWrapper) WriteRow(row []sqltypes.Value) (int, error) {
+	hexRow := make([]sqltypes.Value, len(row))
+	for i, v := range row {
+		if w.shouldHexEncode(v) {
+			hexRow[i] = sqltypes.NewVarBinary(string(w.encodeToHex(v.Raw())))
+		} else {
+			hexRow[i] = v
+		}
+	}
+
+	return w.underlying.WriteRow(hexRow)
+}
+
+// shouldHexEncode determines if a value should be hex-encoded (BLOB/BINARY types)
+func (w *hexBlobWrapper) shouldHexEncode(v sqltypes.Value) bool {
+	if v.Raw() == nil {
+		return false
+	}
+
+	vType := v.Type()
+	switch vType {
+	case querypb.Type_BLOB,
+		querypb.Type_BINARY,
+		querypb.Type_VARBINARY:
+		return true
+	}
+
+	return false
+}
+
+// encodeToHex converts raw bytes to hex with 0x prefix (MySQL format)
+func (w *hexBlobWrapper) encodeToHex(raw []byte) []byte {
+	encoded := hex.EncodeToString(raw)
+	// Prefix with 0x for MySQL compatibility
+	return append([]byte("0x"), []byte(encoded)...)
+}
+
+func (w *hexBlobWrapper) ShouldFlush() bool {
+	return w.underlying.ShouldFlush()
+}
+
+func (w *hexBlobWrapper) Flush(outdir, database, table string, fileNo int) error {
+	return w.underlying.Flush(outdir, database, table, fileNo)
+}
+
+func (w *hexBlobWrapper) Close(outdir, database, table string, fileNo int) error {
+	return w.underlying.Close(outdir, database, table, fileNo)
+}

--- a/internal/dumper/hex_dumper.go
+++ b/internal/dumper/hex_dumper.go
@@ -60,6 +60,10 @@ func (w *hexBlobWrapper) shouldHexEncode(v sqltypes.Value) bool {
 
 // encodeToHex converts raw bytes to hex with 0x prefix (MySQL format)
 func (w *hexBlobWrapper) encodeToHex(raw []byte) []byte {
+	if len(raw) == 0 {
+		return []byte("X''")
+	}
+
 	encoded := hex.EncodeToString(raw)
 	// Prefix with 0x for MySQL compatibility
 	return append([]byte("0x"), []byte(encoded)...)

--- a/internal/dumper/hex_dumper_test.go
+++ b/internal/dumper/hex_dumper_test.go
@@ -1,0 +1,202 @@
+package dumper
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	querypb "github.com/xelabs/go-mysqlstack/sqlparser/depends/query"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+type mockTableWriter struct {
+	initialized bool
+	rows        [][]sqltypes.Value
+	fieldNames  []string
+}
+
+func (m *mockTableWriter) Initialize(fieldNames []string) error {
+	m.fieldNames = fieldNames
+	m.initialized = true
+	return nil
+}
+
+func (m *mockTableWriter) WriteRow(row []sqltypes.Value) (int, error) {
+	m.rows = append(m.rows, row)
+	return len(row), nil
+}
+
+func (m *mockTableWriter) ShouldFlush() bool {
+	return false
+}
+
+func (m *mockTableWriter) Flush(outdir, database, table string, fileNo int) error {
+	return nil
+}
+
+func (m *mockTableWriter) Close(outdir, database, table string, fileNo int) error {
+	return nil
+}
+
+func TestHexBlobWrapperWriteRowBLOB(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("123")),
+		sqltypes.MakeTrusted(querypb.Type_BLOB, []byte("hello")),
+	}
+
+	_, err := wrapper.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+	c.Assert(len(mock.rows), qt.Equals, 1)
+
+	// Check that BLOB was hex-encoded
+	encodedValue := mock.rows[0][1]
+	c.Assert(string(encodedValue.Raw()), qt.Equals, "0x68656c6c6f")
+	c.Assert(encodedValue.Type(), qt.Equals, querypb.Type_VARBINARY)
+
+	// Check that non-BLOB value was unchanged
+	c.Assert(mock.rows[0][0].String(), qt.Equals, row[0].String())
+}
+
+func TestHexBlobWrapperWriteRowVARBINARY(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("456")),
+		sqltypes.MakeTrusted(querypb.Type_VARBINARY, []byte("world")),
+	}
+
+	_, err := wrapper.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	encodedValue := mock.rows[0][1]
+	c.Assert(string(encodedValue.Raw()), qt.Equals, "0x776f726c64")
+}
+
+func TestHexBlobWrapperWriteRowBINARY(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("789")),
+		sqltypes.MakeTrusted(querypb.Type_BINARY, []byte("test")),
+	}
+
+	_, err := wrapper.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	encodedValue := mock.rows[0][1]
+	c.Assert(string(encodedValue.Raw()), qt.Equals, "0x74657374")
+}
+
+func TestHexBlobWrapperWriteRowNullBlob(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("123")),
+		sqltypes.MakeTrusted(querypb.Type_BLOB, nil),
+	}
+
+	_, err := wrapper.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	// NULL should pass through unchanged
+	c.Assert(mock.rows[0][1].Raw(), qt.IsNil)
+}
+
+func TestHexBlobWrapperWriteRowNonBinaryTypes(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "name", "age"})
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("123")),
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("John")),
+		sqltypes.MakeTrusted(querypb.Type_INT64, []byte("25")),
+	}
+
+	_, err := wrapper.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	// All non-binary values should pass through unchanged
+	for i, origVal := range row {
+		c.Assert(mock.rows[0][i].String(), qt.Equals, origVal.String())
+	}
+}
+
+func TestHexBlobWrapperInitialize(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	fieldNames := []string{"col1", "col2", "col3"}
+	err := wrapper.Initialize(fieldNames)
+	c.Assert(err, qt.IsNil)
+	c.Assert(mock.initialized, qt.IsTrue)
+	c.Assert(mock.fieldNames, qt.DeepEquals, fieldNames)
+}
+
+func TestHexBlobWrapperShouldFlush(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	result := wrapper.ShouldFlush()
+	c.Assert(result, qt.IsFalse)
+}
+
+func TestHexBlobWrapperFlush(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	err := wrapper.Flush("/tmp", "testdb", "testtable", 1)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestHexBlobWrapperClose(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"id", "data"})
+
+	err := wrapper.Close("/tmp", "testdb", "testtable", 1)
+	c.Assert(err, qt.IsNil)
+}
+
+func TestHexBlobWrapperEncodeToHexPrefix(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"data"})
+
+	// Test that hex encoding includes 0x prefix
+	result := wrapper.encodeToHex([]byte("\x00\xff\xaa\xbb"))
+	c.Assert(string(result), qt.Equals, "0x00ffaabb")
+}
+
+func TestHexBlobWrapperShouldHexEncodeDetectsNull(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"data"})
+
+	nullValue := sqltypes.MakeTrusted(querypb.Type_BLOB, nil)
+	result := wrapper.shouldHexEncode(nullValue)
+	c.Assert(result, qt.IsFalse)
+}

--- a/internal/dumper/hex_dumper_test.go
+++ b/internal/dumper/hex_dumper_test.go
@@ -190,6 +190,16 @@ func TestHexBlobWrapperEncodeToHexPrefix(t *testing.T) {
 	c.Assert(string(result), qt.Equals, "0x00ffaabb")
 }
 
+func TestHexBlobWrapperEncodeToHexEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	mock := &mockTableWriter{}
+	wrapper := NewHexBlobWrapper(mock, []string{"data"})
+
+	result := wrapper.encodeToHex([]byte{})
+	c.Assert(string(result), qt.Equals, "X''")
+}
+
 func TestHexBlobWrapperShouldHexEncodeDetectsNull(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/dumper/sql_writer.go
+++ b/internal/dumper/sql_writer.go
@@ -43,7 +43,9 @@ func (w *sqlWriter) WriteRow(row []sqltypes.Value) (int, error) {
 		} else {
 			str := v.String()
 			switch {
-			case v.IsSigned(), v.IsUnsigned(), v.IsFloat(), v.IsIntegral(), v.Type() == querypb.Type_DECIMAL, v.Type() == querypb.Type_VARBINARY:
+			case v.IsSigned(), v.IsUnsigned(), v.IsFloat(), v.IsIntegral(), v.Type() == querypb.Type_DECIMAL:
+				values = append(values, str)
+			case v.Type() == querypb.Type_VARBINARY && w.cfg.HexBlob:
 				values = append(values, str)
 			default:
 				values = append(values, fmt.Sprintf("\"%s\"", escapeBytes(v.Raw())))

--- a/internal/dumper/sql_writer.go
+++ b/internal/dumper/sql_writer.go
@@ -43,7 +43,7 @@ func (w *sqlWriter) WriteRow(row []sqltypes.Value) (int, error) {
 		} else {
 			str := v.String()
 			switch {
-			case v.IsSigned(), v.IsUnsigned(), v.IsFloat(), v.IsIntegral(), v.Type() == querypb.Type_DECIMAL:
+			case v.IsSigned(), v.IsUnsigned(), v.IsFloat(), v.IsIntegral(), v.Type() == querypb.Type_DECIMAL, v.Type() == querypb.Type_VARBINARY:
 				values = append(values, str)
 			default:
 				values = append(values, fmt.Sprintf("\"%s\"", escapeBytes(v.Raw())))

--- a/internal/dumper/sql_writer_test.go
+++ b/internal/dumper/sql_writer_test.go
@@ -1,0 +1,145 @@
+package dumper
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	querypb "github.com/xelabs/go-mysqlstack/sqlparser/depends/query"
+	"github.com/xelabs/go-mysqlstack/sqlparser/depends/sqltypes"
+)
+
+func TestSQLWriterVARBINARYHex(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		StmtSize: 1024,
+	}
+
+	writer := newSQLWriter(cfg, "test_table")
+	err := writer.Initialize([]string{"id", "data"})
+	c.Assert(err, qt.IsNil)
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("123")),
+		sqltypes.MakeTrusted(querypb.Type_VARBINARY, []byte("0x68656c6c6f")),
+	}
+
+	_, err = writer.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	inserts := writer.inserts
+	c.Assert(len(inserts), qt.Equals, 0)
+
+	rows := writer.rows
+	c.Assert(len(rows), qt.Equals, 1)
+
+	expectedRow := "(123,0x68656c6c6f)"
+	c.Assert(rows[0], qt.Equals, expectedRow)
+}
+
+func TestSQLWriterVARBINARYNotQuoted(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		StmtSize: 1024,
+	}
+
+	writer := newSQLWriter(cfg, "test_table")
+	err := writer.Initialize([]string{"id", "data"})
+	c.Assert(err, qt.IsNil)
+
+	hexValue := sqltypes.MakeTrusted(querypb.Type_VARBINARY, []byte("0x776f726c64"))
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("456")),
+		hexValue,
+	}
+
+	_, err = writer.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	rows := writer.rows
+	c.Assert(len(rows), qt.Equals, 1)
+
+	rowStr := rows[0]
+	c.Assert(rowStr, qt.Not(qt.Contains), `"0x`)
+	c.Assert(rowStr, qt.Contains, "0x776f726c64")
+}
+
+func TestSQLWriterVARINTAR(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		StmtSize: 1024,
+	}
+
+	writer := newSQLWriter(cfg, "test_table")
+	err := writer.Initialize([]string{"id", "name"})
+	c.Assert(err, qt.IsNil)
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("789")),
+		sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("hello world")),
+	}
+
+	_, err = writer.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	rows := writer.rows
+	c.Assert(len(rows), qt.Equals, 1)
+
+	expectedRow := `(789,"hello world")`
+	c.Assert(rows[0], qt.Equals, expectedRow)
+}
+
+func TestSQLWriterNullValue(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		StmtSize: 1024,
+	}
+
+	writer := newSQLWriter(cfg, "test_table")
+	err := writer.Initialize([]string{"id", "data"})
+	c.Assert(err, qt.IsNil)
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("123")),
+		sqltypes.NULL,
+	}
+
+	_, err = writer.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	rows := writer.rows
+	c.Assert(len(rows), qt.Equals, 1)
+
+	expectedRow := "(123,NULL)"
+	c.Assert(rows[0], qt.Equals, expectedRow)
+}
+
+func TestSQLWriterNumericTypes(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		StmtSize: 1024,
+	}
+
+	writer := newSQLWriter(cfg, "test_table")
+	err := writer.Initialize([]string{"int_col", "decimal_col"})
+	c.Assert(err, qt.IsNil)
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("42")),
+		sqltypes.MakeTrusted(querypb.Type_DECIMAL, []byte("99.99")),
+	}
+
+	_, err = writer.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	rows := writer.rows
+	c.Assert(len(rows), qt.Equals, 1)
+
+	expectedRow := "(42,99.99)"
+	c.Assert(rows[0], qt.Equals, expectedRow)
+}

--- a/internal/dumper/sql_writer_test.go
+++ b/internal/dumper/sql_writer_test.go
@@ -12,6 +12,7 @@ func TestSQLWriterVARBINARYHex(t *testing.T) {
 	c := qt.New(t)
 
 	cfg := &Config{
+		HexBlob:  true,
 		StmtSize: 1024,
 	}
 
@@ -41,6 +42,7 @@ func TestSQLWriterVARBINARYNotQuoted(t *testing.T) {
 	c := qt.New(t)
 
 	cfg := &Config{
+		HexBlob:  true,
 		StmtSize: 1024,
 	}
 
@@ -64,6 +66,33 @@ func TestSQLWriterVARBINARYNotQuoted(t *testing.T) {
 	rowStr := rows[0]
 	c.Assert(rowStr, qt.Not(qt.Contains), `"0x`)
 	c.Assert(rowStr, qt.Contains, "0x776f726c64")
+}
+
+func TestSQLWriterVARBINARYQuotedWithoutHexBlob(t *testing.T) {
+	c := qt.New(t)
+
+	cfg := &Config{
+		StmtSize: 1024,
+	}
+
+	writer := newSQLWriter(cfg, "test_table")
+	err := writer.Initialize([]string{"id", "data"})
+	c.Assert(err, qt.IsNil)
+
+	row := []sqltypes.Value{
+		sqltypes.MakeTrusted(querypb.Type_INT32, []byte("456")),
+		sqltypes.MakeTrusted(querypb.Type_VARBINARY, []byte("world")),
+	}
+
+	_, err = writer.WriteRow(row)
+	c.Assert(err, qt.IsNil)
+
+	rows := writer.rows
+	c.Assert(len(rows), qt.Equals, 1)
+
+	rowStr := rows[0]
+	c.Assert(rowStr, qt.Contains, `"world"`)
+	c.Assert(rowStr, qt.Not(qt.Contains), "0x776f726c64")
 }
 
 func TestSQLWriterVARINTAR(t *testing.T) {


### PR DESCRIPTION
**This PR would add `--hex-blob` to `pscale database dump`** to address this [issue](https://github.com/planetscale/cli/issues/1172)

**Why:** Binary data (BLOBs, etc.) can break other tools and importers due to encoding issues. `mysqldump` and `mydumper` already have a `--hex-blob` flag for this — we should too.

**It adds**
- A new `--hex-blob` flag for the dump command
- Hex-encoding of  BLOB/BINARY/VARBINARY columns with `0x` prefix
- Updated config and dump logic to use it
- Tests for NULLs and non-binary values


