### PR TITLE
Add secure Cloudflare billing input to database create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,16 +91,21 @@ pscale --org <org> database list --format json
 
 ## Cloudflare-billed databases
 
-To create a database billed to a Cloudflare account, Cloudflare must mint an HMAC billing proof. Pass all three flags together:
+To create a database billed to a Cloudflare account, Cloudflare must mint an HMAC billing proof. Pass the JSON proof directly:
 
 ```bash
 pscale database create <database> --org <org> --format json \
-  --cloudflare-account-id <cloudflare_account_id> \
-  --cloudflare-timestamp <unix_timestamp> \
-  --cloudflare-signature <hmac_hex>
+  --cloudflare-billing '{"account_id":"<cloudflare_account_id>","timestamp":"<unix_timestamp>","signature":"<hmac_hex>"}'
 ```
 
-The CLI does not mint the signature. Incomplete Cloudflare flags fail before the API is called.
+For automation, pass `@-` to read the proof from stdin so the signature is not exposed in process arguments:
+
+```bash
+printf '%s' "$CLOUDFLARE_BILLING_JSON" | \
+  pscale database create <database> --org <org> --format json --cloudflare-billing @-
+```
+
+The CLI does not mint the signature. The JSON object must contain non-empty `account_id`, `timestamp`, and `signature` strings.
 
 ## Flags
 
@@ -109,9 +114,7 @@ The CLI does not mint the signature. Incomplete Cloudflare flags fail before the
 | `--format json` | JSON on stdout |
 | `--org <org>` | Organization (on resource subcommands only) |
 | `--api-url` | Non-production API base URL — pass on every command when not using production |
-| `--cloudflare-account-id` | With timestamp + signature on `database create`: bill the DB to Cloudflare |
-| `--cloudflare-timestamp` | Unix timestamp for the Cloudflare billing signature |
-| `--cloudflare-signature` | HMAC proof of Cloudflare billing intent |
+| `--cloudflare-billing` | Cloudflare billing proof JSON on `database create`; pass `@-` to read it from stdin |
 
 ## JSON errors
 

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -1,9 +1,12 @@
 package database
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -19,16 +22,14 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	createReq := &ps.CreateDatabaseRequest{}
 
 	var flags struct {
-		clusterSize         string
-		engine              string
-		wait                bool
-		replicas            *int
-		majorVersion        string
-		minStorage          int64
-		maxStorage          int64
-		cloudflareAccountID string
-		cloudflareTimestamp string
-		cloudflareSignature string
+		clusterSize       string
+		engine            string
+		wait              bool
+		replicas          *int
+		majorVersion      string
+		minStorage        int64
+		maxStorage        int64
+		cloudflareBilling string
 	}
 
 	cmd := &cobra.Command{
@@ -70,16 +71,14 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 			}
 
