### PR TITLE
fix(release): darwin/amd64 binaries abort on macOS 26

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,9 @@ builds:
       - CC=o64-clang
       - CXX=o64-clang++
       - CGO_ENABLED=1
+      # ld64 only sets SG_READ_ONLY on __DATA_CONST when targeting >= 10.15;
+      # macOS 26 dyld refuses to load binaries without it. Go requires 11+ anyway.
+      - MACOSX_DEPLOYMENT_TARGET=11.0
     main: ./cmd/pscale/main.go
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
@@ -31,6 +34,7 @@ builds:
       - CC=oa64-clang
       - CXX=oa64-clang++
       - CGO_ENABLED=1
+      - MACOSX_DEPLOYMENT_TARGET=11.0
     main: ./cmd/pscale/main.go
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}


### PR DESCRIPTION
## Problem

`pscale` crashes at launch on macOS 26:

```
dyld[66420]: __DATA_CONST segment missing SG_READ_ONLY flag
zsh: abort      pscale --version
```

macOS 26 dyld requires the `SG_READ_ONLY` flag on the `__DATA_CONST` segment. The darwin/amd64 release binaries don't have it: osxcross defaults to a 10.9 deployment target, and ld64 only sets the flag when targeting macOS 10.15+. All amd64 release binaries are affected (including under Rosetta on Apple Silicon, e.g. via Intel Homebrew). The arm64 binaries already target 11.0 and are unaffected.

## Solution

Set `MACOSX_DEPLOYMENT_TARGET=11.0` for the darwin builds — amd64 is the fix; arm64 already targets 11.0 and the env line just makes that explicit. Go itself requires macOS 11+ since Go 1.23, so no supported platform is dropped.

Verified by snapshot-building both darwin targets in the release image and checking the Mach-O segment flags: `__DATA_CONST` now carries `SG_READ_ONLY` (`0x10`) and `minos=11.0` on both arches.