### PR TITLE
docs: add Cursor Cloud pscale build/install notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,3 +256,24 @@ build entry point is `./cmd/pscale` (`main.version`/`main.commit`/`main.date` ca
 set via `-ldflags` if you want an accurate version string). `pscale auth check
 --format json` reports `NO_AUTH` until a user runs `pscale auth login` — installing
 the CLI does not authenticate it.
+
+### `pscale auth login` hangs on the desktop keyring prompt
+
+`pscale` stores its access token via `99designs/keyring`, preferring the
+SecretService (gnome-keyring) backend. In the Cursor Cloud VM the desktop D-Bus
+secret service is present but locked, so after you approve the device flow the CLI
+**blocks on a "Choose password for new keyring" dialog on the desktop** and never
+finishes writing the token (`auth check` keeps reporting `NO_AUTH`).
+
+Work around it by disabling D-Bus so `pscale` falls back to its plaintext file store
+at `~/.config/planetscale/access-token`. Prefix the login (and every subsequent
+`pscale` command, since reads also open the keyring) with:
+
+```bash
+DBUS_SESSION_BUS_ADDRESS=unix:path=/dev/null pscale auth login --format json
+DBUS_SESSION_BUS_ADDRESS=unix:path=/dev/null pscale auth check --format json
+```
+
+Run `login` non-interactively (e.g. in tmux) and hand the user the `verification_url`
++ `user_code` printed as pending JSON on **stderr**; the final result JSON lands on
+**stdout** once approved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,3 +242,17 @@ git clone https://github.com/planetscale/skills.git && cd skills && script/setup
 ```
 
 After installing skills, load `14-pscale-cli-automation` for CLI conventions (or re-run `pscale agent-guide --format json` from any `pscale` binary that includes agent onboarding). Use `00-safe-orchestrator` when the user asks for a full PlanetScale assessment.
+
+## Cursor Cloud specific instructions
+
+To install/rebuild the `pscale` binary from this repo (Go 1.26 is on `PATH`):
+
+```bash
+go build -trimpath -o /tmp/pscale ./cmd/pscale && sudo mv -f /tmp/pscale /usr/local/bin/pscale
+```
+
+`/usr/local/bin` is already on `PATH`, so `pscale --version` works afterward. The
+build entry point is `./cmd/pscale` (`main.version`/`main.commit`/`main.date` can be
+set via `-ldflags` if you want an accurate version string). `pscale auth check
+--format json` reports `NO_AUTH` until a user runs `pscale auth login` — installing
+the CLI does not authenticate it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering two things discovered while setting up a Cursor Cloud dev environment:

1. **Building/installing `pscale`** from this repo (entry point `./cmd/pscale`, install to `/usr/local/bin/pscale`), and that installing the binary does not authenticate it.
2. **`pscale auth login` hangs on the desktop keyring prompt.** In the Cursor Cloud VM the gnome-keyring SecretService backend is present but locked, so after approving the device flow the CLI blocks on a "Choose password for new keyring" dialog and never writes the token (`auth check` keeps reporting `NO_AUTH`). Documented the workaround: run with `DBUS_SESSION_BUS_ADDRESS=unix:path=/dev/null` so `pscale` falls back to its plaintext file store at `~/.config/planetscale/access-token` (must be applied to reads too, since those also open the keyring).

## Why

Both are non-obvious and cost real time to rediscover. The keyring hang in particular looks like a failed login when it's actually a blocked credential write.

## Notes

- Docs-only change; no code changes.
- `pscale version 0.299.0` builds and runs from this repo with Go 1.26.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73613c51-5b7f-4ee0-ba69-08f8c45b1c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73613c51-5b7f-4ee0-ba69-08f8c45b1c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

