### PR TITLE
Update password/branch pagination

### DIFF
--- a/internal/cmd/branch/list.go
+++ b/internal/cmd/branch/list.go
@@ -13,6 +13,11 @@ import (
 
 // ListCmd encapsulates the command for listing branches for a database.
 func ListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
 	cmd := &cobra.Command{
 		Use:     "list <database>",
 		Short:   "List all branches of a database",
@@ -65,89 +70,69 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			if db.Kind == "mysql" {
-				var allBranches []*planetscale.DatabaseBranch
-				page := 1
-				perPage := 100
-
-				for {
-					branches, err := client.DatabaseBranches.List(ctx, &planetscale.ListDatabaseBranchesRequest{
-						Organization: ch.Config.Organization,
-						Database:     database,
-					}, planetscale.WithPage(page), planetscale.WithPerPage(perPage))
-					if err != nil {
-						switch cmdutil.ErrCode(err) {
-						case planetscale.ErrNotFound:
-							return cmdutil.HandleNotFoundWithServiceTokenCheck(
-								ctx, cmd, ch.Config, ch.Client, err, "read_branch",
-								"database %s does not exist in organization %s",
-								printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-						default:
-							return cmdutil.HandleError(err)
-						}
+				branches, err := client.DatabaseBranches.List(ctx, &planetscale.ListDatabaseBranchesRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+				}, planetscale.WithPage(flags.page), planetscale.WithPerPage(flags.perPage))
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case planetscale.ErrNotFound:
+						return cmdutil.HandleNotFoundWithServiceTokenCheck(
+							ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+							"database %s does not exist in organization %s",
+							printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+					default:
+						return cmdutil.HandleError(err)
 					}
-
-					allBranches = append(allBranches, branches...)
-
-					// Check if there are more pages - if we got fewer results than perPage, we're done
-					if len(branches) < perPage {
-						break
-					}
-					page++
 				}
 
-				branches := allBranches
 				end()
 
 				if len(branches) == 0 && ch.Printer.Format() == printer.Human {
-					ch.Printer.Printf("No branches exist in %s.\n", printer.BoldBlue(database))
+					if flags.page == 0 {
+						ch.Printer.Printf("No branches exist in %s.\n", printer.BoldBlue(database))
+					} else {
+						ch.Printer.Println("No branches found on this page.")
+					}
 					return nil
 				}
 
 				return ch.Printer.PrintResource(toDatabaseBranches(branches))
-			} else {
-				var allBranches []*planetscale.PostgresBranch
-				page := 1
-				perPage := 100
-
-				for {
-					branches, err := client.PostgresBranches.List(ctx, &planetscale.ListPostgresBranchesRequest{
-						Organization: ch.Config.Organization,
-						Database:     database,
-					}, planetscale.WithPage(page), planetscale.WithPerPage(perPage))
-					if err != nil {
-						switch cmdutil.ErrCode(err) {
-						case planetscale.ErrNotFound:
-							return cmdutil.HandleNotFoundWithServiceTokenCheck(
-								ctx, cmd, ch.Config, ch.Client, err, "read_branch",
-								"database %s does not exist in organization %s",
-								printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-						default:
-							return cmdutil.HandleError(err)
-						}
-					}
-
-					allBranches = append(allBranches, branches...)
-
-					// Check if there are more pages - if we got fewer results than perPage, we're done
-					if len(branches) < perPage {
-						break
-					}
-					page++
-				}
-
-				branches := allBranches
-				end()
-
-				if len(branches) == 0 && ch.Printer.Format() == printer.Human {
-					ch.Printer.Printf("No branches exist in %s.\n", printer.BoldBlue(database))
-					return nil
-				}
-
-				return ch.Printer.PrintResource(toPostgresBranches(branches))
 			}
+
+			branches, err := client.PostgresBranches.List(ctx, &planetscale.ListPostgresBranchesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			}, planetscale.WithPage(flags.page), planetscale.WithPerPage(flags.perPage))
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+						"database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if len(branches) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page == 0 {
+					ch.Printer.Printf("No branches exist in %s.\n", printer.BoldBlue(database))
+				} else {
+					ch.Printer.Println("No branches found on this page.")
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toPostgresBranches(branches))
 		},
 	}
 
 	cmd.Flags().BoolP("web", "w", false, "List branches in your web browser.")
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
 	return cmd
 }

