### PR TITLE
Add backup policy CRUD commands

### DIFF
--- a/internal/cmd/backup/backup.go
+++ b/internal/cmd/backup/backup.go
@@ -16,7 +16,7 @@ import (
 func BackupCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "backup <command>",
-		Short:             "Create, list, show, and delete branch backups",
+		Short:             "Manage branch backups and backup policies",
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
 
@@ -28,6 +28,7 @@ func BackupCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(RestoreCmd(ch))
+	cmd.AddCommand(PolicyCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/backup/policy.go
+++ b/internal/cmd/backup/policy.go
@@ -1,0 +1,101 @@
+package backup
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// PolicyCmd manages database backup schedules/policies.
+func PolicyCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy <command>",
+		Short: "Create, list, show, update, and delete backup policies",
+		Long: `Manage scheduled backup policies for a database.
+
+Backup policies define automatic backup frequency, schedule, and retention for
+production or development branches. This is separate from one-off branch
+backups created with 'pscale backup create'.`,
+	}
+
+	cmd.AddCommand(PolicyListCmd(ch))
+	cmd.AddCommand(PolicyShowCmd(ch))
+	cmd.AddCommand(PolicyCreateCmd(ch))
+	cmd.AddCommand(PolicyUpdateCmd(ch))
+	cmd.AddCommand(PolicyDeleteCmd(ch))
+
+	return cmd
+}
+
+// BackupPolicy is the human/JSON/CSV view of a backup policy.
+type BackupPolicy struct {
+	ID           string `header:"id" json:"id"`
+	Name         string `header:"name" json:"name"`
+	Target       string `header:"target" json:"target"`
+	Retention    string `header:"retention" json:"retention"`
+	Frequency    string `header:"frequency" json:"frequency"`
+	ScheduleTime string `header:"schedule_time" json:"schedule_time"`
+	ScheduleDay  string `header:"schedule_day" json:"schedule_day"`
+	ScheduleWeek string `header:"schedule_week" json:"schedule_week"`
+	Required     bool   `header:"required" json:"required"`
+	LastRanAt    *int64 `header:"last_ran_at,timestamp(ms|utc|human)" json:"last_ran_at"`
+	NextRunAt    *int64 `header:"next_run_at,timestamp(ms|utc|human)" json:"next_run_at"`
+	CreatedAt    int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
+	UpdatedAt    int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+
+	orig *ps.BackupPolicy
+}
+
+func (p *BackupPolicy) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(p.orig, "", "  ")
+}
+
+func (p *BackupPolicy) MarshalCSVValue() interface{} {
+	return []*BackupPolicy{p}
+}
+
+func toBackupPolicy(policy *ps.BackupPolicy) *BackupPolicy {
+	out := &BackupPolicy{
+		ID:           policy.ID,
+		Name:         policy.Name,
+		Target:       policy.Target,
+		Retention:    formatQuantity(policy.RetentionValue, policy.RetentionUnit),
+		Frequency:    formatQuantity(policy.FrequencyValue, policy.FrequencyUnit),
+		ScheduleTime: policy.ScheduleTime,
+		ScheduleDay:  formatOptionalInt(policy.ScheduleDay),
+		ScheduleWeek: formatOptionalInt(policy.ScheduleWeek),
+		Required:     policy.Required,
+		LastRanAt:    printer.GetMillisecondsIfExists(policy.LastRanAt),
+		NextRunAt:    printer.GetMillisecondsIfExists(policy.NextRunAt),
+		CreatedAt:    printer.GetMilliseconds(policy.CreatedAt),
+		UpdatedAt:    printer.GetMilliseconds(policy.UpdatedAt),
+		orig:         policy,
+	}
+	return out
+}
+
+func toBackupPolicies(policies []*ps.BackupPolicy) []*BackupPolicy {
+	out := make([]*BackupPolicy, 0, len(policies))
+	for _, policy := range policies {
+		out = append(out, toBackupPolicy(policy))
+	}
+	return out
+}
+
+func formatQuantity(value int, unit string) string {
+	if unit == "" {
+		return fmt.Sprintf("%d", value)
+	}
+	return fmt.Sprintf("%d %s", value, unit)
+}
+
+func formatOptionalInt(v *int) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *v)
+}

