### PR TITLE
Add query-patterns download branch command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.174.0
+	github.com/planetscale/planetscale-go v0.175.0
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.174.0 h1:u7UeL+XApeY2ZvettqecRIoemsVMBptAVV4i+2Dq3AA=
-github.com/planetscale/planetscale-go v0.174.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.175.0 h1:ATvKI6Aa47bgc5Zu1kYLaMRbRYVk5VAVi1sAUXlunaQ=
+github.com/planetscale/planetscale-go v0.175.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -38,6 +38,7 @@ func BranchCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(LintCmd(ch))
 	cmd.AddCommand(ConnectionsCmd(ch))
 	cmd.AddCommand(ProcesslistCmd(ch))
+	cmd.AddCommand(QueryPatternsCmd(ch))
 	cmd.AddCommand(vtctld.VtctldCmd(ch))
 	cmd.AddCommand(InfraCmd(ch))
 

--- a/internal/cmd/branch/query_patterns.go
+++ b/internal/cmd/branch/query_patterns.go
@@ -1,0 +1,158 @@
+package branch
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+// queryPatternsPollInterval is how often the download command polls the API
+// while a report is generating. It's a variable so tests can shorten it.
+var queryPatternsPollInterval = 2 * time.Second
+
+// QueryPatternsCmd wraps commands for a branch's query patterns reports.
+func QueryPatternsCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "query-patterns <command>",
+		Short: "Download query pattern reports for a branch",
+	}
+
+	cmd.AddCommand(DownloadQueryPatternsCmd(ch))
+
+	return cmd
+}
+
+// QueryPatternsDownload is the result of downloading a query patterns report.
+type QueryPatternsDownload struct {
+	ID    string `header:"id" json:"id"`
+	State string `header:"state" json:"state"`
+	File  string `header:"file" json:"file"`
+}
+
+// DownloadQueryPatternsCmd generates a query patterns report for a branch,
+// waits for it to finish, and downloads the resulting CSV file.
+func DownloadQueryPatternsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		output string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "download <database> <branch>",
+		Short: "Download a CSV report of the query patterns for a branch",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Generating query patterns report for %s in %s...",
+				printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+
+			report, err := client.QueryPatterns.CreateReport(ctx, &ps.CreateQueryPatternsReportRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			})
+			if err != nil {
+				return queryPatternsError(ch, err, database, branch)
+			}
+
+			ticker := time.NewTicker(queryPatternsPollInterval)
+			defer ticker.Stop()
+
+			for report.State == "pending" {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-ticker.C:
+					report, err = client.QueryPatterns.GetReport(ctx, &ps.GetQueryPatternsReportRequest{
+						Organization: ch.Config.Organization,
+						Database:     database,
+						Branch:       branch,
+						Report:       report.PublicID,
+					})
+					if err != nil {
+						return queryPatternsError(ch, err, database, branch)
+					}
+				}
+			}
+
+			if report.State != "completed" {
+				return fmt.Errorf("query patterns report %s for branch %s failed to generate, please try again",
+					printer.BoldBlue(report.PublicID), printer.BoldBlue(branch))
+			}
+
+			path := flags.output
+			if path == "" {
+				path = fmt.Sprintf("query-patterns-%s-%s-%s-%s.csv",
+					ch.Config.Organization, database, branch,
+					time.Now().UTC().Format("20060102T150405Z"))
+			}
+
+			body, err := client.QueryPatterns.DownloadReport(ctx, &ps.DownloadQueryPatternsReportRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Report:       report.PublicID,
+			})
+			if err != nil {
+				return queryPatternsError(ch, err, database, branch)
+			}
+			defer body.Close()
+
+			f, err := os.Create(path)
+			if err != nil {
+				return fmt.Errorf("creating file %s: %w", path, err)
+			}
+
+			_, err = io.Copy(f, body)
+			if closeErr := f.Close(); err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("writing query patterns report to %s: %w", path, err)
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Successfully downloaded query patterns report to %s\n", printer.BoldBlue(path))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(&QueryPatternsDownload{
+				ID:    report.PublicID,
+				State: report.State,
+				File:  path,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.output, "output", "",
+		"Output file for the query patterns report. Defaults to the current directory as query-patterns-<organization>-<database>-<branch>-<timestamp>.csv.")
+
+	return cmd
+}
+
+// queryPatternsError maps a not-found API error to a message explaining both
+// causes: a missing branch, or query insights being disabled for the database.
+func queryPatternsError(ch *cmdutil.Helper, err error, database, branch string) error {
+	switch cmdutil.ErrCode(err) {
+	case ps.ErrNotFound:
+		return fmt.Errorf("branch %s does not exist in database %s (organization: %s) or query insights is not enabled for the database",
+			printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+	default:
+		return cmdutil.HandleError(err)
+	}
+}

--- a/internal/cmd/branch/query_patterns_test.go
+++ b/internal/cmd/branch/query_patterns_test.go
@@ -1,0 +1,147 @@
+package branch
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+)
+
+const queryPatternsCSV = "normalized_sql,query_count\nselect ?,10\n"
+
+func queryPatternsTestHelper(org, baseURL string, format printer.Format, buf *bytes.Buffer) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(buf)
+	p.SetHumanOutput(bytes.NewBuffer(nil))
+
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{AccessToken: "token", Organization: org, BaseURL: baseURL},
+		Client: func() (*ps.Client, error) {
+			return ps.NewClient(ps.WithBaseURL(baseURL), ps.WithAccessToken("token"))
+		},
+	}
+}
+
+func queryPatternsServer(t *testing.T, c *qt.C, showStates []string) *httptest.Server {
+	t.Helper()
+
+	base := "/v1/organizations/my-org/databases/my-db/branches/my-branch/query-patterns"
+	shows := 0
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(base, func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.Header.Get("Authorization"), qt.Equals, "Bearer token")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "report1", "state": "pending"})
+	})
+
+	mux.HandleFunc(base+"/report1", func(w http.ResponseWriter, r *http.Request) {
+		state := showStates[min(shows, len(showStates)-1)]
+		shows++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "report1", "state": state})
+	})
+
+	mux.HandleFunc(base+"/report1/download", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/blob", http.StatusFound)
+	})
+
+	mux.HandleFunc("/blob", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		gz := gzip.NewWriter(w)
+		_, _ = gz.Write([]byte(queryPatternsCSV))
+		_ = gz.Close()
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestBranch_QueryPatternsDownloadCmd(t *testing.T) {
+	c := qt.New(t)
+
+	prevInterval := queryPatternsPollInterval
+	queryPatternsPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { queryPatternsPollInterval = prevInterval })
+
+	server := queryPatternsServer(t, c, []string{"pending", "completed"})
+
+	var buf bytes.Buffer
+	ch := queryPatternsTestHelper("my-org", server.URL, printer.JSON, &buf)
+
+	output := filepath.Join(t.TempDir(), "report.csv")
+
+	cmd := QueryPatternsCmd(ch)
+	cmd.SetArgs([]string{"download", "my-db", "my-branch", "--output", output})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+
+	data, err := os.ReadFile(output)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(data), qt.Equals, queryPatternsCSV)
+
+	c.Assert(buf.String(), qt.JSONEquals, &QueryPatternsDownload{
+		ID:    "report1",
+		State: "completed",
+		File:  output,
+	})
+}
+
+func TestBranch_QueryPatternsDownloadCmd_Failed(t *testing.T) {
+	c := qt.New(t)
+
+	prevInterval := queryPatternsPollInterval
+	queryPatternsPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { queryPatternsPollInterval = prevInterval })
+
+	server := queryPatternsServer(t, c, []string{"failed"})
+
+	var buf bytes.Buffer
+	ch := queryPatternsTestHelper("my-org", server.URL, printer.JSON, &buf)
+
+	cmd := QueryPatternsCmd(ch)
+	cmd.SetArgs([]string{"download", "my-db", "my-branch", "--output", filepath.Join(t.TempDir(), "report.csv")})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "failed to generate")
+}
+
+func TestBranch_QueryPatternsDownloadCmd_NotFound(t *testing.T) {
+	c := qt.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"code":"not_found","message":"Not Found"}`)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	ch := queryPatternsTestHelper("my-org", server.URL, printer.JSON, &buf)
+
+	cmd := QueryPatternsCmd(ch)
+	cmd.SetArgs([]string{"download", "my-db", "my-branch"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "query insights is not enabled")
+}


### PR DESCRIPTION
Create a query pattern report, poll its status until completed, and then download the csv file.

    $ pscale branch query-patterns download <database> <branch> --org <organization>

    Successfully downloaded query patterns report to query-patterns-<organization>-<database>-<main>-20260706T203128Z.csv