### PR TITLE
Add `processlist show` and `processlist kill` for Vitess

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.166.0
+	github.com/planetscale/planetscale-go v0.167.0
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.166.0 h1:Bnd9+VMYAuQgdAbiYUL6pFHU2gNCGae6JEFq2Whpox0=
-github.com/planetscale/planetscale-go v0.166.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.167.0 h1:TqXYCu7Pgcc3wAVD7cNBqZ1zH5+rXrxr6UGYNSV5V44=
+github.com/planetscale/planetscale-go v0.167.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -35,6 +35,7 @@ func BranchCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(RoutingRulesCmd(ch))
 	cmd.AddCommand(SafeMigrationsCmd(ch))
 	cmd.AddCommand(LintCmd(ch))
+	cmd.AddCommand(ProcesslistCmd(ch))
 	cmd.AddCommand(vtctld.VtctldCmd(ch))
 	cmd.AddCommand(InfraCmd(ch))
 

--- a/internal/cmd/branch/kill.go
+++ b/internal/cmd/branch/kill.go
@@ -68,7 +68,7 @@ the same primary tablet that the process list was read from, so the same
 				case ps.ErrNotFound:
 					return cmdutil.HandleNotFoundWithServiceTokenCheck(
 						ctx, cmd, ch.Config, ch.Client, err, "read_branch",
-						"process %s does not exist on branch %s in database %s (organization: %s)",
+						"process %s or branch %s does not exist in database %s (organization: %s)",
 						printer.BoldBlue(id), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
 				default:
 					return cmdutil.HandleError(err)

--- a/internal/cmd/branch/kill.go
+++ b/internal/cmd/branch/kill.go
@@ -10,6 +10,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// KillProcessResult is the CLI representation of a killed process response.
+type KillProcessResult struct {
+	Success  bool   `header:"success" json:"success"`
+	Keyspace string `header:"keyspace" json:"keyspace"`
+	Shard    string `header:"shard" json:"shard"`
+	Tablet   string `header:"tablet" json:"tablet"`
+	ID       int64  `header:"id,text" json:"id"`
+	Kind     string `header:"kind" json:"kind"`
+}
+
+func (k *KillProcessResult) MarshalCSVValue() interface{} {
+	return []*KillProcessResult{k}
+}
+
+func toKillProcessResult(result *ps.KillProcessResult) *KillProcessResult {
+	return &KillProcessResult{
+		Success:  result.Success,
+		Keyspace: result.Keyspace,
+		Shard:    result.Shard,
+		Tablet:   result.Tablet,
+		ID:       result.ID,
+		Kind:     result.Kind,
+	}
+}
+
 // ProcesslistKillCmd kills a running MySQL process on a Vitess branch.
 func ProcesslistKillCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
@@ -84,7 +109,7 @@ the same primary tablet that the process list was read from, so the same
 				return nil
 			}
 
-			return ch.Printer.PrintJSON(result)
+			return ch.Printer.PrintResource(toKillProcessResult(result))
 		},
 	}
 

--- a/internal/cmd/branch/kill.go
+++ b/internal/cmd/branch/kill.go
@@ -1,0 +1,96 @@
+package branch
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// ProcesslistKillCmd kills a running MySQL process on a Vitess branch.
+func ProcesslistKillCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		keyspace string
+		shard    string
+		query    bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "kill <database> <branch> <id>",
+		Short: "Kill a running MySQL process on a branch (Vitess only)",
+		Long: `Kill a MySQL process by ID, as shown in "pscale branch processlist show".
+
+This command is only supported for Vitess (MySQL) databases.
+
+By default the entire connection is killed (KILL <id>). Pass --query to kill
+only the currently running statement (KILL QUERY <id>). The process must live on
+the same primary tablet that the process list was read from, so the same
+--keyspace/--shard targeting rules apply.`,
+		Args: cmdutil.RequiredArgs("database", "branch", "id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			id, err := strconv.ParseInt(args[2], 10, 64)
+			if err != nil || id <= 0 {
+				return fmt.Errorf("id must be a positive integer, got %q", args[2])
+			}
+
+			kind := "connection"
+			if flags.query {
+				kind = "query"
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(
+				fmt.Sprintf("Killing process %s on %s\u2026",
+					printer.BoldBlue(id), printer.BoldBlue(fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch))))
+			defer end()
+
+			result, err := client.Processlist.Kill(ctx, &ps.KillProcessRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Keyspace:     flags.keyspace,
+				Shard:        flags.shard,
+				ID:           id,
+				Kind:         kind,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+						"process %s does not exist on branch %s in database %s (organization: %s)",
+						printer.BoldBlue(id), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Killed %s %s on keyspace %s shard %s (tablet %s).\n",
+					result.Kind, printer.BoldBlue(result.ID),
+					printer.BoldBlue(result.Keyspace), printer.BoldBlue(result.Shard), printer.BoldBlue(result.Tablet))
+				return nil
+			}
+
+			return ch.Printer.PrintJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace to target (required when the database has multiple keyspaces)")
+	cmd.Flags().StringVar(&flags.shard, "shard", "", "Shard to target (required when the targeted keyspace is sharded)")
+	cmd.Flags().BoolVar(&flags.query, "query", false, "Kill only the running query (KILL QUERY) instead of the whole connection")
+
+	return cmd
+}