--- a/internal/cmd/backup/policy_create.go
+++ b/internal/cmd/backup/policy_create.go
@@ -1,0 +1,100 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// PolicyCreateCmd creates a backup policy.
+func PolicyCreateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		name           string
+		target         string
+		retentionValue int
+		retentionUnit  string
+		frequencyValue int
+		frequencyUnit  string
+		scheduleTime   string
+		scheduleDay    int
+		scheduleWeek   int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create <database>",
+		Short: "Create a backup policy",
+		Long: `Create a scheduled backup policy for production or development branches.
+
+Custom schedules beyond the included defaults may incur additional backup storage charges.`,
+		Args: cmdutil.RequiredArgs("database"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			req := &ps.CreateBackupPolicyRequest{
+				Organization:   ch.Config.Organization,
+				Database:       database,
+				Name:           flags.name,
+				Target:         flags.target,
+				RetentionValue: flags.retentionValue,
+				RetentionUnit:  flags.retentionUnit,
+				FrequencyValue: flags.frequencyValue,
+				FrequencyUnit:  flags.frequencyUnit,
+				ScheduleTime:   flags.scheduleTime,
+			}
+			if cmd.Flags().Changed("schedule-day") {
+				req.ScheduleDay = &flags.scheduleDay
+			}
+			if cmd.Flags().Changed("schedule-week") {
+				req.ScheduleWeek = &flags.scheduleWeek
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating backup policy for %s", printer.BoldBlue(database)))
+			defer end()
+
+			policy, err := client.BackupPolicies.Create(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toBackupPolicy(policy))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.name, "name", "", "Optional name for the backup policy")
+	cmd.Flags().StringVar(&flags.target, "target", "", "Branch target: production or development (required)")
+	cmd.Flags().IntVar(&flags.retentionValue, "retention-value", 0, "Retention period value (required)")
+	cmd.Flags().StringVar(&flags.retentionUnit, "retention-unit", "", "Retention unit: hour, day, week, month, or year (required)")
+	cmd.Flags().IntVar(&flags.frequencyValue, "frequency-value", 0, "Frequency value (required)")
+	cmd.Flags().StringVar(&flags.frequencyUnit, "frequency-unit", "", "Frequency unit: hour, day, week, or month (required)")
+	cmd.Flags().StringVar(&flags.scheduleTime, "schedule-time", "", "Schedule time of day in HH:MM format (required)")
+	cmd.Flags().IntVar(&flags.scheduleDay, "schedule-day", 0, "Day of week (0=Sunday … 6=Saturday); used for weekly/monthly schedules")
+	cmd.Flags().IntVar(&flags.scheduleWeek, "schedule-week", 0, "Week of month (0=first … 3=fourth); used for monthly schedules")
+
+	cmd.MarkFlagRequired("target")          // nolint:errcheck
+	cmd.MarkFlagRequired("retention-value") // nolint:errcheck
+	cmd.MarkFlagRequired("retention-unit")  // nolint:errcheck
+	cmd.MarkFlagRequired("frequency-value") // nolint:errcheck
+	cmd.MarkFlagRequired("frequency-unit")  // nolint:errcheck
+	cmd.MarkFlagRequired("schedule-time")   // nolint:errcheck
+
+	return cmd
+}

