### PR TITLE
Support name and status password filters

### DIFF
--- a/internal/cmd/password/list.go
+++ b/internal/cmd/password/list.go
@@ -16,6 +16,8 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		page    int
 		perPage int
+		name    string
+		status  string
 	}
 
 	cmd := &cobra.Command{
@@ -61,7 +63,12 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 				Organization: ch.Config.Organization,
 				Database:     database,
 				Branch:       branch,
-			}, planetscale.WithPage(flags.page), planetscale.WithPerPage(flags.perPage))
+			},
+				planetscale.WithSearch(flags.name),
+				planetscale.WithStatus(flags.status),
+				planetscale.WithPage(flags.page),
+				planetscale.WithPerPage(flags.perPage),
+			)
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case planetscale.ErrNotFound:
@@ -75,10 +82,12 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if len(passwords) == 0 && ch.Printer.Format() == printer.Human {
-				if flags.page == 0 {
-					ch.Printer.Printf("No passwords exist in %s.\n", forMsg)
-				} else {
+				if flags.page > 0 {
 					ch.Printer.Println("No passwords found on this page.")
+				} else if flags.name != "" || flags.status != "" {
+					ch.Printer.Printf("No passwords in %s match the specified filters.\n", forMsg)
+				} else {
+					ch.Printer.Printf("No passwords exist in %s.\n", forMsg)
 				}
 				return nil
 			}
@@ -94,7 +103,12 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("web", "w", false, "List passwords in your web browser.")
+	cmd.Flags().StringVar(&flags.name, "name", "", "Filter passwords by name using a substring match")
+	cmd.Flags().StringVar(&flags.status, "status", "", "Filter passwords by status (active, renewable, or expired)")
 	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
 	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	cmd.RegisterFlagCompletionFunc("status", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"active", "renewable", "expired"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
 }

--- a/internal/cmd/password/list_test.go
+++ b/internal/cmd/password/list_test.go
@@ -45,6 +45,8 @@ func TestPassword_ListCmd(t *testing.T) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(listQueryParam(opts, "q"), qt.Equals, "production")
+			c.Assert(listQueryParam(opts, "status"), qt.Equals, "renewable")
 			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "100")
 			c.Assert(listQueryParam(opts, "page"), qt.Equals, "")
 
@@ -65,7 +67,7 @@ func TestPassword_ListCmd(t *testing.T) {
 	}
 
 	cmd := ListCmd(ch)
-	cmd.SetArgs([]string{db, branch})
+	cmd.SetArgs([]string{db, branch, "--name", "production", "--status", "renewable"})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
@@ -126,4 +128,35 @@ func TestPassword_ListCmdPagination(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(listCalls, qt.Equals, 1)
 	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestPassword_ListCmdFilteredEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	svc := &mock.PasswordsService{
+		ListFn: func(context.Context, *ps.ListDatabaseBranchPasswordRequest, ...ps.ListOption) ([]*ps.DatabaseBranchPassword, error) {
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "--name", "production"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "match the specified filters")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "No passwords exist")
 }

--- a/internal/cmd/role/list.go
+++ b/internal/cmd/role/list.go
@@ -16,6 +16,8 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		page    int
 		perPage int
