### PR TITLE
Fix Windows command injection when opening auth login URL

### DIFF
--- a/internal/cmdutil/browser.go
+++ b/internal/cmdutil/browser.go
@@ -1,6 +1,8 @@
 package cmdutil
 
 import (
+	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -9,30 +11,70 @@ import (
 
 const ApplicationURL = "https://app.planetscale.com"
 
-func browserCommand(goos, url string) *exec.Cmd {
+// validateBrowserURL rejects URLs that are unsafe to pass to an OS opener.
+// Only http(s) is allowed, and a leading '-' is rejected so open/xdg-open
+// cannot treat the value as a command-line flag.
+func validateBrowserURL(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("URL must not be empty")
+	}
+	if strings.HasPrefix(raw, "-") {
+		return fmt.Errorf("URL must not start with '-'")
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("unsupported URL scheme %q (want http or https)", u.Scheme)
+	}
+
+	if u.Host == "" {
+		return fmt.Errorf("URL must include a host")
+	}
+
+	return nil
+}
+
+func browserCommand(goos, rawURL string) (*exec.Cmd, error) {
+	if err := validateBrowserURL(rawURL); err != nil {
+		return nil, err
+	}
+
 	exe := "open"
 	var args []string
 	switch goos {
 	case "darwin":
-		args = append(args, url)
+		args = append(args, rawURL)
 	case "windows":
-		exe, _ = exec.LookPath("cmd")
-		r := strings.NewReplacer("&", "^&")
-		args = append(args, "/c", "start", r.Replace(url))
+		// Prefer rundll32 over `cmd /c start` so the URL is not re-parsed by
+		// cmd.exe (which would honor metacharacters like | < > ^).
+		exe = "rundll32"
+		args = append(args, "url.dll,FileProtocolHandler", rawURL)
 	default:
 		exe = linuxExe()
-		args = append(args, url)
+		args = append(args, rawURL)
 	}
 
 	cmd := exec.Command(exe, args...)
 	cmd.Stderr = os.Stderr
-	return cmd
+	return cmd, nil
 }
 
 // TryOpenBrowser opens the default web browser at url. It does not require a TTY.
 // Callers should print the URL when this returns an error (headless CI, SSH, etc.).
+// Only http and https URLs are opened; other schemes and values starting with '-'
+// are rejected.
 func TryOpenBrowser(goos, url string) error {
-	return browserCommand(goos, url).Run()
+	cmd, err := browserCommand(goos, url)
+	if err != nil {
+		return err
+	}
+	return cmd.Run()
 }
 
 func linuxExe() string {

--- a/internal/cmdutil/browser_test.go
+++ b/internal/cmdutil/browser_test.go
@@ -1,0 +1,102 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBrowserURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{name: "https", url: "https://auth.planetscale.com/device?user_code=ABC"},
+		{name: "http", url: "http://example.com/device"},
+		{name: "https uppercase scheme", url: "HTTPS://example.com/ok"},
+		{name: "empty", url: "", wantErr: "must not be empty"},
+		{name: "leading dash", url: "-https://example.com", wantErr: "must not start with '-'"},
+		{name: "file scheme", url: "file:///etc/passwd", wantErr: "unsupported URL scheme"},
+		{name: "javascript scheme", url: "javascript:alert(1)", wantErr: "unsupported URL scheme"},
+		{name: "missing scheme", url: "example.com/path", wantErr: "unsupported URL scheme"},
+		{name: "missing host", url: "https:///path", wantErr: "must include a host"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateBrowserURL(tt.url)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateBrowserURL(%q) = %v, want nil", tt.url, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateBrowserURL(%q) = nil, want error containing %q", tt.url, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateBrowserURL(%q) = %v, want error containing %q", tt.url, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBrowserCommandWindowsUsesRundll32(t *testing.T) {
+	t.Parallel()
+
+	// PoC-style URL with cmd.exe metacharacters. Must not go through `cmd /c start`.
+	rawURL := "https://example.com/device?user_code=ABC&x=1|calc.exe"
+	cmd, err := browserCommand("windows", rawURL)
+	if err != nil {
+		t.Fatalf("browserCommand: %v", err)
+	}
+	if cmd.Args[0] != "rundll32" {
+		t.Fatalf("Args[0] = %q, want rundll32", cmd.Args[0])
+	}
+	wantArgs := []string{"rundll32", "url.dll,FileProtocolHandler", rawURL}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("Args = %#v, want %#v", cmd.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if cmd.Args[i] != want {
+			t.Fatalf("Args[%d] = %q, want %q", i, cmd.Args[i], want)
+		}
+	}
+}
+
+func TestBrowserCommandDarwinAndLinuxPassURLArg(t *testing.T) {
+	t.Parallel()
+
+	rawURL := "https://example.com/login"
+	for _, goos := range []string{"darwin", "linux"} {
+		cmd, err := browserCommand(goos, rawURL)
+		if err != nil {
+			t.Fatalf("%s: %v", goos, err)
+		}
+		if len(cmd.Args) < 2 || cmd.Args[len(cmd.Args)-1] != rawURL {
+			t.Fatalf("%s Args = %#v, want trailing %q", goos, cmd.Args, rawURL)
+		}
+	}
+}
+
+func TestTryOpenBrowserRejectsUnsafeURL(t *testing.T) {
+	t.Parallel()
+
+	err := TryOpenBrowser("linux", "file:///tmp/x")
+	if err == nil {
+		t.Fatal("TryOpenBrowser(file:) = nil, want error")
+	}
+
+	err = TryOpenBrowser("windows", "javascript:alert(1)")
+	if err == nil {
+		t.Fatal("TryOpenBrowser(javascript:) = nil, want error")
+	}
+
+	err = TryOpenBrowser("darwin", "-https://example.com")
+	if err == nil {
+		t.Fatal("TryOpenBrowser(leading dash) = nil, want error")
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pscale auth login` opens the browser to `verification_uri_complete` from the auth server. On Windows that used `cmd /c start <url>` with only `&` escaped, so a malicious or MITM auth response could inject cmd.exe metacharacters (`|`, `<`, `>`, etc.) and run arbitrary commands.

## Fix

- Validate the URL before any opener runs: allow only `http`/`https`, require a host, and reject a leading `-` (option injection into `open`/`xdg-open`).
- On Windows, open via `rundll32 url.dll,FileProtocolHandler <url>` so the URL is not re-parsed by cmd.exe.
- Add unit tests for validation and for the Windows command shape (including a PoC-style URL with `|`).

Invalid URLs fail `TryOpenBrowser`, so login falls back to printing the URL for manual open instead of spawning a shell.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d182d4f0-e564-4de0-9676-cdfef611cb46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d182d4f0-e564-4de0-9676-cdfef611cb46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