--- a/internal/cmd/backup/policy_delete.go
+++ b/internal/cmd/backup/policy_delete.go
@@ -1,0 +1,120 @@
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// PolicyDeleteCmd deletes a backup policy.
+func PolicyDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <database> <policy-id>",
+		Short:   "Delete a backup policy",
+		Long:    "Delete a custom backup policy. Required default system policies cannot be deleted.",
+		Args:    cmdutil.RequiredArgs("database", "policy-id"),
+		Aliases: []string{"rm"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			policyID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			policy, err := client.BackupPolicies.Get(ctx, &ps.GetBackupPolicyRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Policy:       policyID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("backup policy %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(policyID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			if policy.Required {
+				return fmt.Errorf("backup policy %s is a required default policy and cannot be deleted",
+					printer.BoldBlue(policyID))
+			}
+
+			if !force {
+				if ch.Printer.Format() != printer.Human {
+					return fmt.Errorf(`cannot delete backup policy with the output format "%s" (run with --force to override)`, ch.Printer.Format())
+				}
+
+				confirmationName := fmt.Sprintf("%s/%s", database, policyID)
+				if !printer.IsTTY {
+					return fmt.Errorf("cannot confirm deletion of backup policy %q (run with --force to override)", confirmationName)
+				}
+
+				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"), printer.BoldBlue(confirmationName), printer.Bold("to confirm:"))
+				prompt := &survey.Input{Message: confirmationMessage}
+
+				var userInput string
+				err := survey.AskOne(prompt, &userInput)
+				if err != nil {
+					if err == terminal.InterruptErr {
+						os.Exit(0)
+					}
+					return err
+				}
+
+				if userInput != confirmationName {
+					return errors.New("incorrect backup policy name entered, skipping deletion")
+				}
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting backup policy %s from %s", printer.BoldBlue(policyID), printer.BoldBlue(database)))
+			defer end()
+
+			err = client.BackupPolicies.Delete(ctx, &ps.DeleteBackupPolicyRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Policy:       policyID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("backup policy %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(policyID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Backup policy %s was successfully deleted from %s.\n",
+					printer.BoldBlue(policyID), printer.BoldBlue(database))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "backup policy deleted",
+				"policy": policyID,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Delete a backup policy without confirmation")
+	return cmd
+}

--- a/internal/cmd/backup/policy_list.go
+++ b/internal/cmd/backup/policy_list.go
@@ -1,0 +1,59 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// PolicyListCmd lists backup policies for a database.
+func PolicyListCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list <database>",
+		Short:   "List backup policies for a database",
+		Args:    cmdutil.RequiredArgs("database"),
+		Aliases: []string{"ls"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching backup policies for %s", printer.BoldBlue(database)))
+			defer end()
+
+			policies, err := client.BackupPolicies.List(ctx, &ps.ListBackupPoliciesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(policies) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No backup policies exist for %s.\n", printer.BoldBlue(database))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toBackupPolicies(policies))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/backup/policy_show.go
+++ b/internal/cmd/backup/policy_show.go
@@ -1,0 +1,55 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// PolicyShowCmd shows a single backup policy.
+func PolicyShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <database> <policy-id>",
+		Short: "Show a backup policy",
+		Args:  cmdutil.RequiredArgs("database", "policy-id"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			policyID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching backup policy %s for %s", printer.BoldBlue(policyID), printer.BoldBlue(database)))
+			defer end()
+
+			policy, err := client.BackupPolicies.Get(ctx, &ps.GetBackupPolicyRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Policy:       policyID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("backup policy %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(policyID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toBackupPolicy(policy))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/backup/policy_test.go
+++ b/internal/cmd/backup/policy_test.go
@@ -1,0 +1,353 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestBackupPolicy_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	policies := []*ps.BackupPolicy{{
+		ID:             "policy-1",
+		Name:           "Production daily",
+		Target:         "production",
+		RetentionValue: 2,
+		RetentionUnit:  "day",
+		FrequencyValue: 12,
+		FrequencyUnit:  "hour",
+		ScheduleTime:   "09:10",
+		Required:       true,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}}
+
+	svc := &mock.BackupPoliciesService{
+		ListFn: func(ctx context.Context, req *ps.ListBackupPoliciesRequest, opts ...ps.ListOption) ([]*ps.BackupPolicy, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return policies, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyListCmd(ch)
+	cmd.SetArgs([]string{db})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, []*BackupPolicy{{orig: policies[0]}})
+}
+
+func TestBackupPolicy_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	policyID := "policy-1"
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	policy := &ps.BackupPolicy{
+		ID:             policyID,
+		Name:           "Production daily",
+		Target:         "production",
+		RetentionValue: 2,
+		RetentionUnit:  "day",
+		FrequencyValue: 12,
+		FrequencyUnit:  "hour",
+		ScheduleTime:   "09:10",
+		Required:       true,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+
+	svc := &mock.BackupPoliciesService{
+		GetFn: func(ctx context.Context, req *ps.GetBackupPolicyRequest) (*ps.BackupPolicy, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Policy, qt.Equals, policyID)
+			return policy, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyShowCmd(ch)
+	cmd.SetArgs([]string{db, policyID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &BackupPolicy{orig: policy})
+}
+
+func TestBackupPolicy_CreateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	day := 1
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	policy := &ps.BackupPolicy{
+		ID:             "policy-2",
+		Name:           "Weekly prod",
+		Target:         "production",
+		RetentionValue: 7,
+		RetentionUnit:  "day",
+		FrequencyValue: 1,
+		FrequencyUnit:  "week",
+		ScheduleTime:   "03:00",
+		ScheduleDay:    &day,
+		Required:       false,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+
+	svc := &mock.BackupPoliciesService{
+		CreateFn: func(ctx context.Context, req *ps.CreateBackupPolicyRequest) (*ps.BackupPolicy, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Name, qt.Equals, "Weekly prod")
+			c.Assert(req.Target, qt.Equals, "production")
+			c.Assert(req.RetentionValue, qt.Equals, 7)
+			c.Assert(req.RetentionUnit, qt.Equals, "day")
+			c.Assert(req.FrequencyValue, qt.Equals, 1)
+			c.Assert(req.FrequencyUnit, qt.Equals, "week")
+			c.Assert(req.ScheduleTime, qt.Equals, "03:00")
+			c.Assert(req.ScheduleDay, qt.IsNotNil)
+			c.Assert(*req.ScheduleDay, qt.Equals, 1)
+			return policy, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyCreateCmd(ch)
+	cmd.SetArgs([]string{
+		db,
+		"--name", "Weekly prod",
+		"--target", "production",
+		"--retention-value", "7",
+		"--retention-unit", "day",
+		"--frequency-value", "1",
+		"--frequency-unit", "week",
+		"--schedule-time", "03:00",
+		"--schedule-day", "1",
+	})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &BackupPolicy{orig: policy})
+}
+
+func TestBackupPolicy_UpdateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	policyID := "policy-1"
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	policy := &ps.BackupPolicy{
+		ID:             policyID,
+		Name:           "Production daily",
+		Target:         "production",
+		RetentionValue: 14,
+		RetentionUnit:  "day",
+		FrequencyValue: 12,
+		FrequencyUnit:  "hour",
+		ScheduleTime:   "09:10",
+		Required:       true,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}
+
+	svc := &mock.BackupPoliciesService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateBackupPolicyRequest) (*ps.BackupPolicy, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Policy, qt.Equals, policyID)
+			c.Assert(req.RetentionValue, qt.IsNotNil)
+			c.Assert(*req.RetentionValue, qt.Equals, 14)
+			c.Assert(req.RetentionUnit, qt.IsNotNil)
+			c.Assert(*req.RetentionUnit, qt.Equals, "day")
+			c.Assert(req.Target, qt.IsNil)
+			return policy, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyUpdateCmd(ch)
+	cmd.SetArgs([]string{db, policyID, "--retention-value", "14", "--retention-unit", "day"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &BackupPolicy{orig: policy})
+}
+
+func TestBackupPolicy_UpdateCmd_NoFlags(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	svc := &mock.BackupPoliciesService{}
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyUpdateCmd(ch)
+	cmd.SetArgs([]string{"mydb", "policy-1"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "at least one policy flag must be provided")
+	c.Assert(svc.UpdateFnInvoked, qt.IsFalse)
+}
+
+func TestBackupPolicy_DeleteCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "mydb"
+	policyID := "policy-2"
+
+	svc := &mock.BackupPoliciesService{
+		GetFn: func(ctx context.Context, req *ps.GetBackupPolicyRequest) (*ps.BackupPolicy, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Policy, qt.Equals, policyID)
+			return &ps.BackupPolicy{ID: policyID, Required: false}, nil
+		},
+		DeleteFn: func(ctx context.Context, req *ps.DeleteBackupPolicyRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Policy, qt.Equals, policyID)
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyDeleteCmd(ch)
+	cmd.SetArgs([]string{db, policyID, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result": "backup policy deleted",
+		"policy": policyID,
+	})
+}
+
+func TestBackupPolicy_DeleteCmd_RejectsRequiredDefault(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	org := "planetscale"
+	db := "mydb"
+	policyID := "policy-1"
+
+	svc := &mock.BackupPoliciesService{
+		GetFn: func(ctx context.Context, req *ps.GetBackupPolicyRequest) (*ps.BackupPolicy, error) {
+			return &ps.BackupPolicy{
+				ID:       policyID,
+				Name:     "Production daily",
+				Required: true,
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{BackupPolicies: svc}, nil
+		},
+	}
+
+	cmd := PolicyDeleteCmd(ch)
+	cmd.SetArgs([]string{db, policyID, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*required default policy and cannot be deleted.*`)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(svc.DeleteFnInvoked, qt.IsFalse)
+}

--- a/internal/cmd/backup/policy_update.go
+++ b/internal/cmd/backup/policy_update.go
@@ -1,0 +1,125 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// PolicyUpdateCmd updates a backup policy.
+func PolicyUpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		name           string
+		target         string
+		retentionValue int
+		retentionUnit  string
+		frequencyValue int
+		frequencyUnit  string
+		scheduleTime   string
+		scheduleDay    int
+		scheduleWeek   int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <database> <policy-id>",
+		Short: "Update a backup policy",
+		Long: `Update a backup policy.
+
+Only flags you pass are sent to the API. Required system policies may reject
+some changes.`,
+		Args: cmdutil.RequiredArgs("database", "policy-id"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			policyID := args[1]
+
+			req := &ps.UpdateBackupPolicyRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Policy:       policyID,
+			}
+
+			changed := false
+			if cmd.Flags().Changed("name") {
+				req.Name = &flags.name
+				changed = true
+			}
+			if cmd.Flags().Changed("target") {
+				req.Target = &flags.target
+				changed = true
+			}
+			if cmd.Flags().Changed("retention-value") {
+				req.RetentionValue = &flags.retentionValue
+				changed = true
+			}
+			if cmd.Flags().Changed("retention-unit") {
+				req.RetentionUnit = &flags.retentionUnit
+				changed = true
+			}
+			if cmd.Flags().Changed("frequency-value") {
+				req.FrequencyValue = &flags.frequencyValue
+				changed = true
+			}
+			if cmd.Flags().Changed("frequency-unit") {
+				req.FrequencyUnit = &flags.frequencyUnit
+				changed = true
+			}
+			if cmd.Flags().Changed("schedule-time") {
+				req.ScheduleTime = &flags.scheduleTime
+				changed = true
+			}
+			if cmd.Flags().Changed("schedule-day") {
+				req.ScheduleDay = &flags.scheduleDay
+				changed = true
+			}
+			if cmd.Flags().Changed("schedule-week") {
+				req.ScheduleWeek = &flags.scheduleWeek
+				changed = true
+			}
+
+			if !changed {
+				return fmt.Errorf("at least one policy flag must be provided")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating backup policy %s for %s", printer.BoldBlue(policyID), printer.BoldBlue(database)))
+			defer end()
+
+			policy, err := client.BackupPolicies.Update(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("backup policy %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(policyID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toBackupPolicy(policy))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.name, "name", "", "Name for the backup policy")
+	cmd.Flags().StringVar(&flags.target, "target", "", "Branch target: production or development")
+	cmd.Flags().IntVar(&flags.retentionValue, "retention-value", 0, "Retention period value")
+	cmd.Flags().StringVar(&flags.retentionUnit, "retention-unit", "", "Retention unit: hour, day, week, month, or year")
+	cmd.Flags().IntVar(&flags.frequencyValue, "frequency-value", 0, "Frequency value")
+	cmd.Flags().StringVar(&flags.frequencyUnit, "frequency-unit", "", "Frequency unit: hour, day, week, or month")
+	cmd.Flags().StringVar(&flags.scheduleTime, "schedule-time", "", "Schedule time of day in HH:MM format")
+	cmd.Flags().IntVar(&flags.scheduleDay, "schedule-day", 0, "Day of week (0=Sunday … 6=Saturday)")
+	cmd.Flags().IntVar(&flags.scheduleWeek, "schedule-week", 0, "Week of month (0=first … 3=fourth)")
+
+	return cmd
+}

--- a/internal/mock/backup_policy.go
+++ b/internal/mock/backup_policy.go
@@ -1,0 +1,49 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+type BackupPoliciesService struct {
+	ListFn        func(context.Context, *ps.ListBackupPoliciesRequest, ...ps.ListOption) ([]*ps.BackupPolicy, error)
+	ListFnInvoked bool
+
+	GetFn        func(context.Context, *ps.GetBackupPolicyRequest) (*ps.BackupPolicy, error)
+	GetFnInvoked bool
+
+	CreateFn        func(context.Context, *ps.CreateBackupPolicyRequest) (*ps.BackupPolicy, error)
+	CreateFnInvoked bool
+
+	UpdateFn        func(context.Context, *ps.UpdateBackupPolicyRequest) (*ps.BackupPolicy, error)
+	UpdateFnInvoked bool
+
+	DeleteFn        func(context.Context, *ps.DeleteBackupPolicyRequest) error
+	DeleteFnInvoked bool
+}
+
+func (s *BackupPoliciesService) List(ctx context.Context, req *ps.ListBackupPoliciesRequest, opts ...ps.ListOption) ([]*ps.BackupPolicy, error) {
+	s.ListFnInvoked = true
+	return s.ListFn(ctx, req, opts...)
+}
+
+func (s *BackupPoliciesService) Get(ctx context.Context, req *ps.GetBackupPolicyRequest) (*ps.BackupPolicy, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
+}
+
+func (s *BackupPoliciesService) Create(ctx context.Context, req *ps.CreateBackupPolicyRequest) (*ps.BackupPolicy, error) {
+	s.CreateFnInvoked = true
+	return s.CreateFn(ctx, req)
+}
+
+func (s *BackupPoliciesService) Update(ctx context.Context, req *ps.UpdateBackupPolicyRequest) (*ps.BackupPolicy, error) {
+	s.UpdateFnInvoked = true
+	return s.UpdateFn(ctx, req)
+}
+
+func (s *BackupPoliciesService) Delete(ctx context.Context, req *ps.DeleteBackupPolicyRequest) error {
+	s.DeleteFnInvoked = true
+	return s.DeleteFn(ctx, req)
+}

--- a/internal/planetscale/backup_policies.go
+++ b/internal/planetscale/backup_policies.go
@@ -1,0 +1,183 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"time"
+)
+
+// BackupPolicy represents a scheduled backup policy for a database.
+type BackupPolicy struct {
+	ID             string     `json:"id"`
+	DisplayName    string     `json:"display_name"`
+	Name           string     `json:"name"`
+	Target         string     `json:"target"`
+	RetentionValue int        `json:"retention_value"`
+	RetentionUnit  string     `json:"retention_unit"`
+	FrequencyValue int        `json:"frequency_value"`
+	FrequencyUnit  string     `json:"frequency_unit"`
+	ScheduleTime   string     `json:"schedule_time"`
+	ScheduleDay    *int       `json:"schedule_day"`
+	ScheduleWeek   *int       `json:"schedule_week"`
+	Required       bool       `json:"required"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	LastRanAt      *time.Time `json:"last_ran_at"`
+	NextRunAt      *time.Time `json:"next_run_at"`
+}
+
+type backupPoliciesResponse struct {
+	Policies []*BackupPolicy `json:"data"`
+}
+
+// ListBackupPoliciesRequest encapsulates listing backup policies for a database.
+type ListBackupPoliciesRequest struct {
+	Organization string
+	Database     string
+}
+
+// GetBackupPolicyRequest encapsulates getting a single backup policy.
+type GetBackupPolicyRequest struct {
+	Organization string
+	Database     string
+	Policy       string
+}
+
+// CreateBackupPolicyRequest encapsulates creating a backup policy.
+type CreateBackupPolicyRequest struct {
+	Organization   string `json:"-"`
+	Database       string `json:"-"`
+	Name           string `json:"name,omitempty"`
+	Target         string `json:"target"`
+	RetentionValue int    `json:"retention_value"`
+	RetentionUnit  string `json:"retention_unit"`
+	FrequencyValue int    `json:"frequency_value"`
+	FrequencyUnit  string `json:"frequency_unit"`
+	ScheduleTime   string `json:"schedule_time"`
+	ScheduleDay    *int   `json:"schedule_day,omitempty"`
+	ScheduleWeek   *int   `json:"schedule_week,omitempty"`
+}
+
+// UpdateBackupPolicyRequest encapsulates updating a backup policy.
+type UpdateBackupPolicyRequest struct {
+	Organization   string  `json:"-"`
+	Database       string  `json:"-"`
+	Policy         string  `json:"-"`
+	Name           *string `json:"name,omitempty"`
+	Target         *string `json:"target,omitempty"`
+	RetentionValue *int    `json:"retention_value,omitempty"`
+	RetentionUnit  *string `json:"retention_unit,omitempty"`
+	FrequencyValue *int    `json:"frequency_value,omitempty"`
+	FrequencyUnit  *string `json:"frequency_unit,omitempty"`
+	ScheduleTime   *string `json:"schedule_time,omitempty"`
+	ScheduleDay    *int    `json:"schedule_day,omitempty"`
+	ScheduleWeek   *int    `json:"schedule_week,omitempty"`
+}
+
+// DeleteBackupPolicyRequest encapsulates deleting a backup policy.
+type DeleteBackupPolicyRequest struct {
+	Organization string
+	Database     string
+	Policy       string
+}
+
+// BackupPoliciesService is an interface for the PlanetScale backup policies API.
+type BackupPoliciesService interface {
+	List(context.Context, *ListBackupPoliciesRequest, ...ListOption) ([]*BackupPolicy, error)
+	Get(context.Context, *GetBackupPolicyRequest) (*BackupPolicy, error)
+	Create(context.Context, *CreateBackupPolicyRequest) (*BackupPolicy, error)
+	Update(context.Context, *UpdateBackupPolicyRequest) (*BackupPolicy, error)
+	Delete(context.Context, *DeleteBackupPolicyRequest) error
+}
+
+type backupPoliciesService struct {
+	client *Client
+}
+
+var _ BackupPoliciesService = &backupPoliciesService{}
+
+func NewBackupPoliciesService(client *Client) *backupPoliciesService {
+	return &backupPoliciesService{client: client}
+}
+
+func (s *backupPoliciesService) List(ctx context.Context, listReq *ListBackupPoliciesRequest, opts ...ListOption) ([]*BackupPolicy, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, backupPoliciesAPIPath(listReq.Organization, listReq.Database), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list backup policies: %w", err)
+	}
+
+	resp := &backupPoliciesResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Policies, nil
+}
+
+func (s *backupPoliciesService) Get(ctx context.Context, getReq *GetBackupPolicyRequest) (*BackupPolicy, error) {
+	req, err := s.client.newRequest(http.MethodGet, backupPolicyAPIPath(getReq.Organization, getReq.Database, getReq.Policy), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get backup policy: %w", err)
+	}
+
+	policy := &BackupPolicy{}
+	if err := s.client.do(ctx, req, &policy); err != nil {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+func (s *backupPoliciesService) Create(ctx context.Context, createReq *CreateBackupPolicyRequest) (*BackupPolicy, error) {
+	req, err := s.client.newRequest(http.MethodPost, backupPoliciesAPIPath(createReq.Organization, createReq.Database), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for create backup policy: %w", err)
+	}
+
+	policy := &BackupPolicy{}
+	if err := s.client.do(ctx, req, &policy); err != nil {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+func (s *backupPoliciesService) Update(ctx context.Context, updateReq *UpdateBackupPolicyRequest) (*BackupPolicy, error) {
+	req, err := s.client.newRequest(http.MethodPatch, backupPolicyAPIPath(updateReq.Organization, updateReq.Database, updateReq.Policy), updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for update backup policy: %w", err)
+	}
+
+	policy := &BackupPolicy{}
+	if err := s.client.do(ctx, req, &policy); err != nil {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+func (s *backupPoliciesService) Delete(ctx context.Context, deleteReq *DeleteBackupPolicyRequest) error {
+	req, err := s.client.newRequest(http.MethodDelete, backupPolicyAPIPath(deleteReq.Organization, deleteReq.Database, deleteReq.Policy), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for delete backup policy: %w", err)
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+func backupPoliciesAPIPath(org, db string) string {
+	return path.Join("v1/organizations", org, "databases", db, "backup-policies")
+}
+
+func backupPolicyAPIPath(org, db, policy string) string {
+	return path.Join(backupPoliciesAPIPath(org, db), policy)
+}

--- a/internal/planetscale/backup_policies_test.go
+++ b/internal/planetscale/backup_policies_test.go
@@ -1,0 +1,227 @@
+package planetscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackupPolicies_List(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/backup-policies")
+		w.WriteHeader(200)
+		out := `{
+			"data":[{
+				"id":"policy-1",
+				"display_name":"Backup policy Production daily",
+				"name":"Production daily",
+				"target":"production",
+				"retention_value":2,
+				"retention_unit":"day",
+				"frequency_value":12,
+				"frequency_unit":"hour",
+				"schedule_time":"09:10",
+				"schedule_day":null,
+				"schedule_week":null,
+				"required":true,
+				"created_at":"2021-01-14T10:19:23.000Z",
+				"updated_at":"2021-01-14T10:19:23.000Z",
+				"last_ran_at":null,
+				"next_run_at":"2021-01-15T03:23:00.000Z"
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	policies, err := client.BackupPolicies.List(context.Background(), &ListBackupPoliciesRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(policies, qt.HasLen, 1)
+	c.Assert(policies[0].ID, qt.Equals, "policy-1")
+	c.Assert(policies[0].Target, qt.Equals, "production")
+	c.Assert(policies[0].Required, qt.IsTrue)
+	c.Assert(policies[0].ScheduleDay, qt.IsNil)
+	c.Assert(policies[0].NextRunAt, qt.IsNotNil)
+	c.Assert(policies[0].NextRunAt.Equal(time.Date(2021, time.January, 15, 3, 23, 0, 0, time.UTC)), qt.IsTrue)
+}
+
+func TestBackupPolicies_Get(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/backup-policies/policy-1")
+		w.WriteHeader(200)
+		out := `{
+			"id":"policy-1",
+			"display_name":"Backup policy Production daily",
+			"name":"Production daily",
+			"target":"production",
+			"retention_value":2,
+			"retention_unit":"day",
+			"frequency_value":12,
+			"frequency_unit":"hour",
+			"schedule_time":"09:10",
+			"required":true,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z"
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	policy, err := client.BackupPolicies.Get(context.Background(), &GetBackupPolicyRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Policy:       "policy-1",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(policy.Name, qt.Equals, "Production daily")
+}
+
+func TestBackupPolicies_Create(t *testing.T) {
+	c := qt.New(t)
+
+	day := 1
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/backup-policies")
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["name"], qt.Equals, "Weekly prod")
+		c.Assert(body["target"], qt.Equals, "production")
+		c.Assert(body["retention_value"], qt.Equals, float64(7))
+		c.Assert(body["retention_unit"], qt.Equals, "day")
+		c.Assert(body["frequency_value"], qt.Equals, float64(1))
+		c.Assert(body["frequency_unit"], qt.Equals, "week")
+		c.Assert(body["schedule_time"], qt.Equals, "03:00")
+		c.Assert(body["schedule_day"], qt.Equals, float64(1))
+
+		w.WriteHeader(201)
+		out := `{
+			"id":"policy-2",
+			"display_name":"Backup policy Weekly prod",
+			"name":"Weekly prod",
+			"target":"production",
+			"retention_value":7,
+			"retention_unit":"day",
+			"frequency_value":1,
+			"frequency_unit":"week",
+			"schedule_time":"03:00",
+			"schedule_day":1,
+			"required":false,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z"
+		}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	policy, err := client.BackupPolicies.Create(context.Background(), &CreateBackupPolicyRequest{
+		Organization:   testOrg,
+		Database:       "my-db",
+		Name:           "Weekly prod",
+		Target:         "production",
+		RetentionValue: 7,
+		RetentionUnit:  "day",
+		FrequencyValue: 1,
+		FrequencyUnit:  "week",
+		ScheduleTime:   "03:00",
+		ScheduleDay:    &day,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(policy.ID, qt.Equals, "policy-2")
+	c.Assert(policy.Required, qt.IsFalse)
+}
+
+func TestBackupPolicies_Update(t *testing.T) {
+	c := qt.New(t)
+
+	retention := 14
+	unit := "day"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/backup-policies/policy-1")
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["retention_value"], qt.Equals, float64(14))
+		c.Assert(body["retention_unit"], qt.Equals, "day")
+		_, ok := body["target"]
+		c.Assert(ok, qt.IsFalse)
+
+		w.WriteHeader(200)
+		out := `{
+			"id":"policy-1",
+			"display_name":"Backup policy Production daily",
+			"name":"Production daily",
+			"target":"production",
+			"retention_value":14,
+			"retention_unit":"day",
+			"frequency_value":12,
+			"frequency_unit":"hour",
+			"schedule_time":"09:10",
+			"required":true,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z"
+		}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	policy, err := client.BackupPolicies.Update(context.Background(), &UpdateBackupPolicyRequest{
+		Organization:   testOrg,
+		Database:       "my-db",
+		Policy:         "policy-1",
+		RetentionValue: &retention,
+		RetentionUnit:  &unit,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(policy.RetentionValue, qt.Equals, 14)
+}
+
+func TestBackupPolicies_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/backup-policies/policy-2")
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.BackupPolicies.Delete(context.Background(), &DeleteBackupPolicyRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Policy:       "policy-2",
+	})
+	c.Assert(err, qt.IsNil)
+}

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -50,6 +50,7 @@ type Client struct {
 	baseURL *url.URL
 
 	AuditLogs             AuditLogsService
+	BackupPolicies        BackupPoliciesService
 	Backups               BackupsService
 	BranchInfrastructure  BranchInfrastructureService
 	D1ImportNotifications D1ImportNotificationsService
@@ -319,6 +320,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.client.CheckRedirect = makeSameHostCheckRedirect(c.baseURL.Hostname())
 
 	c.AuditLogs = &auditlogsService{client: c}
+	c.BackupPolicies = &backupPoliciesService{client: c}
 	c.Backups = &backupsService{client: c}
 	c.BranchInfrastructure = &branchInfrastructureService{client: c}
 	c.D1ImportNotifications = &d1ImportNotificationsService{client: c}


### PR DESCRIPTION
## Summary

Adds `pscale backup policy` subcommands for managing a database's scheduled backup policies (backup frequency, schedule, and retention). This is separate from the existing one-off branch backups created with `pscale backup create`.

## Commands

- `pscale backup policy list <database>` — list backup policies
- `pscale backup policy show <database> <policy>` — show a single policy
- `pscale backup policy create <database>` — create a policy
- `pscale backup policy update <database> <policy>` — update a policy
- `pscale backup policy delete <database> <policy>` — delete a policy

Delete refuses to remove required default policies (the API rejects it too; this gives a clearer message before the call).

All commands support `--format json`.

## Test plan

- [x] Unit tests for the client, mocks, and commands (including the required-default delete guard)
- [x] `go test ./...`, `staticcheck`, `go vet`, and `gofmt` all clean
- [x] Manual round-trip against a dev database: list, create, show, update (verified persisted), delete, and error/not-found paths