### PR TITLE
Fix credential header leak on cross-domain `pscale api` redirects

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -185,7 +185,9 @@ func ApiCmd(ch *cmdutil.Helper, userAgent string, defaultHeaders map[string]stri
 		if res.StatusCode >= 300 && res.StatusCode < 400 {
 			location := res.Header.Get("Location")
 			if location != "" {
-				newRes, handleErr := handleRedirect(ctx, req, res, location, ch.Debug())
+				// Do not pass original request headers: secrets in -H values
+				// must not be sent to an attacker-controlled Location host.
+				newRes, handleErr := handleRedirect(ctx, location, ch.Debug())
 				if handleErr != nil {
 					return handleErr
 				}
@@ -387,27 +389,20 @@ func parseValue(s string) (interface{}, error) {
 	return v, json.Unmarshal([]byte(s), &v)
 }
 
-// handleRedirect processes cross-domain redirects by following the redirect
-// manually without sending authentication headers
-func handleRedirect(ctx context.Context, originalReq *http.Request, originalRes *http.Response, location string, debug bool) (*http.Response, error) {
-	// Create a new request without auth headers
+// handleRedirect follows a cross-domain redirect without forwarding credentials
+// or user-supplied headers. Users may put secrets in arbitrary --header/-H
+// values (Cookie, X-Api-Key, etc.), so the redirect request is created fresh
+// and must not copy headers from the original request.
+func handleRedirect(ctx context.Context, location string, debug bool) (*http.Response, error) {
 	redirectReq, err := http.NewRequestWithContext(ctx, "GET", location, nil)
 	if err != nil {
 		return nil, fmt.Errorf("preparing redirect request: %w", err)
 	}
 
-	// Copy all headers except Authorization
-	for k, v := range originalReq.Header {
-		if !strings.EqualFold(k, "Authorization") {
-			redirectReq.Header[k] = v
-		}
-	}
-
 	if debug {
-		fmt.Fprintf(os.Stderr, "Following cross-domain redirect to %s without auth headers\n", location)
+		fmt.Fprintf(os.Stderr, "Following cross-domain redirect to %s without original request headers\n", location)
 	}
 
-	// Use a new client without auth for the redirect
 	redirectClient := &http.Client{}
 	redirectRes, err := redirectClient.Do(redirectReq)
 	if err != nil {

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -173,49 +173,37 @@ func TestRedirectCheck(t *testing.T) {
 }
 
 func TestHandleRedirect(t *testing.T) {
-	// Create a test context
 	ctx := context.Background()
 
-	// Create an original request with auth header
-	originalReq, _ := http.NewRequest("GET", "https://api.example.com/path", nil)
-	originalReq.Header.Set("Authorization", "Bearer token123")
-	originalReq.Header.Set("User-Agent", "test-agent")
-
-	// Create a mock original response
-	originalRes := &http.Response{
-		StatusCode: 302,
-		Header:     http.Header{},
+	// Cross-domain redirects must not carry credentials or user-supplied headers
+	// from the original request (Authorization, Cookie, X-Api-Key, etc.).
+	credentialHeaders := []string{
+		"Authorization",
+		"Proxy-Authorization",
+		"Cookie",
+		"X-Api-Key",
 	}
-	originalRes.Header.Set("Location", "https://other-domain.com/newpath")
 
-	// Mock a response from the redirect target
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Ensure auth header is not present
-		if r.Header.Get("Authorization") != "" {
-			t.Error("Auth header was incorrectly passed to redirect target")
+		for _, name := range credentialHeaders {
+			require.Empty(t, r.Header.Get(name),
+				"credential header %q must not be present on cross-domain redirect request", name)
 		}
-
-		// Ensure other headers were preserved
-		if r.Header.Get("User-Agent") != "test-agent" {
-			t.Error("Other headers were not preserved in redirect")
-		}
+		// Accept is a common original-request header; it must not be forwarded.
+		require.Empty(t, r.Header.Get("Accept"))
 
 		w.Write([]byte("Redirect target content"))
 	}))
 	defer mockServer.Close()
 
-	// Test the handleRedirect function with the mock server
-	redirectRes, err := handleRedirect(ctx, originalReq, originalRes, mockServer.URL, false)
+	redirectRes, err := handleRedirect(ctx, mockServer.URL, false)
 
-	// Verify the result
 	require.NoError(t, err)
 	require.NotNil(t, redirectRes)
 
-	// Read the response body
 	body, err := io.ReadAll(redirectRes.Body)
 	require.NoError(t, err)
 	redirectRes.Body.Close()
 
-	// Verify the response content
 	require.Equal(t, "Redirect target content", string(body))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`pscale api` follows cross-host redirects in `handleRedirect` with a fresh HTTP client, but previously copied every original request header except the literal `Authorization` header. Users can supply arbitrary headers via `--header`/`-H` (e.g. `Cookie`, `X-Api-Key`, `Proxy-Authorization`), so those secrets were forwarded to whatever host was named in `Location`.

## Fix

Cross-host redirects now use a fresh GET request with **no headers copied** from the original request. Stripping only `Authorization` is insufficient because credentials can live in any user-supplied header name.

Rebased/merged with `main` after #1301 (exact-host redirect checks). That PR still copied non-`Authorization` headers; this change keeps the no-header-forwarding behavior on top of the tighter host matching.

## Test plan

- [x] `go test ./internal/cmd/api/` — `TestHandleRedirect` asserts credential-bearing headers are absent on the redirect request; `TestRedirectCheck` covers exact-host matching from #1301
- [ ] Manual: `pscale api` against an endpoint that 302s cross-host with `-H 'X-Api-Key: secret'` and confirm the secret is not sent to the redirect target

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32c47c08-cc20-4040-bf5e-2d052fe945be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32c47c08-cc20-4040-bf5e-2d052fe945be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