--- a/internal/cmd/branch/list_test.go
+++ b/internal/cmd/branch/list_test.go
@@ -3,6 +3,7 @@ package branch
 import (
 	"bytes"
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -13,6 +14,14 @@ import (
 	qt "github.com/frankban/quicktest"
 	ps "github.com/planetscale/cli/internal/planetscale"
 )
+
+func listQueryParam(opts []ps.ListOption, key string) string {
+	lo := &ps.ListOptions{URLValues: &url.Values{}}
+	for _, opt := range opts {
+		_ = opt(lo)
+	}
+	return lo.URLValues.Get(key)
+}
 
 func TestBranch_ListCmd(t *testing.T) {
 	c := qt.New(t)
@@ -35,6 +44,8 @@ func TestBranch_ListCmd(t *testing.T) {
 		ListFn: func(ctx context.Context, req *ps.ListDatabaseBranchesRequest, opts ...ps.ListOption) ([]*ps.DatabaseBranch, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "100")
+			c.Assert(listQueryParam(opts, "page"), qt.Equals, "")
 
 			return branches, nil
 		},
@@ -151,6 +162,8 @@ func TestBranch_ListCmd_PostgreSQL(t *testing.T) {
 		ListFn: func(ctx context.Context, req *ps.ListPostgresBranchesRequest, opts ...ps.ListOption) ([]*ps.PostgresBranch, error) {
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "100")
+			c.Assert(listQueryParam(opts, "page"), qt.Equals, "")
 
 			return branches, nil
 		},

--- a/internal/cmd/password/delete.go
+++ b/internal/cmd/password/delete.go
@@ -48,8 +48,7 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 				end := ch.Printer.PrintProgress(fmt.Sprintf("Finding password %s in %s/%s",
 					printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
 
-				// Fetch all passwords to find the one with matching name
-				var allPasswords []*ps.DatabaseBranchPassword
+				var foundPassword *ps.DatabaseBranchPassword
 				page := 1
 				perPage := 100
 
@@ -70,25 +69,20 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 						}
 					}
 
-					allPasswords = append(allPasswords, passwords...)
+					for _, password := range passwords {
+						if password.Name == name {
+							foundPassword = password
+							break
+						}
+					}
 
-					// Check if there are more pages
-					if len(passwords) < perPage {
+					if foundPassword != nil || len(passwords) < perPage {
 						break
 					}
 					page++
 				}
 
 				end()
-
-				// Find password with matching name
-				var foundPassword *ps.DatabaseBranchPassword
-				for _, password := range allPasswords {
-					if password.Name == name {
-						foundPassword = password
-						break
-					}
-				}
 
 				if foundPassword == nil {
 					return fmt.Errorf("password with name %s does not exist in branch %s of %s (organization: %s)",

--- a/internal/cmd/password/delete_test.go
+++ b/internal/cmd/password/delete_test.go
@@ -181,3 +181,67 @@ func TestPassword_DeleteCmdByNameNotFound(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `password with name nonexistent-password does not exist.*`)
 	c.Assert(svc.ListFnInvoked, qt.IsTrue)
 }
+
+func TestPassword_DeleteCmdByNameEarlyExit(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	passwordName := "target-password"
+	passwordId := "password123"
+
+	listCalls := 0
+	svc := &mock.PasswordsService{
+		ListFn: func(ctx context.Context, req *ps.ListDatabaseBranchPasswordRequest, opts ...ps.ListOption) ([]*ps.DatabaseBranchPassword, error) {
+			listCalls++
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+
+			if listCalls == 1 {
+				c.Assert(listQueryParam(opts, "page"), qt.Equals, "1")
+				page := make([]*ps.DatabaseBranchPassword, 100)
+				for i := range page {
+					page[i] = &ps.DatabaseBranchPassword{
+						PublicID: "other",
+						Name:     "filler",
+					}
+				}
+				return page, nil
+			}
+
+			c.Assert(listQueryParam(opts, "page"), qt.Equals, "2")
+			return []*ps.DatabaseBranchPassword{
+				{PublicID: passwordId, Name: passwordName},
+			}, nil
+		},
+		DeleteFn: func(ctx context.Context, req *ps.DeleteDatabaseBranchPasswordRequest) error {
+			c.Assert(req.PasswordId, qt.Equals, passwordId)
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := DeleteCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--name", passwordName, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(listCalls, qt.Equals, 2)
+	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/password/list.go
+++ b/internal/cmd/password/list.go
@@ -13,6 +13,11 @@ import (
 
 // ListCmd encapsulates the command for listing passwords for a branch.
 func ListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
 	cmd := &cobra.Command{
 		Use:     "list <database> [branch]",
 		Short:   "List all passwords of a database",
@@ -52,40 +57,29 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching passwords for %s", forMsg))
 			defer end()
 
-			var allPasswords []*planetscale.DatabaseBranchPassword
-			page := 1
-			perPage := 100
-
-			for {
-				passwords, err := client.Passwords.List(ctx, &planetscale.ListDatabaseBranchPasswordRequest{
-					Organization: ch.Config.Organization,
-					Database:     database,
-					Branch:       branch,
-				}, planetscale.WithPage(page), planetscale.WithPerPage(perPage))
-				if err != nil {
-					switch cmdutil.ErrCode(err) {
-					case planetscale.ErrNotFound:
-						return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
-							printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-					default:
-						return cmdutil.HandleError(err)
-					}
+			passwords, err := client.Passwords.List(ctx, &planetscale.ListDatabaseBranchPasswordRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}, planetscale.WithPage(flags.page), planetscale.WithPerPage(flags.perPage))
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
 				}
-
-				allPasswords = append(allPasswords, passwords...)
-
-				// Check if there are more pages - if we got fewer results than perPage, we're done
-				if len(passwords) < perPage {
-					break
-				}
-				page++
 			}
 
-			passwords := allPasswords
 			end()
 
 			if len(passwords) == 0 && ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("No passwords exist in %s.\n", forMsg)
+				if flags.page == 0 {
+					ch.Printer.Printf("No passwords exist in %s.\n", forMsg)
+				} else {
+					ch.Printer.Println("No passwords found on this page.")
+				}
 				return nil
 			}
 
@@ -100,5 +94,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("web", "w", false, "List passwords in your web browser.")
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
 	return cmd
 }

--- a/internal/cmd/password/list_test.go
+++ b/internal/cmd/password/list_test.go
@@ -3,6 +3,7 @@ package password
 import (
 	"bytes"
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -13,6 +14,14 @@ import (
 
 	qt "github.com/frankban/quicktest"
 )
+
+func listQueryParam(opts []ps.ListOption, key string) string {
+	lo := &ps.ListOptions{URLValues: &url.Values{}}
+	for _, opt := range opts {
+		_ = opt(lo)
+	}
+	return lo.URLValues.Get(key)
+}
 
 func TestPassword_ListCmd(t *testing.T) {
 	c := qt.New(t)
@@ -36,6 +45,8 @@ func TestPassword_ListCmd(t *testing.T) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "100")
+			c.Assert(listQueryParam(opts, "page"), qt.Equals, "")
 
 			return resp, nil
 		},
@@ -72,4 +83,47 @@ func TestPassword_ListCmd(t *testing.T) {
 	}
 
 	c.Assert(buf.String(), qt.JSONEquals, passwords)
+}
+
+func TestPassword_ListCmdPagination(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	resp := []*ps.DatabaseBranchPassword{{Name: "foo"}}
+
+	listCalls := 0
+	svc := &mock.PasswordsService{
+		ListFn: func(ctx context.Context, req *ps.ListDatabaseBranchPasswordRequest, opts ...ps.ListOption) ([]*ps.DatabaseBranchPassword, error) {
+			listCalls++
+			c.Assert(listQueryParam(opts, "page"), qt.Equals, "2")
+			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "50")
+			return resp, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--page", "2", "--per-page", "50"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(listCalls, qt.Equals, 1)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
 }

--- a/internal/cmd/role/list.go
+++ b/internal/cmd/role/list.go
@@ -13,6 +13,11 @@ import (
 
 // ListCmd encapsulates the command for listing roles for a branch.
 func ListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
 	cmd := &cobra.Command{
 		Use:     "list <database> <branch>",
 		Short:   "List all roles for a Postgres database branch",
@@ -47,43 +52,32 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching roles for %s", forMsg))
 			defer end()
 
-			var allRoles []*ps.PostgresRole
-			page := 1
-			perPage := 100
-
-			for {
-				roles, err := client.PostgresRoles.List(ctx, &ps.ListPostgresRolesRequest{
-					Organization: ch.Config.Organization,
-					Database:     database,
-					Branch:       branch,
-				}, ps.WithPage(page), ps.WithPerPage(perPage))
-				if err != nil {
-					switch cmdutil.ErrCode(err) {
-					case ps.ErrNotFound:
-						return cmdutil.HandleNotFoundWithServiceTokenCheck(
-							ctx, cmd, ch.Config, ch.Client, err,
-							"read_branch",
-							"database %s or branch %s does not exist in organization %s",
-							printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
-					default:
-						return cmdutil.HandleError(err)
-					}
+			roles, err := client.PostgresRoles.List(ctx, &ps.ListPostgresRolesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"read_branch",
+						"database %s or branch %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
 				}
-
-				allRoles = append(allRoles, roles...)
-
-				// Check if there are more pages - if we got fewer results than perPage, we're done
-				if len(roles) < perPage {
-					break
-				}
-				page++
 			}
 
-			roles := allRoles
 			end()
 
 			if len(roles) == 0 && ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("No roles exist in %s.\n", forMsg)
+				if flags.page == 0 {
+					ch.Printer.Printf("No roles exist in %s.\n", forMsg)
+				} else {
+					ch.Printer.Println("No roles found on this page.")
+				}
 				return nil
 			}
 
@@ -92,6 +86,8 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("web", "w", false, "List roles in your web browser.")
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
 	return cmd
 }
 

--- a/internal/cmd/role/list_test.go
+++ b/internal/cmd/role/list_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
 	"github.com/planetscale/cli/internal/printer"
-	ps "github.com/planetscale/planetscale-go/planetscale"
+	ps "github.com/planetscale/cli/internal/planetscale"
 
 	qt "github.com/frankban/quicktest"
 )

--- a/internal/cmd/role/list_test.go
+++ b/internal/cmd/role/list_test.go
@@ -1,0 +1,73 @@
+package role
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func listQueryParam(opts []ps.ListOption, key string) string {
+	lo := &ps.ListOptions{URLValues: &url.Values{}}
+	for _, opt := range opts {
+		_ = opt(lo)
+	}
+	return lo.URLValues.Get(key)
+}
+
+func TestRole_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	roles := []*ps.PostgresRole{
+		{Name: "reader"},
+		{Name: "writer"},
+	}
+
+	listCalls := 0
+	svc := &mock.PostgresRolesService{
+		ListFn: func(ctx context.Context, req *ps.ListPostgresRolesRequest, opts ...ps.ListOption) ([]*ps.PostgresRole, error) {
+			listCalls++
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "100")
+			c.Assert(listQueryParam(opts, "page"), qt.Equals, "")
+			return roles, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{PostgresRoles: svc}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(listCalls, qt.Equals, 1)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/role/list_test.go
+++ b/internal/cmd/role/list_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
 	"github.com/planetscale/cli/internal/mock"
-	"github.com/planetscale/cli/internal/printer"
 	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
 
 	qt "github.com/frankban/quicktest"
 )


### PR DESCRIPTION
For dbs with huge numbers of passwords, iterating until done is highly inefficient.

Adding pagination params and setting default size to 100 results, which covers most databases.