### PR TITLE
Add --global-keyspace to branch vtctld move-tables create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/planetscale/planetscale-go v0.177.0
+	github.com/planetscale/planetscale-go v0.178.0
 	github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4
 	github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjL
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e h1:MZ8D+Z3m2vvqGZLvoQfpaGg/j1fNDr4j03s3PRz4rVY=
 github.com/planetscale/noglog v0.2.1-0.20210421230640-bea75fcd2e8e/go.mod h1:hwAsSPQdvPa3WcfKfzTXxtEq/HlqwLjQasfO6QbGo4Q=
-github.com/planetscale/planetscale-go v0.177.0 h1:jVE8uInjGayJ7RLaqwBK7VPgu96U/99dwV2MbbuRywA=
-github.com/planetscale/planetscale-go v0.177.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
+github.com/planetscale/planetscale-go v0.178.0 h1:1a+VwVpvV4eAFaeL1bLCPcnWKItuYTSBfD2s8BN+6To=
+github.com/planetscale/planetscale-go v0.178.0/go.mod h1:paQCI5SgquuoewvMQM7R+r1XJO868bdP6/ihGidYRM0=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4 h1:Xv5pj20Rhfty1Tv0OVcidg4ez4PvGrpKvb6rvUwQgDs=
 github.com/planetscale/psdb v0.0.0-20250717190954-65c6661ab6e4/go.mod h1:M52h5IWxAcbdQ1hSZrLAGQC4ZXslxEsK/Wh9nu3wdWs=
 github.com/planetscale/psdbproxy v0.0.0-20250728082226-3f4ea3a74ec7 h1:aRd6vdE1fyuSI4RVj7oCr8lFmgqXvpnPUmN85VbZCp8=

--- a/internal/cmd/branch/vtctld/move_tables.go
+++ b/internal/cmd/branch/vtctld/move_tables.go
@@ -48,6 +48,7 @@ func MoveTablesCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		deferSecondaryKeys           bool
 		onDDL                        string
 		shardedAutoIncrementHandling string
+		globalKeyspace               string
 		sourceTimeZone               string
 		tenantID                     string
 		cells                        []string
@@ -84,6 +85,7 @@ func MoveTablesCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				Tables:                       flags.tables,
 				OnDDL:                        flags.onDDL,
 				ShardedAutoIncrementHandling: flags.shardedAutoIncrementHandling,
+				GlobalKeyspace:               flags.globalKeyspace,
 				SourceTimeZone:               flags.sourceTimeZone,
 				TenantID:                     flags.tenantID,
 				Cells:                        flags.cells,
@@ -132,6 +134,7 @@ func MoveTablesCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.deferSecondaryKeys, "defer-secondary-keys", true, "Defer secondary keys during the copy phase")
 	cmd.Flags().StringVar(&flags.onDDL, "on-ddl", "", "DDL handling strategy (IGNORE, STOP, EXEC, EXEC_IGNORE)")
 	cmd.Flags().StringVar(&flags.shardedAutoIncrementHandling, "sharded-auto-increment-handling", "", "Auto increment handling for sharded keyspaces")
+	cmd.Flags().StringVar(&flags.globalKeyspace, "global-keyspace", "", "Unsharded keyspace in which to create the backing sequence tables when --sharded-auto-increment-handling is REPLACE")
 	cmd.Flags().StringVar(&flags.sourceTimeZone, "source-time-zone", "", "Source time zone")
 	cmd.Flags().StringVar(&flags.tenantID, "tenant-id", "", "Tenant ID")
 	cmd.Flags().StringSliceVar(&flags.cells, "cells", nil, "Cells to restrict the workflow to (comma-separated)")

--- a/internal/cmd/branch/vtctld/move_tables_test.go
+++ b/internal/cmd/branch/vtctld/move_tables_test.go
@@ -83,6 +83,7 @@ func TestMoveTablesCreate(t *testing.T) {
 			c.Assert(req.TabletTypes, qt.IsNil)
 			c.Assert(req.ExcludeTables, qt.IsNil)
 			c.Assert(req.TenantID, qt.Equals, "")
+			c.Assert(req.GlobalKeyspace, qt.Equals, "")
 			c.Assert(req.AtomicCopy, qt.IsNil)
 			return &ps.VtctldOperationReference{ID: "create-op"}, nil
 		},
@@ -183,6 +184,8 @@ func TestMoveTablesCreateWithAllFlags(t *testing.T) {
 			c.Assert(req.TabletTypes, qt.DeepEquals, []string{"PRIMARY", "REPLICA"})
 			c.Assert(req.ExcludeTables, qt.DeepEquals, []string{"t1", "t2"})
 			c.Assert(req.TenantID, qt.Equals, "tenant-123")
+			c.Assert(req.ShardedAutoIncrementHandling, qt.Equals, "REPLACE")
+			c.Assert(req.GlobalKeyspace, qt.Equals, "global")
 			c.Assert(req.AtomicCopy, qt.IsNotNil)
 			c.Assert(*req.AtomicCopy, qt.IsTrue)
 			c.Assert(req.AllTables, qt.IsNotNil)
@@ -215,6 +218,8 @@ func TestMoveTablesCreateWithAllFlags(t *testing.T) {
 		"--tablet-types", "PRIMARY,REPLICA",
 		"--exclude-tables", "t1,t2",
 		"--tenant-id", "tenant-123",
+		"--sharded-auto-increment-handling", "REPLACE",
+		"--global-keyspace", "global",
 		"--atomic-copy",
 	})
 	err := cmd.Execute()


### PR DESCRIPTION
## Summary

Adds a `--global-keyspace` flag to `pscale branch vtctld move-tables create`, exposing the vtctld MoveTables `Create --global-keyspace` option. With it, `--sharded-auto-increment-handling=REPLACE` can auto-create the backing sequence tables in the given unsharded keyspace at `switch-traffic --initialize-target-sequences` time, instead of requiring the customer to manually declare each `<table>_seq` sequence in an unsharded keyspace's vschema before cutover.

## Dependency

⚠️ Depends on planetscale/planetscale-go#322, which adds `GlobalKeyspace` to `MoveTablesCreateRequest`. This branch will not compile in CI until that PR is merged, released, and `go.mod` here is bumped to a version containing the field (currently pinned to v0.175.0).

## Testing

- Verified locally with a temporary `go.mod` replace pointing at the planetscale-go#322 branch: `go build ./...` clean, `go vet ./...` clean, all `./internal/...` tests pass (the replace is not part of this PR)
- `TestMoveTablesCreate` asserts `GlobalKeyspace` is empty when the flag is not passed
- `TestMoveTablesCreateWithAllFlags` passes `--sharded-auto-increment-handling REPLACE --global-keyspace global` and asserts both reach the request
- `--global-keyspace` renders in `pscale branch vtctld move-tables create --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)