### PR TITLE
feat: allow to specify name when creating backup

### DIFF
--- a/internal/cmd/backup/create.go
+++ b/internal/cmd/backup/create.go
@@ -56,5 +56,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVar(&createReq.Name, "name", "", "Optional name for the backup")
+
 	return cmd
 }

--- a/internal/cmd/backup/create_test.go
+++ b/internal/cmd/backup/create_test.go
@@ -33,6 +33,7 @@ func TestBackup_CreateCmd(t *testing.T) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Name, qt.Equals, "")
 
 			return res, nil
 		},
@@ -52,6 +53,53 @@ func TestBackup_CreateCmd(t *testing.T) {
 
 	cmd := CreateCmd(ch)
 	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBackup_CreateCmdWithName(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	name := "my-backup"
+
+	res := &ps.Backup{Name: "foo"}
+
+	svc := &mock.BackupsService{
+		CreateFn: func(ctx context.Context, req *ps.CreateBackupRequest) (*ps.Backup, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Name, qt.Equals, name)
+
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--name", name})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
This add a optional flag `--name` so name can be specified when creating a backup.


E.g.

```
➜  pscale-cli git:(feat/backup-flag-name) go run cmd/pscale/main.go backup create _ main           
!! WARNING: You are using a self-compiled binary which is not officially supported.
!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true

Backup 2026.06.03 09:02:30.838 was successfully created.
```

```
➜  pscale-cli git:(main) ✗ go run cmd/pscale/main.go backup create _ main --name pkk
!! WARNING: You are using a self-compiled binary which is not officially supported.
!! To dismiss this warning, set PSCALE_DISABLE_DEV_WARNING=true

Backup pkk was successfully created.
```