### PR TITLE
Fix OAuth token re-sent to sibling subdomains on redirect

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -151,9 +151,12 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 			}
 		}
 
-		// Store the original domain for detecting cross-domain redirects
-		originalDomain := extractRootDomain(req.URL.Host)
-		redirectCheck := makeRedirectCheck(originalDomain)
+		// Only the exact API host may receive credentials on redirects.
+		// The oauth2 transport attaches Authorization to every hop, so we
+		// must refuse redirects to sibling subdomains (and any other host)
+		// and follow those without auth via handleRedirect.
+		originalHost := req.URL.Hostname()
+		redirectCheck := makeRedirectCheck(originalHost)
 
 		var cl *http.Client
 		if ch.Config.AccessToken != "" {
@@ -162,7 +165,7 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 			cl = oauth2.NewClient(ctx, oauth2.StaticTokenSource(tok))
 
 			// Set our custom redirect policy
-			cl.CheckRedirect = makeRedirectCheck(originalDomain)
+			cl.CheckRedirect = redirectCheck
 		} else if ch.Config.ServiceToken != "" && ch.Config.ServiceTokenID != "" {
 			// For service tokens, manually set the auth header
 			req.Header.Set("Authorization", ch.Config.ServiceTokenID+":"+ch.Config.ServiceToken)
@@ -212,18 +215,17 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 	return cmd
 }
 
