### PR TITLE
Fix destructive SQL gate bypass via MySQL executable comments

### DIFF
--- a/internal/sqlquery/destructive.go
+++ b/internal/sqlquery/destructive.go
@@ -150,6 +150,7 @@ func stripSQLGuardIgnoredText(stmt string) string {
 	quote := byte(0)
 	lineComment := false
 	blockComment := false
+	execComment := false
 	for i := 0; i < len(stmt); i++ {
 		c := stmt[i]
 		if lineComment {
@@ -187,6 +188,15 @@ func stripSQLGuardIgnoredText(stmt string) string {
 			}
 			continue
 		}
+		// MySQL executable comments /*! ... */ and /*!NNNNN ... */ are live SQL.
+		// Blank the delimiters (and optional version digits) but keep the body.
+		if execComment && c == '*' && i+1 < len(stmt) && stmt[i+1] == '/' {
+			out.WriteByte(' ')
+			i++
+			out.WriteByte(' ')
+			execComment = false
+			continue
+		}
 		switch c {
 		case '#':
 			lineComment = true
@@ -202,10 +212,22 @@ func stripSQLGuardIgnoredText(stmt string) string {
 			}
 		case '/':
 			if i+1 < len(stmt) && stmt[i+1] == '*' {
-				blockComment = true
-				out.WriteByte(' ')
-				i++
-				out.WriteByte(' ')
+				if i+2 < len(stmt) && stmt[i+2] == '!' {
+					out.WriteByte(' ')
+					out.WriteByte(' ')
+					out.WriteByte(' ')
+					i += 2
+					for i+1 < len(stmt) && stmt[i+1] >= '0' && stmt[i+1] <= '9' {
+						i++
+						out.WriteByte(' ')
+					}
+					execComment = true
+				} else {
+					blockComment = true
+					out.WriteByte(' ')
+					i++
+					out.WriteByte(' ')
+				}
 			} else {
 				out.WriteByte(c)
 			}

--- a/internal/sqlquery/destructive_test.go
+++ b/internal/sqlquery/destructive_test.go
@@ -35,6 +35,13 @@ func TestIsDestructiveQuery(t *testing.T) {
 		{query: "SELECT 1 # ; DELETE FROM users\nSELECT 2", want: false},
 		{query: "SELECT 1 /* ; TRUNCATE users */; SELECT 2", want: false},
 		{query: "SELECT 1; /* comment */ DELETE FROM users", want: true},
+		// MySQL executable comments are live SQL, not inert comments.
+		{query: "/*! DROP TABLE users */", want: true},
+		{query: "/*!50000 DROP TABLE users */", want: true},
+		{query: "/*!80000 DELETE FROM users WHERE id = 1 */", want: true},
+		{query: "/*!99999 TRUNCATE TABLE users */", want: true},
+		{query: "/*! SELECT 1 */", want: false},
+		{query: "SELECT 1 /* ! DROP TABLE users */", want: false},
 		{query: "SELECT deleted_at FROM users", want: false},
 		{query: "SELECT is_deleted FROM users", want: false},
 		{query: "SELECT * FROM delete_queue", want: false},
@@ -61,16 +68,24 @@ func TestExecuteBlocksDestructiveWithoutForce(t *testing.T) {
 		Config: &config.Config{Organization: "bb"},
 	}
 
-	_, err := Execute(t.Context(), ch, Options{
-		Organization: "bb",
-		Database:     "db",
-		Branch:       "main",
-		Query:        "DELETE FROM users",
-	})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if _, ok := errors.AsType[*DestructiveQueryError](err); !ok {
-		t.Fatalf("error = %T (%v), want *DestructiveQueryError", err, err)
+	for _, query := range []string{
+		"DELETE FROM users",
+		"/*! DROP TABLE users */",
+		"/*!50000 DROP TABLE users */",
+	} {
+		t.Run(query, func(t *testing.T) {
+			_, err := Execute(t.Context(), ch, Options{
+				Organization: "bb",
+				Database:     "db",
+				Branch:       "main",
+				Query:        query,
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if _, ok := errors.AsType[*DestructiveQueryError](err); !ok {
+				t.Fatalf("error = %T (%v), want *DestructiveQueryError", err, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pscale sql` requires `--force` before running destructive statements, but `stripSQLGuardIgnoredText` blanked every `/* ... */` block before the DELETE/DROP/TRUNCATE scan. MySQL treats `/*! ... */` and version-gated `/*!NNNNN ... */` as live SQL, so a query like `/*! DROP TABLE users */` skipped the gate while the original text still reached `db.ExecContext`.

## Fix

Treat MySQL executable comment openers (`/*!` and `/*!` + version digits) as delimiters only: blank the markers, keep the body as live SQL, and blank the closing `*/`. Ordinary `/* ... */` comments stay inert.

## Tests

- `IsDestructiveQuery` coverage for `/*! DROP/DELETE/TRUNCATE ... */`, version-gated forms, non-destructive executable comments, and spaced `/* ! ... */` (still inert)
- `Execute` rejects executable-comment DROP without `--force`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e822526-59cd-478f-88ae-09b3c7bc7725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e822526-59cd-478f-88ae-09b3c7bc7725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

