### PR TITLE
Preserve raw API error codes in JSON agent output

### DIFF
--- a/internal/cmdutil/json_error.go
+++ b/internal/cmdutil/json_error.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"regexp"
 	"strings"
+
+	"github.com/planetscale/cli/internal/planetscale"
 )
 
 // JSONErrorIssue mirrors the issue shape used by auth check, sql, and import
@@ -49,6 +51,7 @@ func GlobalJSONError(err error) JSONErrorResponse {
 	msg := err.Error()
 	status := "error"
 	code := "COMMAND_FAILED"
+	apiCode := ""
 
 	if cmdErr, ok := errors.AsType[*Error](err); ok {
 		if cmdErr.Msg != "" {
@@ -57,6 +60,9 @@ func GlobalJSONError(err error) JSONErrorResponse {
 		if cmdErr.ExitCode == ActionRequestedExitCode {
 			status = "action_required"
 		}
+	}
+	if perr, ok := err.(*planetscale.Error); ok {
+		apiCode = perr.APICode
 	}
 
 	msg = ansiEscape.ReplaceAllString(msg, "")
@@ -166,6 +172,15 @@ func GlobalJSONError(err error) JSONErrorResponse {
 		nextSteps = []string{
 			AgentAuthCheckCmd(),
 			AgentGuideCmd(),
+		}
+	}
+
+	if apiCode != "" {
+		code = apiCode
+		if apiCode == "schema_mutation_blocked" {
+			nextSteps = []string{
+				"Wait for the active vtctld mutation or deploy to finish, then retry",
+			}
 		}
 	}
 

--- a/internal/cmdutil/json_error_test.go
+++ b/internal/cmdutil/json_error_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+
+	"github.com/planetscale/cli/internal/planetscale"
 )
 
 func TestGlobalJSONErrorAuthRequired(t *testing.T) {
@@ -137,6 +139,32 @@ func TestGlobalJSONErrorGenericFallback(t *testing.T) {
 	}
 	if len(resp.NextSteps) != 2 || resp.NextSteps[0] != AgentAuthCheckCmd() {
 		t.Fatalf("next_steps = %#v", resp.NextSteps)
+	}
+}
+
+func TestGlobalJSONErrorSchemaMutationBlocked(t *testing.T) {
+	resp := GlobalJSONError(&planetscale.Error{
+		APICode: "schema_mutation_blocked",
+	})
+	if resp.Code() != "schema_mutation_blocked" {
+		t.Fatalf("code = %q", resp.Code())
+	}
+	if len(resp.NextSteps) != 1 || resp.NextSteps[0] != "Wait for the active vtctld mutation or deploy to finish, then retry" {
+		t.Fatalf("next_steps = %#v", resp.NextSteps)
+	}
+	for _, step := range resp.NextSteps {
+		if step == AgentAuthCheckCmd() || step == AgentAuthLoginCmd() {
+			t.Fatalf("schema_mutation_blocked should not suggest auth, got %#v", resp.NextSteps)
+		}
+	}
+}
+
+func TestGlobalJSONErrorPreservesOtherAPICodes(t *testing.T) {
+	resp := GlobalJSONError(&planetscale.Error{
+		APICode: "unprocessable",
+	})
+	if resp.Code() != "unprocessable" {
+		t.Fatalf("code = %q", resp.Code())
 	}
 }
 

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -462,8 +462,9 @@ func (c *Client) handleResponse(ctx context.Context, res *http.Response, v inter
 		}
 
 		return &Error{
-			msg:  errorRes.Message,
-			Code: errCode,
+			msg:     errorRes.Message,
+			Code:    errCode,
+			APICode: errorRes.Code,
 		}
 	}
 
@@ -660,6 +661,10 @@ type Error struct {
 
 	// Code specifies the error code. i.e; NotFound, RateLimited, etc...
 	Code ErrorCode
+
+	// APICode is the raw code from the API error JSON body (e.g.
+	// "schema_mutation_blocked"). Empty when the response had no code field.
+	APICode string
 
 	// Meta contains additional information depending on the error code. As an
 	// example, if the Code is "ErrResponseMalformed", the map will be: ["body"]

--- a/internal/planetscale/client_test.go
+++ b/internal/planetscale/client_test.go
@@ -71,6 +71,19 @@ func TestDo(t *testing.T) {
 			},
 		},
 		{
+			desc:       "preserves raw API code for schema_mutation_blocked",
+			statusCode: http.StatusUnprocessableEntity,
+			method:     http.MethodPost,
+			response: `{
+				"code": "schema_mutation_blocked",
+				"message": "MoveTables create in progress"
+			}`,
+			expectedError: &Error{
+				msg:     "MoveTables create in progress",
+				APICode: "schema_mutation_blocked",
+			},
+		},
+		{
 			desc:       "returns ErrorResponse for 5xx errors",
 			statusCode: http.StatusInternalServerError,
 			method:     http.MethodGet,
@@ -165,6 +178,11 @@ func TestDo(t *testing.T) {
 			if err != nil {
 				if tt.expectedError != nil {
 					c.Assert(tt.expectedError.Error(), qt.Equals, err.Error())
+					if want, ok := tt.expectedError.(*Error); ok && want.APICode != "" {
+						got, ok := err.(*Error)
+						c.Assert(ok, qt.IsTrue)
+						c.Assert(got.APICode, qt.Equals, want.APICode)
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary
- Retain the raw API `{code, message}` code on `planetscale.Error` as `APICode`.
- `GlobalJSONError` emits that code in `issues[0].code` (exact `schema_mutation_blocked`) instead of collapsing unknown API failures to `COMMAND_FAILED`.
- `schema_mutation_blocked` gets actionable next steps (wait/retry) rather than auth troubleshooting.

## Test plan
- [x] `go test ./internal/planetscale/ ./internal/cmdutil/`
- [x] `make lint`
- [ ] After release: `pscale branch vtctld move-tables create ... --format json` while a marker is active shows `"code":"schema_mutation_blocked"` in the JSON envelope


Made with [Cursor](https://cursor.com)