### PR TITLE
Hide Cloudflare billing flags from `database create` help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ pscale --org <org> database list --format json
 
 ## Cloudflare-billed databases
 
-To create a database billed to a Cloudflare account, Cloudflare must mint an HMAC billing proof. Pass all three flags together:
+These flags are hidden from `--help` and intended only for Cloudflare-minted HMAC flows (not human CLI use). To create a database billed to a Cloudflare account, Cloudflare must mint an HMAC billing proof. Pass all three flags together:
 
 ```bash
 pscale database create <database> --org <org> --format json \

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -157,6 +157,9 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.cloudflareAccountID, "cloudflare-account-id", "", "Cloudflare account ID to bill this database to. Requires --cloudflare-timestamp and --cloudflare-signature.")
 	cmd.Flags().StringVar(&flags.cloudflareTimestamp, "cloudflare-timestamp", "", "Unix timestamp for the Cloudflare billing signature. Requires --cloudflare-account-id and --cloudflare-signature.")
 	cmd.Flags().StringVar(&flags.cloudflareSignature, "cloudflare-signature", "", "HMAC signature proving Cloudflare billing intent. Requires --cloudflare-account-id and --cloudflare-timestamp.")
+	_ = cmd.Flags().MarkHidden("cloudflare-account-id")
+	_ = cmd.Flags().MarkHidden("cloudflare-timestamp")
+	_ = cmd.Flags().MarkHidden("cloudflare-signature")
 
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the database is ready")
 

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -476,3 +476,14 @@ func TestDatabase_CreateCmdCloudflareBillingIncomplete(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, ".*cloudflare-account-id, --cloudflare-timestamp, and --cloudflare-signature are all required.*")
 	c.Assert(svc.CreateFnInvoked, qt.IsFalse)
 }
+
+func TestDatabase_CreateCmdCloudflareFlagsHidden(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := CreateCmd(&cmdutil.Helper{})
+	for _, name := range []string{"cloudflare-account-id", "cloudflare-timestamp", "cloudflare-signature"} {
+		flag := cmd.Flags().Lookup(name)
+		c.Assert(flag, qt.IsNotNil, qt.Commentf("flag %q", name))
+		c.Assert(flag.Hidden, qt.IsTrue, qt.Commentf("flag %q", name))
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1311: conceal the Cloudflare billing flags (`--cloudflare-account-id`, `--cloudflare-timestamp`, `--cloudflare-signature`) from `pscale database create --help` so they don't confuse end users.

Uses the existing Cobra `MarkHidden` pattern (same as `--strategy` on deploy requests). Flags remain fully functional when passed; they are just omitted from help/usage and typical shell completion.

Also notes in `AGENTS.md` that these flags are hidden and intended for Cloudflare-minted HMAC flows only.

## Test plan

- [x] `go test ./internal/cmd/database/ -run Cloudflare`
- [ ] Confirm `pscale database create --help` does not list the three Cloudflare flags
- [ ] Confirm passing all three flags still works for Cloudflare-billed create
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3da11a2-073d-406a-a1b0-b2e576361b9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3da11a2-073d-406a-a1b0-b2e576361b9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

