### PR TITLE
Omit OAuth client credentials from auth help text

### DIFF
--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	psauth "github.com/planetscale/cli/internal/auth"
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
 
@@ -49,7 +48,7 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&clientID, "client-id", psauth.OAuthClientID, "The client ID for the PlanetScale CLI application.")
-	cmd.Flags().StringVar(&clientSecret, "client-secret", psauth.OAuthClientSecret, "The client ID for the PlanetScale CLI application")
+	// Kept for flag compatibility; auth check does not use OAuth client credentials.
+	addOAuthClientFlags(cmd, &clientID, &clientSecret)
 	return cmd
 }

--- a/internal/cmd/auth/check.go
+++ b/internal/cmd/auth/check.go
@@ -8,9 +8,6 @@ import (
 )
 
 func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
-	var clientID string
-	var clientSecret string
-
 	cmd := &cobra.Command{
 		Use:   "check",
 		Args:  cobra.NoArgs,
@@ -48,7 +45,5 @@ func CheckCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	// Kept for flag compatibility; auth check does not use OAuth client credentials.
-	addOAuthClientFlags(cmd, &clientID, &clientSecret)
 	return cmd
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -33,6 +33,7 @@ func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
 				return errors.New("the 'login' command requires an interactive shell (use --format json; browser opens when possible, then polls until approved)")
 			}
 
+			clientID, clientSecret = resolveOAuthClient(clientID, clientSecret)
 			authenticator, err := psauth.New(cleanhttp.DefaultClient(), clientID, clientSecret, psauth.SetBaseURL(authURL))
 			if err != nil {
 				if jsonMode {
@@ -126,8 +127,7 @@ func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&clientID, "client-id", psauth.OAuthClientID, "The client ID for the PlanetScale CLI application.")
-	cmd.Flags().StringVar(&clientSecret, "client-secret", psauth.OAuthClientSecret, "The client ID for the PlanetScale CLI application")
+	addOAuthClientFlags(cmd, &clientID, &clientSecret)
 	cmd.Flags().StringVar(&authURL, "api-url", psauth.DefaultBaseURL, "The PlanetScale Auth API base URL.")
 
 	return cmd

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -33,6 +33,7 @@ func LogoutCmd(ch *cmdutil.Helper) *cobra.Command {
 				_ = waitForEnter(cmd.InOrStdin())
 			}
 
+			clientID, clientSecret = resolveOAuthClient(clientID, clientSecret)
 			authenticator, err := auth.New(cleanhttp.DefaultClient(), clientID, clientSecret, auth.SetBaseURL(apiURL))
 			if err != nil {
 				return err
@@ -56,8 +57,7 @@ func LogoutCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&clientID, "client-id", auth.OAuthClientID, "The client ID for the PlanetScale CLI application.")
-	cmd.Flags().StringVar(&clientSecret, "client-secret", auth.OAuthClientSecret, "The client ID for the PlanetScale CLI application")
+	addOAuthClientFlags(cmd, &clientID, &clientSecret)
 	cmd.Flags().StringVar(&apiURL, "api-url", auth.DefaultBaseURL, "The PlanetScale base API URL.")
 	return cmd
 }

--- a/internal/cmd/auth/oauth_flags.go
+++ b/internal/cmd/auth/oauth_flags.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	psauth "github.com/planetscale/cli/internal/auth"
+
+	"github.com/spf13/cobra"
+)
+
+// addOAuthClientFlags registers --client-id and --client-secret without exposing
+// the built-in OAuth credentials as help-text defaults.
+func addOAuthClientFlags(cmd *cobra.Command, clientID, clientSecret *string) {
+	cmd.Flags().StringVar(clientID, "client-id", "", "The client ID for the PlanetScale CLI application.")
+	cmd.Flags().StringVar(clientSecret, "client-secret", "", "The client secret for the PlanetScale CLI application.")
+}
+
+// resolveOAuthClient returns the flag values, falling back to the built-in
+// PlanetScale CLI OAuth application credentials when unset.
+func resolveOAuthClient(clientID, clientSecret string) (string, string) {
+	if clientID == "" {
+		clientID = psauth.OAuthClientID
+	}
+	if clientSecret == "" {
+		clientSecret = psauth.OAuthClientSecret
+	}
+	return clientID, clientSecret
+}

