### PR TITLE
Add vtctld get-routing-rules command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.168.1-0.20260609224250-8001bcf5eba5
+	github.com/planetscale/planetscale-go v0.168.1
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.167.0
+	github.com/planetscale/planetscale-go v0.167.1-0.20260606201648-938306efbc47
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,10 @@ github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2v
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
 github.com/planetscale/planetscale-go v0.168.1-0.20260609224250-8001bcf5eba5 h1:z+ao9YVEVP9GHpyB1Gmw48dt2+RQsS+BAOTE1QUigrw=
 github.com/planetscale/planetscale-go v0.168.1-0.20260609224250-8001bcf5eba5/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.168.1-0.20260610223405-068c67a15c9b h1:VJwfNPEI1sYyo52bhN/f8xxeHoh/BhE/0XWaNy5jYOk=
+github.com/planetscale/planetscale-go v0.168.1-0.20260610223405-068c67a15c9b/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.168.1 h1:ikGvRC5YlQQiNf7vF9vxi6WBXNs2NokNie0sazMTTcA=
+github.com/planetscale/planetscale-go v0.168.1/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2v
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
 github.com/planetscale/planetscale-go v0.167.0 h1:TqXYCu7Pgcc3wAVD7cNBqZ1zH5+rXrxr6UGYNSV5V44=
 github.com/planetscale/planetscale-go v0.167.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.167.1-0.20260606201648-938306efbc47 h1:gU4tPFSjq8bPGAJ7n9jswgslbEgMMpuZNYzDUyQ4DoA=
+github.com/planetscale/planetscale-go v0.167.1-0.20260606201648-938306efbc47/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/vtctld/routing_rules.go
+++ b/internal/cmd/branch/vtctld/routing_rules.go
@@ -1,0 +1,49 @@
+package vtctld
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// GetRoutingRulesCmd reads live routing rules from the cluster via vtctld.
+func GetRoutingRulesCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-routing-rules <database> <branch>",
+		Short: "Get live routing rules for a branch",
+		Long: "Get live routing rules from the cluster via vtctld. " +
+			"This reads the current cluster state, unlike `pscale branch routing-rules get`, " +
+			"which reads from the schema snapshot.",
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(
+				fmt.Sprintf("Fetching routing rules for %s\u2026",
+					progressTarget(ch.Config.Organization, database, branch)))
+			defer end()
+
+			data, err := client.Vtctld.GetRoutingRules(ctx, &ps.VtctldGetRoutingRulesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+
+			end()
+			return ch.Printer.PrettyPrintJSON(data)
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/branch/vtctld/routing_rules_test.go
+++ b/internal/cmd/branch/vtctld/routing_rules_test.go
@@ -1,0 +1,54 @@
+package vtctld
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestGetRoutingRules(t *testing.T) {
+	c := qt.New(t)
+
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	svc := &mock.VtctldService{
+		GetRoutingRulesFn: func(ctx context.Context, req *ps.VtctldGetRoutingRulesRequest) (json.RawMessage, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			return json.RawMessage(`{"rules":{"rules":[]}}`), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Vtctld: svc,
+			}, nil
+		},
+	}
+
+	cmd := GetRoutingRulesCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetRoutingRulesFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/branch/vtctld/routing_rules_test.go
+++ b/internal/cmd/branch/vtctld/routing_rules_test.go
@@ -27,7 +27,7 @@ func TestGetRoutingRules(t *testing.T) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
-			return json.RawMessage(`{"rules":{"rules":[]}}`), nil
+			return json.RawMessage(`{"rules":[]}`), nil
 		},
 	}
 

--- a/internal/cmd/branch/vtctld/vtctld.go
+++ b/internal/cmd/branch/vtctld/vtctld.go
@@ -20,6 +20,7 @@ func VtctldCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(PlannedReparentShardCmd(ch))
 	cmd.AddCommand(ListWorkflowsCmd(ch))
 	cmd.AddCommand(ListKeyspacesCmd(ch))
+	cmd.AddCommand(GetRoutingRulesCmd(ch))
 	cmd.AddCommand(ListTabletsCmd(ch))
 	cmd.AddCommand(StartWorkflowCmd(ch))
 	cmd.AddCommand(StopWorkflowCmd(ch))

--- a/internal/mock/vtctld_general.go
+++ b/internal/mock/vtctld_general.go
@@ -14,6 +14,9 @@ type VtctldService struct {
 	ListKeyspacesFn        func(context.Context, *ps.VtctldListKeyspacesRequest) (json.RawMessage, error)
 	ListKeyspacesFnInvoked bool
 
+	GetRoutingRulesFn        func(context.Context, *ps.VtctldGetRoutingRulesRequest) (json.RawMessage, error)
+	GetRoutingRulesFnInvoked bool
+
 	ListTabletsFn        func(context.Context, *ps.ListBranchTabletsRequest) ([]*ps.TabletGroup, error)
 	ListTabletsFnInvoked bool
 
@@ -44,6 +47,11 @@ func (s *VtctldService) ListWorkflows(ctx context.Context, req *ps.VtctldListWor
 func (s *VtctldService) ListKeyspaces(ctx context.Context, req *ps.VtctldListKeyspacesRequest) (json.RawMessage, error) {
 	s.ListKeyspacesFnInvoked = true
 	return s.ListKeyspacesFn(ctx, req)
+}
+
+func (s *VtctldService) GetRoutingRules(ctx context.Context, req *ps.VtctldGetRoutingRulesRequest) (json.RawMessage, error) {
+	s.GetRoutingRulesFnInvoked = true
+	return s.GetRoutingRulesFn(ctx, req)
 }
 
 func (s *VtctldService) ListTablets(ctx context.Context, req *ps.ListBranchTabletsRequest) ([]*ps.TabletGroup, error) {


### PR DESCRIPTION
Adds a vtctld command to read live routing rules from the cluster:

```
pscale branch vtctld get-routing-rules <database> <branch>
```

This complements `pscale branch routing-rules get`, which reads from the schema snapshot.

Depends on planetscale/planetscale-go#313.

## Manual testing

Tested end-to-end against a dev Vitess branch (org with `direct_vtctld_access` enabled) with the full stack deployed.

1. Created a Vitess database and waited for the default branch to become ready.
2. `pscale branch vtctld get-routing-rules <database> <branch>` returned `{"rules":[]}`.
3. Created a second keyspace on that branch:
   ```
   pscale keyspace create <database> <branch> target-ks --cluster-size PS-10 --wait
   ```
4. Created an identical `customers` table on both the default keyspace and `target-ks`.
5. Applied routing rules so rdonly queries against `customers` on the default keyspace are served from `target-ks`:
   ```json
   {
     "rules": [
       {"from_table": "customers@rdonly", "to_tables": ["target-ks.customers"]},
       {"from_table": "target-ks.customers", "to_tables": ["<default-keyspace>.customers"]},
       {"from_table": "customers", "to_tables": ["<default-keyspace>.customers"]}
     ]
   }
   ```
   ```
   pscale branch routing-rules update <database> <branch> --routing-rules routing-rules.json
   ```
6. `pscale branch vtctld get-routing-rules <database> <branch>` returned:
   ```json
   {
     "rules": [
       {
         "fromTable": "customers@rdonly",
         "toTables": ["target-ks.customers"]
       },
       {
         "fromTable": "target-ks.customers",
         "toTables": ["<default-keyspace>.customers"]
       },
       {
         "fromTable": "customers",
         "toTables": ["<default-keyspace>.customers"]
       }
     ]
   }
   ```