### PR TITLE
Require --keep-data and --keep-routing-rules for move-tables complete and cancel

### DIFF
--- a/internal/cmd/branch/vtctld/move_tables.go
+++ b/internal/cmd/branch/vtctld/move_tables.go
@@ -442,8 +442,10 @@ func MoveTablesCancelCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.targetKeyspace, "target-keyspace", "", "Target keyspace")
 	cmd.Flags().BoolVar(&flags.keepData, "keep-data", false, "Keep the data in the target keyspace")
 	cmd.Flags().BoolVar(&flags.keepRoutingRules, "keep-routing-rules", false, "Keep the routing rules")
-	cmd.MarkFlagRequired("workflow")        // nolint:errcheck
-	cmd.MarkFlagRequired("target-keyspace") // nolint:errcheck
+	cmd.MarkFlagRequired("workflow")           // nolint:errcheck
+	cmd.MarkFlagRequired("target-keyspace")    // nolint:errcheck
+	cmd.MarkFlagRequired("keep-data")          // nolint:errcheck
+	cmd.MarkFlagRequired("keep-routing-rules") // nolint:errcheck
 
 	return cmd
 }
@@ -518,8 +520,10 @@ func MoveTablesCompleteCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.keepRoutingRules, "keep-routing-rules", false, "Keep the routing rules")
 	cmd.Flags().BoolVar(&flags.renameTables, "rename-tables", false, "Rename source tables instead of dropping them")
 	cmd.Flags().BoolVar(&flags.dryRun, "dry-run", false, "Only show what would be done")
-	cmd.MarkFlagRequired("workflow")        // nolint:errcheck
-	cmd.MarkFlagRequired("target-keyspace") // nolint:errcheck
+	cmd.MarkFlagRequired("workflow")           // nolint:errcheck
+	cmd.MarkFlagRequired("target-keyspace")    // nolint:errcheck
+	cmd.MarkFlagRequired("keep-data")          // nolint:errcheck
+	cmd.MarkFlagRequired("keep-routing-rules") // nolint:errcheck
 
 	return cmd
 }

--- a/internal/cmd/branch/vtctld/move_tables_test.go
+++ b/internal/cmd/branch/vtctld/move_tables_test.go
@@ -506,12 +506,15 @@ func TestMoveTablesCancelWithFlags(t *testing.T) {
 	branch := "my-branch"
 
 	keepData := false
+	keepRoutingRules := false
 	svc := &mock.MoveTablesService{
 		CancelFn: func(ctx context.Context, req *ps.MoveTablesCancelRequest) (*ps.VtctldOperationReference, error) {
 			c.Assert(req.Workflow, qt.Equals, "my-workflow")
 			c.Assert(req.TargetKeyspace, qt.Equals, "target-ks")
 			c.Assert(req.KeepData, qt.IsNotNil)
 			c.Assert(*req.KeepData, qt.Equals, keepData)
+			c.Assert(req.KeepRoutingRules, qt.IsNotNil)
+			c.Assert(*req.KeepRoutingRules, qt.Equals, keepRoutingRules)
 			return &ps.VtctldOperationReference{ID: "cancel-op"}, nil
 		},
 	}
@@ -539,6 +542,7 @@ func TestMoveTablesCancelWithFlags(t *testing.T) {
 		"--workflow", "my-workflow",
 		"--target-keyspace", "target-ks",
 		"--keep-data=false",
+		"--keep-routing-rules=false",
 	})
 	err := cmd.Execute()
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
## Background

Vitess `MoveTables` workflow `complete` and `cancel` have `--keep-data` and `--keep-routing-rules` args, both of which default to `false`. This means that the default behavior of Vitess is to delete source data and the routing rules created by the workflow upon `complete`, and to delete target data and routing rules upon `cancel`.

Whether or not you think these defaults are good or bad, it is hopefully beyond debate that if a user is unaware of the defaults, they are potentially in for a very nasty surprise. PlanetScale's position internally is that `--keep-data=true` is a safer default, and therefore we've inverted the default behavior of PlanetScale Vitess. As of now, we have not documented this anywhere, and as a result some early users of `pscale branch vtctld` have been thrown for a loop.

After going back and forth internally about what the best defaults are, we decided that the best option for now is to simply _not_ have defaults, and require users to explicitly specify the behavior they want.

## Changes

Make the `--keep-data` and `--keep-routing-rules` flags required for both `move-tables` `complete` and `cancel` commands. This ensures users explicitly specify whether to keep or delete data and routing rules.

Users must now provide both flags with explicit values, one of the following:
- `--keep-data` (defaults to true if no value given)
- `--keep-data=true` (explicit true)
- `--keep-data=false` (explicit false)