+		name    string
+		status  string
 	}
 
 	cmd := &cobra.Command{
@@ -56,7 +58,12 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 				Organization: ch.Config.Organization,
 				Database:     database,
 				Branch:       branch,
-			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			},
+				ps.WithSearch(flags.name),
+				ps.WithStatus(flags.status),
+				ps.WithPage(flags.page),
+				ps.WithPerPage(flags.perPage),
+			)
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
@@ -73,10 +80,12 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if len(roles) == 0 && ch.Printer.Format() == printer.Human {
-				if flags.page == 0 {
-					ch.Printer.Printf("No roles exist in %s.\n", forMsg)
-				} else {
+				if flags.page > 0 {
 					ch.Printer.Println("No roles found on this page.")
+				} else if flags.name != "" || flags.status != "" {
+					ch.Printer.Printf("No roles in %s match the specified filters.\n", forMsg)
+				} else {
+					ch.Printer.Printf("No roles exist in %s.\n", forMsg)
 				}
 				return nil
 			}
@@ -86,8 +95,13 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("web", "w", false, "List roles in your web browser.")
+	cmd.Flags().StringVar(&flags.name, "name", "", "Filter roles by name using a substring match")
+	cmd.Flags().StringVar(&flags.status, "status", "", "Filter roles by status (active, renewable, disabled, or expired)")
 	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
 	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	cmd.RegisterFlagCompletionFunc("status", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"active", "renewable", "disabled", "expired"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	return cmd
 }
 

--- a/internal/cmd/role/list_test.go
+++ b/internal/cmd/role/list_test.go
@@ -47,6 +47,8 @@ func TestRole_ListCmd(t *testing.T) {
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.Database, qt.Equals, db)
 			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(listQueryParam(opts, "q"), qt.Equals, "analytics")
+			c.Assert(listQueryParam(opts, "status"), qt.Equals, "disabled")
 			c.Assert(listQueryParam(opts, "per_page"), qt.Equals, "100")
 			c.Assert(listQueryParam(opts, "page"), qt.Equals, "")
 			return roles, nil
@@ -64,10 +66,41 @@ func TestRole_ListCmd(t *testing.T) {
 	}
 
 	cmd := ListCmd(ch)
-	cmd.SetArgs([]string{db, branch})
+	cmd.SetArgs([]string{db, branch, "--name", "analytics", "--status", "disabled"})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(listCalls, qt.Equals, 1)
 	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestRole_ListCmdFilteredEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+
+	svc := &mock.PostgresRolesService{
+		ListFn: func(context.Context, *ps.ListPostgresRolesRequest, ...ps.ListOption) ([]*ps.PostgresRole, error) {
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{PostgresRoles: svc}, nil
+		},
+	}
+
+	cmd := ListCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "--status", "expired"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "match the specified filters")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "No roles exist")
 }

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -148,6 +148,26 @@ func WithRegion(region string) ListOption {
 	}
 }
 
+// WithSearch returns a ListOption that sets the "q" URL parameter.
+func WithSearch(search string) ListOption {
+	return func(opt *ListOptions) error {
+		if search != "" {
+			opt.URLValues.Set("q", search)
+		}
+		return nil
+	}
+}
+
+// WithStatus returns a ListOption that sets the "status" URL parameter.
+func WithStatus(status string) ListOption {
+	return func(opt *ListOptions) error {
+		if status != "" {
+			opt.URLValues.Set("status", status)
+		}
+		return nil
+	}
+}
+
 // WithPage returns a ListOption that sets the "page" URL parameter.
 func WithPage(page int) ListOption {
 	return func(opt *ListOptions) error {

--- a/internal/planetscale/passwords_test.go
+++ b/internal/planetscale/passwords_test.go
@@ -273,6 +273,28 @@ func TestPasswords_ListWithPagination(t *testing.T) {
 	c.Assert(passwords, qt.DeepEquals, want)
 }
 
+func TestPasswords_ListWithFilters(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Query().Get("q"), qt.Equals, "production")
+		c.Assert(r.URL.Query().Get("status"), qt.Equals, "renewable")
+		_, err := w.Write([]byte(`{"data":[]}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.Passwords.List(context.Background(), &ListDatabaseBranchPasswordRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+	}, WithSearch("production"), WithStatus("renewable"))
+	c.Assert(err, qt.IsNil)
+}
+
 func TestPasswords_Get(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/planetscale/postgres_roles_test.go
+++ b/internal/planetscale/postgres_roles_test.go
@@ -204,6 +204,28 @@ func TestPostgresRoles_ListWithPagination(t *testing.T) {
 	c.Assert(roles, qt.DeepEquals, want)
 }
 
+func TestPostgresRoles_ListWithFilters(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Query().Get("q"), qt.Equals, "analytics")
+		c.Assert(r.URL.Query().Get("status"), qt.Equals, "disabled")
+		_, err := w.Write([]byte(`{"data":[]}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	_, err = client.PostgresRoles.List(context.Background(), &ListPostgresRolesRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+	}, WithSearch("analytics"), WithStatus("disabled"))
+	c.Assert(err, qt.IsNil)
+}
+
 func TestPostgresRoles_Get(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Filter roles and passwords by a name substring match and status.

```
$ pscale password list <database> <branch> --name prod --status active

$ pscale role list <database> <branch> --name prod --status active
```