--- a/internal/cmd/branch/kill_test.go
+++ b/internal/cmd/branch/kill_test.go
@@ -105,6 +105,7 @@ func TestKill_NotFound(t *testing.T) {
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "process")
+	c.Assert(err.Error(), qt.Contains, "or branch")
 	c.Assert(err.Error(), qt.Contains, "101")
 	c.Assert(err.Error(), qt.Contains, branch)
 	c.Assert(err.Error(), qt.Contains, db)

--- a/internal/cmd/branch/kill_test.go
+++ b/internal/cmd/branch/kill_test.go
@@ -42,6 +42,32 @@ func TestKill(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, `"success": true`)
 }
 
+func TestKill_CSVOutput(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		KillFn: func(ctx context.Context, req *ps.KillProcessRequest) (*ps.KillProcessResult, error) {
+			return &ps.KillProcessResult{
+				Success: true, Keyspace: "main", Shard: "-", Tablet: "zone1-2001", ID: req.ID, Kind: "connection",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.CSV, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"kill", db, branch, "101"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "true,main,-,zone1-2001,101,connection")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "{")
+	c.Assert(buf.String(), qt.Not(qt.Contains), `"success"`)
+}
+
 func TestKill_QueryFlag(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/cmd/branch/kill_test.go
+++ b/internal/cmd/branch/kill_test.go
@@ -1,0 +1,114 @@
+package branch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestKill(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		KillFn: func(ctx context.Context, req *ps.KillProcessRequest) (*ps.KillProcessResult, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.ID, qt.Equals, int64(101))
+			c.Assert(req.Kind, qt.Equals, "connection")
+			return &ps.KillProcessResult{
+				Success: true, Keyspace: "main", Shard: "-", Tablet: "zone1-2001", ID: 101, Kind: "connection",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"kill", db, branch, "101"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.KillFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"success": true`)
+}
+
+func TestKill_QueryFlag(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		KillFn: func(ctx context.Context, req *ps.KillProcessRequest) (*ps.KillProcessResult, error) {
+			c.Assert(req.Kind, qt.Equals, "query")
+			return &ps.KillProcessResult{Success: true, ID: req.ID, Kind: "query"}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"kill", db, branch, "101", "--query"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.KillFnInvoked, qt.IsTrue)
+}
+
+func TestKill_InvalidID(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.ProcesslistService{
+		KillFn: func(ctx context.Context, req *ps.KillProcessRequest) (*ps.KillProcessResult, error) {
+			return nil, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper("my-org", svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"kill", "my-db", "my-branch", "not-a-number"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(svc.KillFnInvoked, qt.IsFalse)
+}
+
+func TestKill_NotFound(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "missing-db", "missing-branch"
+
+	svc := &mock.ProcesslistService{
+		KillFn: func(ctx context.Context, req *ps.KillProcessRequest) (*ps.KillProcessResult, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"kill", db, branch, "101"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "process")
+	c.Assert(err.Error(), qt.Contains, "101")
+	c.Assert(err.Error(), qt.Contains, branch)
+	c.Assert(err.Error(), qt.Contains, db)
+	c.Assert(err.Error(), qt.Contains, org)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "Not Found")
+	c.Assert(svc.KillFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/branch/processlist.go
+++ b/internal/cmd/branch/processlist.go
@@ -21,6 +21,18 @@ type Process struct {
 	Info    string `header:"info" json:"info"`
 }
 
+// ProcesslistResult is the CLI representation of a process list response.
+type ProcesslistResult struct {
+	Keyspace  string       `json:"keyspace"`
+	Shard     string       `json:"shard"`
+	Tablet    string       `json:"tablet"`
+	Processes []ps.Process `json:"processes"`
+}
+
+func (p *ProcesslistResult) MarshalCSVValue() interface{} {
+	return toProcesses(p.Processes)
+}
+
 func toProcesses(processes []ps.Process) []*Process {
 	rows := make([]*Process, 0, len(processes))
 	for _, p := range processes {
@@ -36,6 +48,15 @@ func toProcesses(processes []ps.Process) []*Process {
 		})
 	}
 	return rows
+}
+
+func toProcesslistResult(result *ps.ProcesslistResult) *ProcesslistResult {
+	return &ProcesslistResult{
+		Keyspace:  result.Keyspace,
+		Shard:     result.Shard,
+		Tablet:    result.Tablet,
+		Processes: result.Processes,
+	}
 }
 
 // ProcesslistCmd manages MySQL process lists for a Vitess branch.
@@ -115,7 +136,7 @@ pass --shard. Process IDs shown here can be passed to
 				return ch.Printer.PrintResource(toProcesses(result.Processes))
 			}
 
-			return ch.Printer.PrintJSON(result)
+			return ch.Printer.PrintResource(toProcesslistResult(result))
 		},
 	}
 

--- a/internal/cmd/branch/processlist.go
+++ b/internal/cmd/branch/processlist.go
@@ -1,0 +1,126 @@
+package branch
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// Process is the table/json representation of a single MySQL process.
+type Process struct {
+	ID      int64  `header:"id,text" json:"id"`
+	User    string `header:"user" json:"user"`
+	Host    string `header:"host" json:"host"`
+	DB      string `header:"db" json:"db"`
+	Command string `header:"command" json:"command"`
+	Time    int64  `header:"time (seconds),text" json:"time"`
+	State   string `header:"state" json:"state"`
+	Info    string `header:"info" json:"info"`
+}
+
+func toProcesses(processes []ps.Process) []*Process {
+	rows := make([]*Process, 0, len(processes))
+	for _, p := range processes {
+		rows = append(rows, &Process{
+			ID:      p.ID,
+			User:    p.User,
+			Host:    p.Host,
+			DB:      p.DB,
+			Command: p.Command,
+			Time:    p.Time,
+			State:   p.State,
+			Info:    p.Info,
+		})
+	}
+	return rows
+}
+
+// ProcesslistCmd manages MySQL process lists for a Vitess branch.
+func ProcesslistCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "processlist <command>",
+		Short: "Show and kill running MySQL processes for a branch",
+		Long: `Show and kill running MySQL processes for a branch.
+
+This command is only supported for Vitess databases.`,
+	}
+
+	cmd.AddCommand(ProcesslistShowCmd(ch))
+	cmd.AddCommand(ProcesslistKillCmd(ch))
+
+	return cmd
+}
+
+// ProcesslistShowCmd shows the MySQL process list for a Vitess branch.
+func ProcesslistShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		keyspace string
+		shard    string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "show <database> <branch>",
+		Short: "Show the running MySQL processes for a branch",
+		Long: `Show the output of "SHOW FULL PROCESSLIST" for a branch.
+
+This command is only supported for Vitess databases.
+
+The process list is read from a single primary tablet. If the database has a
+single unsharded keyspace, that primary is targeted automatically. If it has
+multiple keyspaces, pass --keyspace; if the targeted keyspace is sharded, also
+pass --shard. Process IDs shown here can be passed to
+"pscale branch processlist kill".`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(
+				fmt.Sprintf("Fetching process list for %s\u2026",
+					printer.BoldBlue(fmt.Sprintf("%s/%s/%s", ch.Config.Organization, database, branch))))
+			defer end()
+
+			result, err := client.Processlist.List(ctx, &ps.ProcesslistRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Keyspace:     flags.keyspace,
+				Shard:        flags.shard,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+						"branch %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Process list for keyspace %s shard %s (tablet %s):\n",
+					printer.BoldBlue(result.Keyspace), printer.BoldBlue(result.Shard), printer.BoldBlue(result.Tablet))
+				return ch.Printer.PrintResource(toProcesses(result.Processes))
+			}
+
+			return ch.Printer.PrintJSON(result)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace to target (required when the database has multiple keyspaces)")
+	cmd.Flags().StringVar(&flags.shard, "shard", "", "Shard to target (required when the targeted keyspace is sharded)")
+
+	return cmd
+}

--- a/internal/cmd/branch/processlist_test.go
+++ b/internal/cmd/branch/processlist_test.go
@@ -1,0 +1,148 @@
+package branch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func processlistTestHelper(org string, svc ps.ProcesslistService, format printer.Format, buf *bytes.Buffer) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(buf)
+
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Processlist: svc}, nil
+		},
+	}
+}
+
+func TestProcesslist(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		ListFn: func(ctx context.Context, req *ps.ProcesslistRequest) (*ps.ProcesslistResult, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Keyspace, qt.Equals, "commerce")
+			c.Assert(req.Shard, qt.Equals, "-80")
+			return &ps.ProcesslistResult{
+				Keyspace: "commerce",
+				Shard:    "-80",
+				Tablet:   "zone1-1001",
+				Processes: []ps.Process{
+					{ID: 101, User: "vt_app", Command: "Query", Time: 42, Info: "SELECT 1"},
+				},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"show", db, branch, "--keyspace", "commerce", "--shard", "-80"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"tablet": "zone1-1001"`)
+	c.Assert(buf.String(), qt.Contains, `"user": "vt_app"`)
+}
+
+func TestProcesslist_NoTargetFlags(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		ListFn: func(ctx context.Context, req *ps.ProcesslistRequest) (*ps.ProcesslistResult, error) {
+			c.Assert(req.Keyspace, qt.Equals, "")
+			c.Assert(req.Shard, qt.Equals, "")
+			return &ps.ProcesslistResult{Keyspace: "main", Shard: "-", Tablet: "zone1-2001"}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"show", db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestProcesslist_HumanOutputDoesNotAbbreviateNumericFields(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		ListFn: func(ctx context.Context, req *ps.ProcesslistRequest) (*ps.ProcesslistResult, error) {
+			return &ps.ProcesslistResult{
+				Keyspace: "main",
+				Shard:    "-",
+				Tablet:   "zone1-2001",
+				Processes: []ps.Process{
+					{ID: 121500, User: "vt_app", Command: "Sleep", Time: 2100},
+				},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.Human, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"show", db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "TIME (SECONDS)")
+	c.Assert(buf.String(), qt.Contains, "121500")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "121.5K")
+	c.Assert(buf.String(), qt.Contains, "2100")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "2.1K")
+}
+
+func TestProcesslist_NotFound(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "missing-db", "missing-branch"
+
+	svc := &mock.ProcesslistService{
+		ListFn: func(ctx context.Context, req *ps.ProcesslistRequest) (*ps.ProcesslistResult, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.JSON, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"show", db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "branch")
+	c.Assert(err.Error(), qt.Contains, branch)
+	c.Assert(err.Error(), qt.Contains, db)
+	c.Assert(err.Error(), qt.Contains, org)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "Not Found")
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/branch/processlist_test.go
+++ b/internal/cmd/branch/processlist_test.go
@@ -63,6 +63,37 @@ func TestProcesslist(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, `"user": "vt_app"`)
 }
 
+func TestProcesslist_CSVOutput(t *testing.T) {
+	c := qt.New(t)
+
+	org, db, branch := "my-org", "my-db", "my-branch"
+
+	svc := &mock.ProcesslistService{
+		ListFn: func(ctx context.Context, req *ps.ProcesslistRequest) (*ps.ProcesslistResult, error) {
+			return &ps.ProcesslistResult{
+				Keyspace: "commerce",
+				Shard:    "-80",
+				Tablet:   "zone1-1001",
+				Processes: []ps.Process{
+					{ID: 101, User: "vt_app", Host: "10.0.0.1", DB: "main", Command: "Query", Time: 42, State: "running", Info: "SELECT 1"},
+				},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := processlistTestHelper(org, svc, printer.CSV, &buf)
+
+	cmd := ProcesslistCmd(ch)
+	cmd.SetArgs([]string{"show", db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "101,vt_app,10.0.0.1,main,Query,42,running,SELECT 1")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "{")
+	c.Assert(buf.String(), qt.Not(qt.Contains), `"processes"`)
+}
+
 func TestProcesslist_NoTargetFlags(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/mock/processlist.go
+++ b/internal/mock/processlist.go
@@ -1,0 +1,25 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+type ProcesslistService struct {
+	ListFn        func(context.Context, *ps.ProcesslistRequest) (*ps.ProcesslistResult, error)
+	ListFnInvoked bool
+
+	KillFn        func(context.Context, *ps.KillProcessRequest) (*ps.KillProcessResult, error)
+	KillFnInvoked bool
+}
+
+func (s *ProcesslistService) List(ctx context.Context, req *ps.ProcesslistRequest) (*ps.ProcesslistResult, error) {
+	s.ListFnInvoked = true
+	return s.ListFn(ctx, req)
+}
+
+func (s *ProcesslistService) Kill(ctx context.Context, req *ps.KillProcessRequest) (*ps.KillProcessResult, error) {
+	s.KillFnInvoked = true
+	return s.KillFn(ctx, req)
+}


### PR DESCRIPTION
This adds the ability to view the processlist for a specific Vitess keyspace/shard. For unsharded, it defaults to the primary in the single keyspace.

`processlist kill` is available to kill a running process on a specific keyspace/shard