### PR TITLE
Use root API URL for auth check

### DIFF
--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -11,7 +11,6 @@ import (
 func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 	var clientID string
 	var clientSecret string
-	var apiURL string
 
 	cmd := &cobra.Command{
 		Use:   "check",
@@ -52,6 +51,5 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().StringVar(&clientID, "client-id", psauth.OAuthClientID, "The client ID for the PlanetScale CLI application.")
 	cmd.Flags().StringVar(&clientSecret, "client-secret", psauth.OAuthClientSecret, "The client ID for the PlanetScale CLI application")
-	cmd.Flags().StringVar(&apiURL, "api-url", psauth.DefaultBaseURL, "The PlanetScale base API URL.")
 	return cmd
 }

--- a/internal/cmd/auth/check_test.go
+++ b/internal/cmd/auth/check_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
+	ps "github.com/planetscale/cli/internal/planetscale"
 	"github.com/planetscale/cli/internal/printer"
-	ps "github.com/planetscale/planetscale-go/planetscale"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/auth/check_test.go
+++ b/internal/cmd/auth/check_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/printer"
+	ps "github.com/planetscale/planetscale-go/planetscale"
+	"github.com/spf13/cobra"
+)
+
+func TestCheckCmdDoesNotShadowAPIURLFlag(t *testing.T) {
+	cmd := CheckCmd(&cmdutil.Helper{})
+	if cmd.Flags().Lookup("api-url") != nil {
+		t.Fatal("auth check must not define a local --api-url flag")
+	}
+}
+
+func TestCheckCmdUsesRootPersistentAPIURL(t *testing.T) {
+	const customURL = "https://api.custom.example/v1"
+
+	format := printer.JSON
+	var out bytes.Buffer
+	cfg := &config.Config{BaseURL: ps.DefaultBaseURL}
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  cfg,
+		Client: func() (*ps.Client, error) {
+			return cfg.NewClientFromConfig()
+		},
+	}
+	ch.Printer.SetResourceOutput(&out)
+
+	root := &cobra.Command{Use: "pscale", SilenceErrors: true, SilenceUsage: true}
+	root.PersistentFlags().StringVar(&cfg.BaseURL, "api-url", ps.DefaultBaseURL, "The base URL for the PlanetScale API.")
+	root.PersistentFlags().VarP(printer.NewFormatValue(printer.Human, &format), "format", "f", "output format")
+	root.AddCommand(AuthCmd(ch))
+	root.SetArgs([]string{"--api-url", customURL, "--format", "json", "auth", "check"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected exit error for unauthenticated auth check")
+	}
+	var cmdErr *cmdutil.Error
+	if !errors.As(err, &cmdErr) || !cmdErr.Handled {
+		t.Fatalf("expected handled JSON exit error, got %v", err)
+	}
+
+	var resp AuthCheckResponse
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("stdout json: %v, out=%q", err, out.String())
+	}
+	if resp.APIURL != customURL {
+		t.Fatalf("api_url = %q, want %q", resp.APIURL, customURL)
+	}
+}


### PR DESCRIPTION
**Problem:**

`auth check` redeclared `--api-url` into an unused local variable. That shadowed the root flag bound to `Config.BaseURL`, so credential validation could use a different API than the caller requested.

**Solution:**

Remove the command-local flag and inherit the root persistent `--api-url`.

_Security impact:_ None.

_Testing:_

```text
$ go test ./... -count=1
ok
```