### PR TITLE
Disable Arch User Repository integration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,30 +96,6 @@ docker_manifests:
     image_templates:
       - "planetscale/pscale:{{ .Tag }}-amd64"
       - "planetscale/pscale:{{ .Tag }}-arm64"
-aurs:
-  -
-    name: pscale-cli-bin
-    homepage: https://github.com/planetscale/cli
-    description: The PlanetScale CLI
-    private_key: '{{ .Env.AUR_KEY }}'
-    license: Apache 2.0
-    git_url: 'ssh://aur@aur.archlinux.org/pscale-cli-bin.git'
-    provides:
-      - pscale
-    conflicts:
-      - pscale
-    package: |-
-      # bin
-      install -Dm755 "./pscale" "${pkgdir}/usr/bin/pscale"
-
-      # completions
-      mkdir -p "${pkgdir}/usr/share/bash-completion/completions/"
-      mkdir -p "${pkgdir}/usr/share/zsh/site-functions/"
-      mkdir -p "${pkgdir}/usr/share/fish/vendor_completions.d/"
-      install -Dm644 "./completions/pscale.bash" "${pkgdir}/usr/share/bash-completion/completions/pscale"
-      install -Dm644 "./completions/pscale.zsh" "${pkgdir}/usr/share/zsh/site-functions/_pscale"
-      install -Dm644 "./completions/pscale.fish" "${pkgdir}/usr/share/fish/vendor_completions.d/pscale.fish"
-
 nfpms:
   - maintainer: PlanetScale
     description: The PlanetScale CLI


### PR DESCRIPTION
The AUR has been [down due to maintenance since 7/30](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/YPJ3FQYJTJXXY3RUXCYLMHUKHLIUNVFF/) and is blocking new releases of the CLI. This change stops trying to publish to it.