-			cloudflareAccountID := flags.cloudflareAccountID
-			cloudflareTimestamp := flags.cloudflareTimestamp
-			cloudflareSignature := flags.cloudflareSignature
-			if cloudflareAccountID != "" || cloudflareTimestamp != "" || cloudflareSignature != "" {
-				if cloudflareAccountID == "" || cloudflareTimestamp == "" || cloudflareSignature == "" {
-					return fmt.Errorf("--cloudflare-account-id, --cloudflare-timestamp, and --cloudflare-signature are all required when billing to Cloudflare")
+			if flags.cloudflareBilling != "" {
+				billing, err := parseCloudflareBilling(flags.cloudflareBilling, cmd.InOrStdin())
+				if err != nil {
+					return err
 				}
-				createReq.CloudflareAccountID = cloudflareAccountID
-				createReq.CloudflareTimestamp = cloudflareTimestamp
-				createReq.CloudflareSignature = cloudflareSignature
+				createReq.CloudflareAccountID = billing.AccountID
+				createReq.CloudflareTimestamp = billing.Timestamp
+				createReq.CloudflareSignature = billing.Signature
 			}
 
 			client, err := ch.Client()
@@ -154,16 +153,55 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().Int64Var(&flags.minStorage, "min-storage", 0, "Minimum storage size in bytes")
 	cmd.Flags().Int64Var(&flags.maxStorage, "max-storage", 0, "Maximum storage size in bytes for autoscaling")
 
-	cmd.Flags().StringVar(&flags.cloudflareAccountID, "cloudflare-account-id", "", "Cloudflare account ID to bill this database to. Requires --cloudflare-timestamp and --cloudflare-signature.")
-	cmd.Flags().StringVar(&flags.cloudflareTimestamp, "cloudflare-timestamp", "", "Unix timestamp for the Cloudflare billing signature. Requires --cloudflare-account-id and --cloudflare-signature.")
-	cmd.Flags().StringVar(&flags.cloudflareSignature, "cloudflare-signature", "", "HMAC signature proving Cloudflare billing intent. Requires --cloudflare-account-id and --cloudflare-timestamp.")
-	_ = cmd.Flags().MarkHidden("cloudflare-account-id")
-	_ = cmd.Flags().MarkHidden("cloudflare-timestamp")
-	_ = cmd.Flags().MarkHidden("cloudflare-signature")
+	cmd.Flags().StringVar(&flags.cloudflareBilling, "cloudflare-billing", "", `Cloudflare billing proof as JSON, or "@-" to read it from stdin.`)
+	_ = cmd.Flags().MarkHidden("cloudflare-billing")
 
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the database is ready")
 
 	return cmd
+}
+
+type cloudflareBilling struct {
+	AccountID string `json:"account_id"`
+	Timestamp string `json:"timestamp"`
+	Signature string `json:"signature"`
+}
+
+func parseCloudflareBilling(value string, stdin io.Reader) (*cloudflareBilling, error) {
+	data := []byte(value)
+	if value == "@-" {
+		var err error
+		data, err = io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading --cloudflare-billing from stdin: %w", err)
+		}
+	}
+
+	var billing cloudflareBilling
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&billing); err != nil {
+		return nil, fmt.Errorf("parsing --cloudflare-billing JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return nil, fmt.Errorf("parsing --cloudflare-billing JSON: %w", err)
+	}
+	if billing.AccountID == "" || billing.Timestamp == "" || billing.Signature == "" {
+		return nil, fmt.Errorf(`--cloudflare-billing requires non-empty "account_id", "timestamp", and "signature" fields`)
+	}
+
+	return &billing, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values are not allowed")
+		}
+		return err
+	}
+	return nil
 }
 
 func parseDatabaseEngine(engine string) (ps.DatabaseEngine, error) {

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -380,66 +381,113 @@ func TestDatabase_CreateCmdPostgresWithMajorVersion(t *testing.T) {
 }
 
 func TestDatabase_CreateCmdCloudflareBilling(t *testing.T) {
-	c := qt.New(t)
-
-	var buf bytes.Buffer
-	format := printer.JSON
-	p := printer.NewPrinter(&format)
-	p.SetResourceOutput(&buf)
-
-	org := "planetscale"
-	db := "planetscale"
-
-	res := &ps.Database{Name: "foo"}
-
-	svc := &mock.DatabaseService{
-		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
-			c.Assert(req.Organization, qt.Equals, org)
-			c.Assert(req.Name, qt.Equals, db)
-			c.Assert(req.CloudflareAccountID, qt.Equals, "cf_account_123")
-			c.Assert(req.CloudflareTimestamp, qt.Equals, "1710000000")
-			c.Assert(req.CloudflareSignature, qt.Equals, "abc123sig")
-
-			return res, nil
+	tests := []struct {
+		name  string
+		value string
+		stdin string
+	}{
+		{
+			name:  "inline JSON",
+			value: `{"account_id":"cf_account_123","timestamp":"1710000000","signature":"abc123sig"}`,
+		},
+		{
+			name:  "JSON from stdin",
+			value: "@-",
+			stdin: `{"account_id":"cf_account_123","timestamp":"1710000000","signature":"abc123sig"}`,
 		},
 	}
 
-	ch := &cmdutil.Helper{
-		Printer: p,
-		Config: &config.Config{
-			Organization: org,
-		},
-		Client: func() (*ps.Client, error) {
-			return &ps.Client{
-				Databases: svc,
-				Organizations: &mock.OrganizationsService{
-					GetFn: func(ctx context.Context, request *ps.GetOrganizationRequest) (*ps.Organization, error) {
-						return &ps.Organization{
-							RemainingFreeDatabases: 1,
-							Name:                   request.Organization,
-						}, nil
-					},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var buf bytes.Buffer
+			format := printer.JSON
+			p := printer.NewPrinter(&format)
+			p.SetResourceOutput(&buf)
+
+			const (
+				org = "planetscale"
+				db  = "planetscale"
+			)
+			res := &ps.Database{Name: "foo"}
+			svc := &mock.DatabaseService{
+				CreateFn: func(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
+					c.Assert(req.Organization, qt.Equals, org)
+					c.Assert(req.Name, qt.Equals, db)
+					c.Assert(req.CloudflareAccountID, qt.Equals, "cf_account_123")
+					c.Assert(req.CloudflareTimestamp, qt.Equals, "1710000000")
+					c.Assert(req.CloudflareSignature, qt.Equals, "abc123sig")
+					return res, nil
 				},
-			}, nil
-		},
+			}
+			ch := &cmdutil.Helper{
+				Printer: p,
+				Config:  &config.Config{Organization: org},
+				Client: func() (*ps.Client, error) {
+					return &ps.Client{
+						Databases: svc,
+						Organizations: &mock.OrganizationsService{
+							GetFn: func(ctx context.Context, request *ps.GetOrganizationRequest) (*ps.Organization, error) {
+								return &ps.Organization{
+									RemainingFreeDatabases: 1,
+									Name:                   request.Organization,
+								}, nil
+							},
+						},
+					}, nil
+				},
+			}
+
+			cmd := CreateCmd(ch)
+			cmd.SetIn(strings.NewReader(tt.stdin))
+			cmd.SetArgs([]string{db, "--region", "us-east", "--cloudflare-billing", tt.value})
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+			c.Assert(buf.String(), qt.JSONEquals, res)
+		})
 	}
-
-	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{
-		db,
-		"--region", "us-east",
-		"--cloudflare-account-id", "cf_account_123",
-		"--cloudflare-timestamp", "1710000000",
-		"--cloudflare-signature", "abc123sig",
-	})
-	err := cmd.Execute()
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
-	c.Assert(buf.String(), qt.JSONEquals, res)
 }
 
