### PR TITLE
Write query patterns to stdout

### DIFF
--- a/internal/cmd/branch/query_patterns.go
+++ b/internal/cmd/branch/query_patterns.go
@@ -49,14 +49,18 @@ func DownloadQueryPatternsCmd(ch *cmdutil.Helper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database, branch := args[0], args[1]
+			toStdout := flags.output == "-"
 
 			client, err := ch.Client()
 			if err != nil {
 				return err
 			}
 
-			end := ch.Printer.PrintProgress(fmt.Sprintf("Generating query patterns report for %s in %s...",
-				printer.BoldBlue(branch), printer.BoldBlue(database)))
+			end := func() {}
+			if !toStdout {
+				end = ch.Printer.PrintProgress(fmt.Sprintf("Generating query patterns report for %s in %s...",
+					printer.BoldBlue(branch), printer.BoldBlue(database)))
+			}
 			defer end()
 
 			report, err := client.QueryPatterns.CreateReport(ctx, &ps.CreateQueryPatternsReportRequest{
@@ -111,6 +115,13 @@ func DownloadQueryPatternsCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			defer body.Close()
 
+			if toStdout {
+				if _, err := io.Copy(cmd.OutOrStdout(), body); err != nil {
+					return fmt.Errorf("writing query patterns report to stdout: %w", err)
+				}
+				return nil
+			}
+
 			f, err := os.Create(path)
 			if err != nil {
 				return fmt.Errorf("creating file %s: %w", path, err)
@@ -140,7 +151,7 @@ func DownloadQueryPatternsCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.output, "output", "",
-		"Output file for the query patterns report. Defaults to the current directory as query-patterns-<organization>-<database>-<branch>-<timestamp>.csv.")
+		"Output file name, or - to write to stdout. Defaults to query-patterns-<organization>-<database>-<branch>-<timestamp>.csv.")
 
 	return cmd
 }

--- a/internal/cmd/branch/query_patterns_test.go
+++ b/internal/cmd/branch/query_patterns_test.go
@@ -105,6 +105,33 @@ func TestBranch_QueryPatternsDownloadCmd(t *testing.T) {
 	})
 }
 
+func TestBranch_QueryPatternsDownloadCmd_Stdout(t *testing.T) {
+	c := qt.New(t)
+
+	prevInterval := queryPatternsPollInterval
+	queryPatternsPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { queryPatternsPollInterval = prevInterval })
+
+	server := queryPatternsServer(t, c, []string{"pending", "completed"})
+
+	var buf bytes.Buffer
+	ch := queryPatternsTestHelper("my-org", server.URL, printer.Human, &buf)
+
+	var humanOut bytes.Buffer
+	ch.Printer.SetHumanOutput(&humanOut)
+
+	var stdout bytes.Buffer
+	cmd := QueryPatternsCmd(ch)
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"download", "my-db", "my-branch", "--output", "-"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout.String(), qt.Equals, queryPatternsCSV)
+	c.Assert(humanOut.String(), qt.Equals, "")
+	c.Assert(buf.String(), qt.Equals, "")
+}
+
 func TestBranch_QueryPatternsDownloadCmd_Failed(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Support `-` as the customary stdout file name in the `--output` flag so the CSV content can be piped into another tool without an intermediate file.