### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,3 +238,12 @@ git clone https://github.com/planetscale/skills.git && cd skills && script/setup
 ```
 
 After installing skills, load `14-pscale-cli-automation` for CLI conventions (or re-run `pscale agent-guide --format json` from any `pscale` binary that includes agent onboarding). Use `00-safe-orchestrator` when the user asks for a full PlanetScale assessment.
+
+## Cursor Cloud specific instructions
+
+This repo is the Go source for the `pscale` CLI (the sections above document how to *use* an installed `pscale`). Go `1.26` (per `go.mod`) is installed at `/usr/local/go`; the update script runs `go mod download` to warm the module cache.
+
+- Build: `go build -o /tmp/pscale ./cmd/pscale` (or `make build` for `go build -trimpath ./...`).
+- Test: `go test ./...` (or `make test`). Vet: `go vet ./...`. `make lint` additionally `go install`s `staticcheck` from the network.
+- A self-compiled binary prints a dev-warning banner on every command; set `PSCALE_DISABLE_DEV_WARNING=true` to silence it.
+- `pscale auth check --format json` and `pscale agent-guide --format json` run without credentials and are good smoke tests; commands that hit the API need `pscale auth login` or a service token.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` for building/testing the `pscale` CLI from source (the existing content documents how to *use* an installed `pscale`):

- Go `1.26` (per `go.mod`) at `/usr/local/go`; the update script warms the module cache with `go mod download`.
- Build (`go build -o /tmp/pscale ./cmd/pscale` / `make build`), test (`go test ./...`), vet (`go vet ./...`).
- Self-compiled binaries print a dev-warning banner; silence with `PSCALE_DISABLE_DEV_WARNING=true`.
- `pscale auth check --format json` / `agent-guide --format json` run without credentials as smoke tests.

## Why

Docs-only change so future cloud agents know how to build/test the CLI source. No code or behavior changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53d097b5-a9da-4c1e-acd9-e6727ad3a489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53d097b5-a9da-4c1e-acd9-e6727ad3a489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

