### PR TITLE
Add vtctld refresh-state-by-shard command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.171.0
+	github.com/planetscale/planetscale-go v0.174.0
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.171.0 h1:ZBltEV1SANoQDUMc0VVUmGD4urjquZqh/y9XgGxG3Pw=
-github.com/planetscale/planetscale-go v0.171.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.174.0 h1:u7UeL+XApeY2ZvettqecRIoemsVMBptAVV4i+2Dq3AA=
+github.com/planetscale/planetscale-go v0.174.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/vtctld/refresh_state_by_shard.go
+++ b/internal/cmd/branch/vtctld/refresh_state_by_shard.go
@@ -1,0 +1,71 @@
+package vtctld
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// RefreshStateByShardCmd reloads tablet records for all tablets in a shard via vtctld.
+func RefreshStateByShardCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		keyspace string
+		shard    string
+		cells    []string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "refresh-state-by-shard <database> <branch>",
+		Short: "Reload tablet records for all tablets in a shard",
+		Long: "Reload the tablet record for all tablets in a shard via vtctld, " +
+			"optionally limited to the specified cells.",
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			if flags.keyspace == "" {
+				return fmt.Errorf("keyspace is required")
+			}
+			if flags.shard == "" {
+				return fmt.Errorf("shard is required")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(
+				fmt.Sprintf("Refreshing tablet state for %s/%s on %s…",
+					flags.keyspace, flags.shard,
+					progressTarget(ch.Config.Organization, database, branch)))
+			defer end()
+
+			data, err := client.Vtctld.RefreshStateByShard(ctx, &ps.VtctldRefreshStateByShardRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Keyspace:     flags.keyspace,
+				Shard:        flags.shard,
+				Cells:        flags.cells,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+
+			end()
+			return ch.Printer.PrettyPrintJSON(data)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace name")
+	cmd.Flags().StringVar(&flags.shard, "shard", "", "Shard name (e.g. \"-\" for unsharded)")
+	cmd.Flags().StringSliceVar(&flags.cells, "cells", nil, "Cells to refresh (comma-separated)")
+	cmd.MarkFlagRequired("keyspace")
+	cmd.MarkFlagRequired("shard")
+
+	return cmd
+}

--- a/internal/cmd/branch/vtctld/refresh_state_by_shard_test.go
+++ b/internal/cmd/branch/vtctld/refresh_state_by_shard_test.go
@@ -1,0 +1,61 @@
+package vtctld
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+func TestRefreshStateByShard(t *testing.T) {
+	c := qt.New(t)
+
+	org := "my-org"
+	db := "my-db"
+	branch := "my-branch"
+
+	svc := &mock.VtctldService{
+		RefreshStateByShardFn: func(ctx context.Context, req *ps.VtctldRefreshStateByShardRequest) (json.RawMessage, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Keyspace, qt.Equals, "commerce")
+			c.Assert(req.Shard, qt.Equals, "-")
+			c.Assert(req.Cells, qt.DeepEquals, []string{"zone1"})
+			return json.RawMessage(`{}`), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Vtctld: svc,
+			}, nil
+		},
+	}
+
+	cmd := RefreshStateByShardCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	cmd.Flags().Set("keyspace", "commerce")
+	cmd.Flags().Set("shard", "-")
+	cmd.Flags().Set("cells", "zone1")
+
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.RefreshStateByShardFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/branch/vtctld/vtctld.go
+++ b/internal/cmd/branch/vtctld/vtctld.go
@@ -23,6 +23,7 @@ func VtctldCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(GetRoutingRulesCmd(ch))
 	cmd.AddCommand(GetShardCmd(ch))
 	cmd.AddCommand(SetShardTabletControlCmd(ch))
+	cmd.AddCommand(RefreshStateByShardCmd(ch))
 	cmd.AddCommand(ListTabletsCmd(ch))
 	cmd.AddCommand(StartWorkflowCmd(ch))
 	cmd.AddCommand(StopWorkflowCmd(ch))

--- a/internal/mock/vtctld_general.go
+++ b/internal/mock/vtctld_general.go
@@ -23,6 +23,9 @@ type VtctldService struct {
 	SetShardTabletControlFn        func(context.Context, *ps.VtctldSetShardTabletControlRequest) (json.RawMessage, error)
 	SetShardTabletControlFnInvoked bool
 
+	RefreshStateByShardFn        func(context.Context, *ps.VtctldRefreshStateByShardRequest) (json.RawMessage, error)
+	RefreshStateByShardFnInvoked bool
+
 	ListTabletsFn        func(context.Context, *ps.ListBranchTabletsRequest) ([]*ps.TabletGroup, error)
 	ListTabletsFnInvoked bool
 
@@ -68,6 +71,11 @@ func (s *VtctldService) GetShard(ctx context.Context, req *ps.VtctldGetShardRequ
 func (s *VtctldService) SetShardTabletControl(ctx context.Context, req *ps.VtctldSetShardTabletControlRequest) (json.RawMessage, error) {
 	s.SetShardTabletControlFnInvoked = true
 	return s.SetShardTabletControlFn(ctx, req)
+}
+
+func (s *VtctldService) RefreshStateByShard(ctx context.Context, req *ps.VtctldRefreshStateByShardRequest) (json.RawMessage, error) {
+	s.RefreshStateByShardFnInvoked = true
+	return s.RefreshStateByShardFn(ctx, req)
 }
 
 func (s *VtctldService) ListTablets(ctx context.Context, req *ps.ListBranchTabletsRequest) ([]*ps.TabletGroup, error) {


### PR DESCRIPTION
Adds a hidden vtctld command to reload tablet records for all tablets in a shard:

```
pscale branch vtctld refresh-state-by-shard <database> <branch> \
  --keyspace <keyspace> --shard <shard>
```

Optional `--cells` limits refresh to specific cells (comma-separated).

Depends on planetscale/planetscale-go#316.

## Manual testing

Tested end-to-end against a dev Vitess branch (org with `direct_vtctld_access` enabled) with the full stack deployed.

1. `pscale branch vtctld refresh-state-by-shard test-vtctld main --keyspace test-vtctld --shard -` returned `{}`.
2. vtctld pod logs confirmed the command reached the cluster:
   ```
   RefreshTabletsByShard called on shard test-vtctld/-
   Calling RefreshState on tablet aws_useast1a_3-3832652810
   Calling RefreshState on tablet aws_useast1b_3-2825515151
   Calling RefreshState on tablet aws_useast1c_3-3300095745
   ```
   All three tablets in the unsharded shard received `RefreshState` (one per cell).