--- a/internal/cmd/auth/oauth_flags_test.go
+++ b/internal/cmd/auth/oauth_flags_test.go
@@ -18,8 +18,14 @@ func TestAuthLogoutHelpOmitsOAuthSecrets(t *testing.T) {
 	assertHelpOmitsOAuthSecrets(t, LogoutCmd(&cmdutil.Helper{}))
 }
 
-func TestAuthCheckHelpOmitsOAuthSecrets(t *testing.T) {
-	assertHelpOmitsOAuthSecrets(t, CheckCmd(&cmdutil.Helper{}))
+func TestAuthCheckHasNoOAuthClientFlags(t *testing.T) {
+	cmd := CheckCmd(&cmdutil.Helper{})
+	if cmd.Flags().Lookup("client-id") != nil {
+		t.Fatal("auth check must not define --client-id")
+	}
+	if cmd.Flags().Lookup("client-secret") != nil {
+		t.Fatal("auth check must not define --client-secret")
+	}
 }
 
 func assertHelpOmitsOAuthSecrets(t *testing.T, cmd *cobra.Command) {

--- a/internal/cmd/auth/oauth_flags_test.go
+++ b/internal/cmd/auth/oauth_flags_test.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	psauth "github.com/planetscale/cli/internal/auth"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func TestAuthLoginHelpOmitsOAuthSecrets(t *testing.T) {
+	assertHelpOmitsOAuthSecrets(t, LoginCmd(&cmdutil.Helper{}))
+}
+
+func TestAuthLogoutHelpOmitsOAuthSecrets(t *testing.T) {
+	assertHelpOmitsOAuthSecrets(t, LogoutCmd(&cmdutil.Helper{}))
+}
+
+func TestAuthCheckHelpOmitsOAuthSecrets(t *testing.T) {
+	assertHelpOmitsOAuthSecrets(t, CheckCmd(&cmdutil.Helper{}))
+}
+
+func assertHelpOmitsOAuthSecrets(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("help: %v", err)
+	}
+
+	help := out.String()
+	if strings.Contains(help, psauth.OAuthClientID) {
+		t.Fatalf("help text must not include OAuth client ID; got:\n%s", help)
+	}
+	if strings.Contains(help, psauth.OAuthClientSecret) {
+		t.Fatalf("help text must not include OAuth client secret; got:\n%s", help)
+	}
+	if !strings.Contains(help, "--client-id") {
+		t.Fatalf("help text should still document --client-id; got:\n%s", help)
+	}
+	if !strings.Contains(help, "--client-secret") {
+		t.Fatalf("help text should still document --client-secret; got:\n%s", help)
+	}
+}
+
+func TestResolveOAuthClientDefaults(t *testing.T) {
+	id, secret := resolveOAuthClient("", "")
+	if id != psauth.OAuthClientID {
+		t.Fatalf("client ID = %q, want built-in default", id)
+	}
+	if secret != psauth.OAuthClientSecret {
+		t.Fatalf("client secret = %q, want built-in default", secret)
+	}
+}
+
+func TestResolveOAuthClientOverrides(t *testing.T) {
+	id, secret := resolveOAuthClient("custom-id", "custom-secret")
+	if id != "custom-id" {
+		t.Fatalf("client ID = %q, want custom-id", id)
+	}
+	if secret != "custom-secret" {
+		t.Fatalf("client secret = %q, want custom-secret", secret)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes https://github.com/planetscale/cli/issues/1279.

`pscale auth login --help` (and the same flags on `logout`) printed the built-in `--client-id` and `--client-secret` defaults. Agents often scrape help into cloud context, which leaks those values and can trigger credential rotation policies.

## Changes

- Register `--client-id` / `--client-secret` with empty defaults so Cobra help no longer prints the built-in OAuth credentials.
- Resolve to the built-in PlanetScale CLI OAuth app credentials at runtime when the flags are unset (`login` / `logout`).
- Remove unused `--client-id` / `--client-secret` from `auth check` entirely.
- Correct the `--client-secret` help string (previously said "client ID").
- Regression tests assert help output does not contain the OAuth client ID or secret.

## Test plan

- [x] `go test ./internal/cmd/auth/`
- [x] `pscale auth login --help` no longer shows client-id/secret defaults
- [x] Same for `auth logout --help`
- [x] `auth check` no longer defines those flags
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-152c3c22-1520-403d-871e-13195084e3f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-152c3c22-1520-403d-871e-13195084e3f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

