### PR TITLE
Improve branch connections not-found error messages

### DIFF
--- a/internal/cmd/branch/connections/client.go
+++ b/internal/cmd/branch/connections/client.go
@@ -1,9 +1,43 @@
 package connections
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/planetscale/cli/internal/cmdutil"
 	live "github.com/planetscale/cli/internal/connections"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
 )
+
+// DatabaseEngine resolves the engine backing a database so connection commands
+// can pick the Vitess or Postgres code path.
+func DatabaseEngine(ctx context.Context, ch *cmdutil.Helper, database string) (ps.DatabaseEngine, error) {
+	client, err := ch.Client()
+	if err != nil {
+		return "", err
+	}
+
+	db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
+		Organization: ch.Config.Organization,
+		Database:     database,
+	})
+	if err != nil {
+		if cmdutil.ErrCode(err) == ps.ErrNotFound {
+			return "", databaseNotFoundError(ch, database)
+		}
+		return "", cmdutil.HandleError(err)
+	}
+	if db == nil {
+		return "", databaseNotFoundError(ch, database)
+	}
+	return db.Kind, nil
+}
+
+func databaseNotFoundError(ch *cmdutil.Helper, database string) error {
+	return fmt.Errorf("database %s does not exist in organization %s",
+		printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+}
 
 func newConnectionsClient(ch *cmdutil.Helper, database, branch string, target ConnectionTarget) (*live.Client, error) {
 	return live.NewClient(live.ClientConfig{

--- a/internal/cmd/branch/connections/top.go
+++ b/internal/cmd/branch/connections/top.go
@@ -139,7 +139,7 @@ func runTop(ctx context.Context, cmd *cobra.Command, ch *cmdutil.Helper, args []
 
 func newTopRequest(ctx context.Context, ch *cmdutil.Helper, args []string, flags topFlags) (topRequest, error) {
 	database := args[0]
-	engine, err := getTopDatabaseKind(ctx, ch, database)
+	engine, err := DatabaseEngine(ctx, ch, database)
 	if err != nil {
 		return topRequest{}, err
 	}
@@ -213,24 +213,6 @@ func runTopHeadless(ctx context.Context, cmd *cobra.Command, ch *cmdutil.Helper,
 	}
 
 	return runHeadlessCapture(ctx, sortedTopLister{client: source.Client, sort: source.View.DefaultSort()}, writer, flags.duration, flags.interval)
-}
-
-func getTopDatabaseKind(ctx context.Context, ch *cmdutil.Helper, database string) (ps.DatabaseEngine, error) {
-	client, err := ch.Client()
-	if err != nil {
-		return "", err
-	}
-	db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
-		Organization: ch.Config.Organization,
-		Database:     database,
-	})
-	if err != nil {
-		return "", err
-	}
-	if db == nil {
-		return "", errors.New("database not found")
-	}
-	return db.Kind, nil
 }
 
 func validateTopFlagsForEngine(engine ps.DatabaseEngine, filter connectionFilter, target ConnectionTarget) error {

--- a/internal/cmd/branch/connections_commands.go
+++ b/internal/cmd/branch/connections_commands.go
@@ -130,22 +130,7 @@ the matching Postgres connection.`,
 }
 
 func databaseEngine(ctx context.Context, ch *cmdutil.Helper, database string) (ps.DatabaseEngine, error) {
-	client, err := ch.Client()
-	if err != nil {
-		return "", err
-	}
-
-	db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
-		Organization: ch.Config.Organization,
-		Database:     database,
-	})
-	if err != nil {
-		return "", err
-	}
-	if db == nil {
-		return "", errors.New("database not found")
-	}
-	return db.Kind, nil
+	return connections.DatabaseEngine(ctx, ch, database)
 }
 
 func vitessConnectionID(raw string) (int64, error) {

--- a/internal/cmd/branch/connections_test.go
+++ b/internal/cmd/branch/connections_test.go
@@ -638,6 +638,22 @@ func TestConnectionsShowRejectsInvalidRoleBeforeLookup(t *testing.T) {
 	c.Assert(databases.GetFnInvoked, qt.IsFalse)
 }
 
+func TestConnectionsShowReportsMissingDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	databases := &mock.DatabaseService{
+		GetFn: func(context.Context, *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+	cmd := connectionsCmdForTest(connectionsTestHelperWithDatabaseService("acme", databases, nil, "http://127.0.0.1:1", printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"show", "nope", "main"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "database nope does not exist in organization acme")
+}
+
 func connectionsTestHelper(org string, engine ps.DatabaseEngine, processlist ps.ProcesslistService, baseURL string, format printer.Format, out *bytes.Buffer) *cmdutil.Helper {
 	return connectionsTestHelperWithDatabaseService(org, databaseServiceForEngine(org, engine), processlist, baseURL, format, out)
 }

--- a/internal/connections/client.go
+++ b/internal/connections/client.go
@@ -493,11 +493,10 @@ func actionIDName(op string) string {
 
 func (s *Client) formatHTTPError(op string, status int, body []byte) error {
 	if status == http.StatusNotFound {
-		hint := fmt.Sprintf(
-			"verify --org=%q database=%q branch=%q exists and live connections are enabled",
-			s.cfg.Organization, s.cfg.Database, s.cfg.Branch,
+		return fmt.Errorf(
+			"branch %s does not exist in database %s (organization: %s), or live connections are not enabled for it",
+			s.cfg.Branch, s.cfg.Database, s.cfg.Organization,
 		)
-		return fmt.Errorf("%s: not found (%s)", op, hint)
 	}
 	if status == http.StatusTooManyRequests {
 		return fmt.Errorf("%s: rate limited, please retry in a moment", op)


### PR DESCRIPTION
## Summary
- Replace bare `Not Found` / opaque live-connections 404s from `pscale branch connections` with the same org/database/branch wording used elsewhere in the CLI.
- Consolidate the duplicated database-engine lookup into one helper so `show`, `kill`, `kill-transaction`, `top`, and `processlist` all get the clearer message.

## Test plan
- [x] `go test ./internal/cmd/branch/... ./internal/connections/...`
- [x] Missing database: `pscale branch connections show nope-db main` → `database nope-db does not exist in organization …`
- [x] Missing branch: `pscale branch connections show <db> nope-branch` → `branch nope-branch does not exist in database …`
- [x] Happy path still works for an existing Postgres branch
- [x] Action-specific 404s (e.g. unknown `transaction_id`) unchanged


Made with [Cursor](https://cursor.com)