### PR TITLE
Apply SessionVars to initPool so schema dumps honor --shard

### DIFF
--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -89,7 +89,8 @@ type dumpContext struct {
 }
 
 func (d *Dumper) Run(ctx context.Context) error {
-	initPool, err := NewPool(d.log, d.cfg.Threads, d.cfg.Address, d.cfg.User, d.cfg.Password, nil, "")
+	// dumpTableSchema runs against initPool, so it needs --shard's USE pin in SessionVars too.
+	initPool, err := NewPool(d.log, d.cfg.Threads, d.cfg.Address, d.cfg.User, d.cfg.Password, d.cfg.SessionVars, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What's broken

`pscale database dump --schema-only --keyspace <target> --shard <s>` against a MoveTables-import target keyspace returns the **source** keyspace's schema, not the target's. Routing rules redirect the fully-qualified `SHOW CREATE TABLE <target>.<t>` to the source despite the `--shard` flag being set.

## Why

`dumper.Run` creates two pools:

- `initPool` (line 92): no SessionVars. Used for `SHOW DATABASES`, `SHOW TABLES FROM`, view enumeration, AND `dumpTableSchema`.
- per-database pool (line 149): gets `cfg.SessionVars` (including the `USE keyspace/shard` injected by `--shard`). Used for data-only dumps.

`dumpTableSchema` lives in `initPool`, so the `USE keyspace/shard` session pin never reaches the connection that issues `SHOW CREATE TABLE`. With no session pin, vtgate applies routing rules to the qualified table reference.

Verified empirically: in `pscale shell`, `USE` `<target-keyspace>/<shard>`; `SHOW CREATE TABLE` `<target-keyspace>`.`<table>` returns target schema as expected; routing-rule bypass works. The bug is solely that the dumper doesn't apply the session pin to its schema-fetch path.

## Fix

One line: pass `d.cfg.SessionVars` to `NewPool` for `initPool` too.

## Test plan

- [x] Existing dumper unit tests pass (`go test ./internal/dumper/...`)
- [x] `pscale database dump --keyspace <target> --shard <s> --schema-only` against an active MoveTables-import target returns target schema instead of routing-rule-redirected source schema (verified locally with a freshly-built binary)
- [x] Without `--shard` / `--replica` / `--rdonly`, behavior is essentially unchanged (`SessionVars` only has `set workload=olap;`, which doesn't affect schema-fetch result content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)