### PR TITLE
Add vtctld get-shard command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.168.1
+	github.com/planetscale/planetscale-go v0.168.2-0.20260611211624-109b07535906
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/planetscale/planetscale-go v0.168.1-0.20260610223405-068c67a15c9b h1:
 github.com/planetscale/planetscale-go v0.168.1-0.20260610223405-068c67a15c9b/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/planetscale-go v0.168.1 h1:ikGvRC5YlQQiNf7vF9vxi6WBXNs2NokNie0sazMTTcA=
 github.com/planetscale/planetscale-go v0.168.1/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.168.2-0.20260611211624-109b07535906 h1:n+R4KmP6Ud62T8tvCK9uJ5pzpx4g0NHaRahecOH/C4M=
+github.com/planetscale/planetscale-go v0.168.2-0.20260611211624-109b07535906/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/vtctld/shard.go
+++ b/internal/cmd/branch/vtctld/shard.go
@@ -1,0 +1,67 @@
+package vtctld
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// GetShardCmd reads a shard record from the cluster via vtctld.
+func GetShardCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		keyspace string
+		shard    string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "get-shard <database> <branch>",
+		Short: "Get a shard record for a branch",
+		Long:  "Get a live shard record from the cluster via vtctld, including tablet controls and denied tables.",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			if flags.keyspace == "" {
+				return fmt.Errorf("keyspace is required")
+			}
+			if flags.shard == "" {
+				return fmt.Errorf("shard is required")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(
+				fmt.Sprintf("Fetching shard %s/%s for %s\u2026",
+					flags.keyspace, flags.shard,
+					progressTarget(ch.Config.Organization, database, branch)))
+			defer end()
+
+			data, err := client.Vtctld.GetShard(ctx, &ps.VtctldGetShardRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Keyspace:     flags.keyspace,
+				Shard:        flags.shard,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+
+			end()
+			return ch.Printer.PrettyPrintJSON(data)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace name")
+	cmd.Flags().StringVar(&flags.shard, "shard", "", "Shard name (e.g. \"-\" for unsharded)")
+	cmd.MarkFlagRequired("keyspace")
+	cmd.MarkFlagRequired("shard")
+
+	return cmd
+}

--- a/internal/cmd/branch/vtctld/shard_test.go
+++ b/internal/cmd/branch/vtctld/shard_test.go
@@ -29,7 +29,7 @@ func TestGetShard(t *testing.T) {
 			c.Assert(req.Branch, qt.Equals, branch)
 			c.Assert(req.Keyspace, qt.Equals, "commerce")
 			c.Assert(req.Shard, qt.Equals, "-")
-			return json.RawMessage(`{"keyspace":"commerce","name":"-"}`), nil
+			return json.RawMessage(`{"tablet_controls":[{"tablet_type":"TABLET_TYPE_RDONLY","cells":["zone1"],"denied_tables":["t"]}]}`), nil
 		},
 	}
 

--- a/internal/cmd/branch/vtctld/shard_test.go
+++ b/internal/cmd/branch/vtctld/shard_test.go
@@ -1,0 +1,56 @@
+package vtctld
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestGetShard(t *testing.T) {
+	c := qt.New(t)
+
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	svc := &mock.VtctldService{
+		GetShardFn: func(ctx context.Context, req *ps.VtctldGetShardRequest) (json.RawMessage, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Keyspace, qt.Equals, "commerce")
+			c.Assert(req.Shard, qt.Equals, "-")
+			return json.RawMessage(`{"keyspace":"commerce","name":"-"}`), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Vtctld: svc,
+			}, nil
+		},
+	}
+
+	cmd := GetShardCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--keyspace", "commerce", "--shard", "-"})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetShardFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/branch/vtctld/vtctld.go
+++ b/internal/cmd/branch/vtctld/vtctld.go
@@ -21,6 +21,7 @@ func VtctldCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ListWorkflowsCmd(ch))
 	cmd.AddCommand(ListKeyspacesCmd(ch))
 	cmd.AddCommand(GetRoutingRulesCmd(ch))
+	cmd.AddCommand(GetShardCmd(ch))
 	cmd.AddCommand(ListTabletsCmd(ch))
 	cmd.AddCommand(StartWorkflowCmd(ch))
 	cmd.AddCommand(StopWorkflowCmd(ch))

--- a/internal/mock/vtctld_general.go
+++ b/internal/mock/vtctld_general.go
@@ -17,6 +17,9 @@ type VtctldService struct {
 	GetRoutingRulesFn        func(context.Context, *ps.VtctldGetRoutingRulesRequest) (json.RawMessage, error)
 	GetRoutingRulesFnInvoked bool
 
+	GetShardFn        func(context.Context, *ps.VtctldGetShardRequest) (json.RawMessage, error)
+	GetShardFnInvoked bool
+
 	ListTabletsFn        func(context.Context, *ps.ListBranchTabletsRequest) ([]*ps.TabletGroup, error)
 	ListTabletsFnInvoked bool
 
@@ -52,6 +55,11 @@ func (s *VtctldService) ListKeyspaces(ctx context.Context, req *ps.VtctldListKey
 func (s *VtctldService) GetRoutingRules(ctx context.Context, req *ps.VtctldGetRoutingRulesRequest) (json.RawMessage, error) {
 	s.GetRoutingRulesFnInvoked = true
 	return s.GetRoutingRulesFn(ctx, req)
+}
+
+func (s *VtctldService) GetShard(ctx context.Context, req *ps.VtctldGetShardRequest) (json.RawMessage, error) {
+	s.GetShardFnInvoked = true
+	return s.GetShardFn(ctx, req)
 }
 
 func (s *VtctldService) ListTablets(ctx context.Context, req *ps.ListBranchTabletsRequest) ([]*ps.TabletGroup, error) {


### PR DESCRIPTION
Adds a hidden vtctld command to read live shard records from the cluster:

```
pscale branch vtctld get-shard <database> <branch> --keyspace <keyspace> --shard <shard>
```

Depends on planetscale/planetscale-go#314.

## Manual testing

Tested end-to-end against a dev Vitess branch (org with `direct_vtctld_access` enabled) with the full stack deployed.

1. Unsharded keyspace:
   ```
   pscale branch vtctld get-shard <database> <branch> --keyspace <keyspace> --shard -
   ```
   returned:
   ```json
   {
     "keyspace": "<keyspace>",
     "name": "-",
     "key_range": {
       "start": "",
       "end": ""
     },
     "tablet_controls": [],
     "is_primary_serving": true
   }
   ```

2. Created a sharded keyspace with `--shards 2`:
   ```
   pscale keyspace create <database> <branch> sharded-ks --cluster-size PS-10 --shards 2 --wait
   ```

3. `pscale branch vtctld get-shard <database> <branch> --keyspace sharded-ks --shard -80` returned:
   ```json
   {
     "keyspace": "sharded-ks",
     "name": "-80",
     "key_range": {
       "start": "",
       "end": "gA=="
     },
     "tablet_controls": [],
     "is_primary_serving": true
   }
   ```

4. `pscale branch vtctld get-shard <database> <branch> --keyspace sharded-ks --shard 80-` returned:
   ```json
   {
     "keyspace": "sharded-ks",
     "name": "80-",
     "key_range": {
       "start": "gA==",
       "end": ""
     },
     "tablet_controls": [],
     "is_primary_serving": true
   }
   ```

`key_range.start`/`end` are base64-encoded bytes (Vitess protojson encoding); `"gA=="` is byte `0x80`, the split point between the two shards.