-// Create a custom redirect check function that blocks cross-domain redirects.
-// The OAuth2 transport adds the Authorization header to every
-// request, even after a cross-domain redirect, which is really bad.
-// So we detect cross-domain redirects and handle them with a
-// separate, auth-less http.Client.
-func makeRedirectCheck(originalDomain string) func(req *http.Request, via []*http.Request) error {
+// makeRedirectCheck blocks redirects away from the exact original host.
+// The OAuth2 transport adds the Authorization header to every request,
+// including after redirects, so we only auto-follow when the hostname
+// matches the configured API host. Other hosts are handled by
+// handleRedirect with a separate, auth-less http.Client.
+func makeRedirectCheck(originalHost string) func(req *http.Request, via []*http.Request) error {
+	originalHost = strings.ToLower(originalHost)
 	return func(req *http.Request, via []*http.Request) error {
-		// Check if this is a redirect to a different domain
-		currentDomain := extractRootDomain(req.URL.Host)
-		if originalDomain != currentDomain {
-			// For cross-domain redirects, don't follow automatically
-			// We'll handle this manually without sending auth headers
+		if originalHost != strings.ToLower(req.URL.Hostname()) {
+			// Different host (including sibling subdomains): do not follow
+			// with the credential-bearing client.
 			return http.ErrUseLastResponse
 		}
 
@@ -387,8 +389,8 @@ func parseValue(s string) (interface{}, error) {
 	return v, json.Unmarshal([]byte(s), &v)
 }
 
-// handleRedirect processes cross-domain redirects by following the redirect
-// manually without sending authentication headers
+// handleRedirect processes cross-host redirects by following the redirect
+// manually without sending authentication headers.
 func handleRedirect(ctx context.Context, originalReq *http.Request, originalRes *http.Response, location string, debug bool) (*http.Response, error) {
 	// Create a new request without auth headers
 	redirectReq, err := http.NewRequestWithContext(ctx, "GET", location, nil)
@@ -404,7 +406,7 @@ func handleRedirect(ctx context.Context, originalReq *http.Request, originalRes 
 	}
 
 	if debug {
-		fmt.Fprintf(os.Stderr, "Following cross-domain redirect to %s without auth headers\n", location)
+		fmt.Fprintf(os.Stderr, "Following cross-host redirect to %s without auth headers\n", location)
 	}
 
 	// Use a new client without auth for the redirect
@@ -415,20 +417,4 @@ func handleRedirect(ctx context.Context, originalReq *http.Request, originalRes 
 	}
 
 	return redirectRes, nil
-}
-
-// extractRootDomain gets the root domain from a host string.  This just
-// assumes that the last two parts of the domain name are the root domain,
-// which is fine for planetscale.com but would break down under compound
-// TLDs like .co.uk.
-func extractRootDomain(host string) string {
-	// Remove port if present
-	host, _, _ = strings.Cut(host, ":")
-
-	parts := strings.Split(host, ".")
-	if len(parts) <= 2 {
-		return host
-	}
-
-	return strings.Join(parts[len(parts)-2:], ".")
 }

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -65,108 +65,78 @@ func TestParseField(t *testing.T) {
 	}
 }
 
-func TestExtractRootDomain(t *testing.T) {
-	tests := []struct {
-		name string
-		host string
-		want string
-	}{
-		{
-			name: "simple domain",
-			host: "example.com",
-			want: "example.com",
-		},
-		{
-			name: "subdomain",
-			host: "api.example.com",
-			want: "example.com",
-		},
-		{
-			name: "multiple subdomains",
-			host: "v1.api.example.com",
-			want: "example.com",
-		},
-		{
-			name: "with port",
-			host: "example.com:8080",
-			want: "example.com",
-		},
-		{
-			name: "subdomain with port",
-			host: "api.example.com:8080",
-			want: "example.com",
-		},
-		{
-			name: "localhost",
-			host: "localhost",
-			want: "localhost",
-		},
-		{
-			name: "localhost with port",
-			host: "localhost:8080",
-			want: "localhost",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := extractRootDomain(tt.host)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestRedirectCheck(t *testing.T) {
 	tests := []struct {
 		name                  string
 		originalHost          string
-		redirectHost          string
+		redirectURL           string
 		expectUseLastResponse bool
 	}{
 		{
-			name:                  "same domain",
+			name:                  "exact same host",
 			originalHost:          "api.example.com",
-			redirectHost:          "www.example.com",
+			redirectURL:           "https://api.example.com/path",
 			expectUseLastResponse: false,
+		},
+		{
+			name:                  "same host different port still same hostname",
+			originalHost:          "api.example.com",
+			redirectURL:           "https://api.example.com:443/path",
+			expectUseLastResponse: false,
+		},
+		{
+			name:                  "case-insensitive hostname match",
+			originalHost:          "API.Example.Com",
+			redirectURL:           "https://api.example.com/path",
+			expectUseLastResponse: false,
+		},
+		{
+			name:                  "sibling subdomain is not same host",
+			originalHost:          "api.planetscale.com",
+			redirectURL:           "https://evil.planetscale.com/path",
+			expectUseLastResponse: true,
+		},
+		{
+			name:                  "www sibling of api host",
+			originalHost:          "api.example.com",
+			redirectURL:           "https://www.example.com/path",
+			expectUseLastResponse: true,
 		},
 		{
 			name:                  "different domain",
 			originalHost:          "api.example.com",
-			redirectHost:          "api.another.com",
+			redirectURL:           "https://api.another.com/path",
 			expectUseLastResponse: true,
 		},
 		{
 			name:                  "localhost to domain",
-			originalHost:          "localhost:8080",
-			redirectHost:          "example.com",
+			originalHost:          "localhost",
+			redirectURL:           "https://example.com/path",
 			expectUseLastResponse: true,
 		},
 		{
 			name:                  "domain to localhost",
 			originalHost:          "example.com",
-			redirectHost:          "localhost:8080",
+			redirectURL:           "http://localhost:8080/path",
 			expectUseLastResponse: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			originalDomain := extractRootDomain(tt.originalHost)
-			redirectCheck := makeRedirectCheck(originalDomain)
+			redirectCheck := makeRedirectCheck(tt.originalHost)
 
-			// Create a test request simulating a redirect
-			req, _ := http.NewRequest("GET", "https://"+tt.redirectHost+"/path", nil)
+			req, err := http.NewRequest("GET", tt.redirectURL, nil)
+			require.NoError(t, err)
 
-			// Run the redirect check
-			err := redirectCheck(req, []*http.Request{})
+			err = redirectCheck(req, []*http.Request{})
 
-			// Check the result
 			if tt.expectUseLastResponse {
 				require.Equal(t, http.ErrUseLastResponse, err,
-					"Expected ErrUseLastResponse for cross-domain redirect")
+					"Expected ErrUseLastResponse for cross-host redirect")
 			} else {
 				require.NoError(t, err,
-					"Expected nil error for same-domain redirect")
+					"Expected nil error for same-host redirect")
 			}
 		})
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pscale api` used a two-label root-domain heuristic (`extractRootDomain`) when deciding whether a redirect could carry credentials. That treated `api.planetscale.com` and any `*.planetscale.com` host as the same site, so the oauth2-backed client followed redirects and re-sent `Authorization: Bearer <token>` to sibling subdomains.

## Fix

- Compare the exact hostname (case-insensitive, port-stripped via `URL.Hostname()`) when deciding whether to auto-follow with the credential-bearing client.
- Redirects to any other host, including sibling subdomains, return `http.ErrUseLastResponse` and continue to be followed by `handleRedirect` without auth.
- Remove the imprecise `extractRootDomain` helper.
- Update tests to cover exact-host matches and sibling-subdomain blocking.

## Test plan

- [x] `go test ./internal/cmd/api/ -count=1`
- [x] Redirect check unit cases for exact host, case-insensitive match, sibling subdomain, and cross-domain

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85dc13bb-53e2-44b3-8919-e8313e5dbbd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85dc13bb-53e2-44b3-8919-e8313e5dbbd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