-func TestDatabase_CreateCmdCloudflareBillingIncomplete(t *testing.T) {
+func TestParseCloudflareBillingErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		match string
+	}{
+		{
+			name:  "invalid JSON",
+			value: `{`,
+			match: `parsing --cloudflare-billing JSON: unexpected EOF`,
+		},
+		{
+			name:  "unknown field",
+			value: `{"account_id":"account","timestamp":"123","signature":"sig","extra":"value"}`,
+			match: `parsing --cloudflare-billing JSON: json: unknown field "extra"`,
+		},
+		{
+			name:  "missing field",
+			value: `{"account_id":"account","timestamp":"123"}`,
+			match: `--cloudflare-billing requires non-empty "account_id", "timestamp", and "signature" fields`,
+		},
+		{
+			name:  "multiple values",
+			value: `{"account_id":"account","timestamp":"123","signature":"sig"} {}`,
+			match: `parsing --cloudflare-billing JSON: multiple JSON values are not allowed`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := parseCloudflareBilling(tt.value, strings.NewReader(""))
+			c.Assert(err, qt.ErrorMatches, tt.match)
+		})
+	}
+}
+
+func TestDatabase_CreateCmdCloudflareBillingInvalid(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
@@ -447,12 +495,9 @@ func TestDatabase_CreateCmdCloudflareBillingIncomplete(t *testing.T) {
 	p := printer.NewPrinter(&format)
 	p.SetResourceOutput(&buf)
 
-	org := "planetscale"
-	db := "planetscale"
-
 	svc := &mock.DatabaseService{
 		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
-			c.Fatalf("Create should not be called with incomplete Cloudflare flags")
+			c.Fatalf("Create should not be called with invalid Cloudflare billing JSON")
 			return nil, nil
 		},
 	}
@@ -460,7 +505,7 @@ func TestDatabase_CreateCmdCloudflareBillingIncomplete(t *testing.T) {
 	ch := &cmdutil.Helper{
 		Printer: p,
 		Config: &config.Config{
-			Organization: org,
+			Organization: "planetscale",
 		},
 		Client: func() (*ps.Client, error) {
 			return &ps.Client{
@@ -470,20 +515,21 @@ func TestDatabase_CreateCmdCloudflareBillingIncomplete(t *testing.T) {
 	}
 
 	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db, "--cloudflare-account-id", "cf_account_123"})
+	cmd.SetArgs([]string{"planetscale", "--cloudflare-billing", `{"account_id":"cf_account_123"}`})
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, ".*cloudflare-account-id, --cloudflare-timestamp, and --cloudflare-signature are all required.*")
+	c.Assert(err, qt.ErrorMatches, `.*--cloudflare-billing requires non-empty "account_id", "timestamp", and "signature" fields.*`)
 	c.Assert(svc.CreateFnInvoked, qt.IsFalse)
 }
 
-func TestDatabase_CreateCmdCloudflareFlagsHidden(t *testing.T) {
+func TestDatabase_CreateCmdCloudflareFlagHidden(t *testing.T) {
 	c := qt.New(t)
 
 	cmd := CreateCmd(&cmdutil.Helper{})
-	for _, name := range []string{"cloudflare-account-id", "cloudflare-timestamp", "cloudflare-signature"} {
-		flag := cmd.Flags().Lookup(name)
-		c.Assert(flag, qt.IsNotNil, qt.Commentf("flag %q", name))
-		c.Assert(flag.Hidden, qt.IsTrue, qt.Commentf("flag %q", name))
+	flag := cmd.Flags().Lookup("cloudflare-billing")
+	c.Assert(flag, qt.IsNotNil)
+	c.Assert(flag.Hidden, qt.IsTrue)
+	for _, removed := range []string{"cloudflare-account-id", "cloudflare-timestamp", "cloudflare-signature"} {
+		c.Assert(cmd.Flags().Lookup(removed), qt.IsNil)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the unreleased three-part Cloudflare billing flags with one JSON `--cloudflare-billing` flag
- support `--cloudflare-billing @-` to read the billing proof from stdin and keep the signature out of process arguments
- validate the billing object and document inline and stdin usage

## Testing
- `go test ./internal/cmd/database`
- `go test ./...`
- `go vet ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0c0bf3b-f5fd-4108-85ac-235f0b292ba3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0c0bf3b-f5fd-4108-85ac-235f0b292ba3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

