### PR TITLE
Add Postgres IP restriction CRUD commands

### DIFF
--- a/internal/cmd/database/database.go
+++ b/internal/cmd/database/database.go
@@ -30,6 +30,7 @@ func DatabaseCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(UpdateCmd(ch))
+	cmd.AddCommand(IPRestrictionCmd(ch))
 	cmd.AddCommand(DumpCmd(ch))
 	cmd.AddCommand(RestoreCmd(ch))
 

--- a/internal/cmd/database/ip_restriction.go
+++ b/internal/cmd/database/ip_restriction.go
@@ -1,0 +1,106 @@
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// IPRestrictionCmd manages Postgres IP restrictions for a database.
+func IPRestrictionCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ip-restriction <command>",
+		Aliases: []string{"cidr", "cidrs"},
+		Short:   "Manage Postgres IP restrictions",
+		Long: `Manage IP restrictions for a PostgreSQL database.
+
+IP restrictions limit which IPv4 addresses or ranges can connect. Rules can
+optionally be scoped to a specific Postgres schema and/or role. This command
+is only available for PostgreSQL databases.`,
+	}
+
+	cmd.AddCommand(IPRestrictionListCmd(ch))
+	cmd.AddCommand(IPRestrictionShowCmd(ch))
+	cmd.AddCommand(IPRestrictionCreateCmd(ch))
+	cmd.AddCommand(IPRestrictionUpdateCmd(ch))
+	cmd.AddCommand(IPRestrictionDeleteCmd(ch))
+
+	return cmd
+}
+
+// IPRestrictionEntry is the human/JSON/CSV view of a Postgres IP restriction entry.
+type IPRestrictionEntry struct {
+	ID          string `header:"id" json:"id"`
+	Schema      string `header:"schema" json:"schema"`
+	Role        string `header:"role" json:"role"`
+	CIDRs       string `header:"cidrs" json:"cidrs"`
+	Description string `header:"description" json:"description"`
+	Actor       string `header:"actor" json:"actor"`
+	CreatedAt   int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
+	UpdatedAt   int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+
+	orig *ps.PostgresCIDR
+}
+
+func (e *IPRestrictionEntry) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(e.orig, "", "  ")
+}
+
+func (e *IPRestrictionEntry) MarshalCSVValue() interface{} {
+	return []*IPRestrictionEntry{e}
+}
+
+func toIPRestrictionEntry(entry *ps.PostgresCIDR) *IPRestrictionEntry {
+	out := &IPRestrictionEntry{
+		ID:        entry.ID,
+		Schema:    emptyAsDash(entry.Schema),
+		Role:      emptyAsDash(entry.Role),
+		CIDRs:     strings.Join(entry.CIDRs, ", "),
+		Actor:     emptyAsDash(entry.Actor.Name),
+		CreatedAt: printer.GetMilliseconds(entry.CreatedAt),
+		UpdatedAt: printer.GetMilliseconds(entry.UpdatedAt),
+		orig:      entry,
+	}
+	if entry.Description != nil && *entry.Description != "" {
+		out.Description = *entry.Description
+	} else {
+		out.Description = "-"
+	}
+	return out
+}
+
+func toIPRestrictionEntries(entries []*ps.PostgresCIDR) []*IPRestrictionEntry {
+	out := make([]*IPRestrictionEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, toIPRestrictionEntry(entry))
+	}
+	return out
+}
+
+// requirePostgresDatabase fetches the database and errors if it is not PostgreSQL.
+func requirePostgresDatabase(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database string) error {
+	db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
+		Organization: ch.Config.Organization,
+		Database:     database,
+	})
+	if err != nil {
+		switch cmdutil.ErrCode(err) {
+		case ps.ErrNotFound:
+			return fmt.Errorf("database %s does not exist in organization %s",
+				printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+		default:
+			return cmdutil.HandleError(err)
+		}
+	}
+	if db.Kind != ps.DatabaseEnginePostgres {
+		return fmt.Errorf("IP restrictions are only available for PostgreSQL databases; %s is %s",
+			printer.BoldBlue(database), printer.BoldBlue(string(db.Kind)))
+	}
+	return nil
+}

--- a/internal/cmd/database/ip_restriction_create.go
+++ b/internal/cmd/database/ip_restriction_create.go
@@ -1,0 +1,82 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// IPRestrictionCreateCmd creates an IP restriction entry.
+func IPRestrictionCreateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		cidrs       []string
+		schema      string
+		role        string
+		description string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create <database>",
+		Short: "Create an IP restriction entry",
+		Long: `Create an IP restriction entry for a PostgreSQL database.
+
+At least one IPv4 CIDR is required (e.g. 192.168.1.0/24 or 203.0.113.10/32).
+Omit --schema / --role (or leave them empty) to apply the restriction to all
+schemas and roles.`,
+		Args: cmdutil.RequiredArgs("database"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requirePostgresDatabase(ctx, ch, client, database); err != nil {
+				return err
+			}
+
+			req := &ps.CreatePostgresCIDRRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Schema:       flags.schema,
+				Role:         flags.role,
+				CIDRs:        flags.cidrs,
+				Description:  flags.description,
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating IP restriction entry for %s", printer.BoldBlue(database)))
+			defer end()
+
+			entry, err := client.PostgresCIDRs.Create(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toIPRestrictionEntry(entry))
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&flags.cidrs, "cidrs", nil, "IPv4 CIDR ranges to allow (required, repeatable or comma-separated)")
+	cmd.Flags().StringVar(&flags.schema, "schema", "", "Postgres schema to restrict (omit for all schemas)")
+	cmd.Flags().StringVar(&flags.role, "role", "", "Postgres role to restrict (omit for all roles)")
+	cmd.Flags().StringVar(&flags.description, "description", "", "Optional description for the IP restriction entry")
+
+	cmd.MarkFlagRequired("cidrs") // nolint:errcheck
+
+	return cmd
+}

--- a/internal/cmd/database/ip_restriction_delete.go
+++ b/internal/cmd/database/ip_restriction_delete.go
@@ -1,0 +1,79 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// IPRestrictionDeleteCmd deletes an IP restriction entry.
+func IPRestrictionDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <database> <entry-id>",
+		Short:   "Delete an IP restriction entry",
+		Long:    "Delete an IP restriction entry from a PostgreSQL database. Deleting an entry removes the restriction from all database branches.",
+		Args:    cmdutil.RequiredArgs("database", "entry-id"),
+		Aliases: []string{"rm"},
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			entryID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requirePostgresDatabase(ctx, ch, client, database); err != nil {
+				return err
+			}
+
+			if !force {
+				if err := ch.Printer.ConfirmCommand(entryID, "delete IP restriction entry", "deletion of IP restriction entry"); err != nil {
+					return err
+				}
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting IP restriction entry %s from %s", printer.BoldBlue(entryID), printer.BoldBlue(database)))
+			defer end()
+
+			err = client.PostgresCIDRs.Delete(ctx, &ps.DeletePostgresCIDRRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           entryID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("IP restriction entry %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(entryID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("IP restriction entry %s was successfully deleted from %s.\n",
+					printer.BoldBlue(entryID), printer.BoldBlue(database))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "IP restriction entry deleted",
+				"id":     entryID,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Delete an IP restriction entry without confirmation")
+	return cmd
+}

--- a/internal/cmd/database/ip_restriction_list.go
+++ b/internal/cmd/database/ip_restriction_list.go
@@ -1,0 +1,62 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// IPRestrictionListCmd lists IP restriction entries for a Postgres database.
+func IPRestrictionListCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list <database>",
+		Short: "List IP restriction entries for a Postgres database",
+		Args:  cmdutil.RequiredArgs("database"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requirePostgresDatabase(ctx, ch, client, database); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching IP restriction entries for %s", printer.BoldBlue(database)))
+			defer end()
+
+			entries, err := client.PostgresCIDRs.List(ctx, &ps.ListPostgresCIDRsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(entries) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No IP restriction entries exist for database %s.\n", printer.BoldBlue(database))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toIPRestrictionEntries(entries))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/database/ip_restriction_show.go
+++ b/internal/cmd/database/ip_restriction_show.go
@@ -1,0 +1,59 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// IPRestrictionShowCmd shows a single IP restriction entry.
+func IPRestrictionShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <database> <entry-id>",
+		Short: "Show an IP restriction entry",
+		Args:  cmdutil.RequiredArgs("database", "entry-id"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			entryID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requirePostgresDatabase(ctx, ch, client, database); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching IP restriction entry %s for %s", printer.BoldBlue(entryID), printer.BoldBlue(database)))
+			defer end()
+
+			entry, err := client.PostgresCIDRs.Get(ctx, &ps.GetPostgresCIDRRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           entryID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("IP restriction entry %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(entryID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toIPRestrictionEntry(entry))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/database/ip_restriction_test.go
+++ b/internal/cmd/database/ip_restriction_test.go
@@ -1,0 +1,291 @@
+package database
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func ipRestrictionTestEntry() *ps.PostgresCIDR {
+	desc := "office"
+	return &ps.PostgresCIDR{
+		ID:          "cidr-1",
+		Schema:      "public",
+		Role:        "reader",
+		CIDRs:       []string{"192.168.1.0/24", "10.0.0.1/32"},
+		Description: &desc,
+		CreatedAt:   time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt:   time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		Actor:       ps.Actor{ID: "user-1", Name: "Alice"},
+	}
+}
+
+func ipRestrictionHelper(c *qt.C, org string, dbSvc *mock.DatabaseService, cidrSvc *mock.PostgresCIDRsService, format printer.Format, buf *bytes.Buffer) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(buf)
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:     dbSvc,
+				PostgresCIDRs: cidrSvc,
+			}, nil
+		},
+	}
+}
+
+func postgresDB(name string) *ps.Database {
+	return &ps.Database{Name: name, Kind: ps.DatabaseEnginePostgres}
+}
+
+func mysqlDB(name string) *ps.Database {
+	return &ps.Database{Name: name, Kind: ps.DatabaseEngineMySQL}
+}
+
+func TestIPRestriction_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	entry := ipRestrictionTestEntry()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return postgresDB(db), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{
+		ListFn: func(ctx context.Context, req *ps.ListPostgresCIDRsRequest, opts ...ps.ListOption) ([]*ps.PostgresCIDR, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return []*ps.PostgresCIDR{entry}, nil
+		},
+	}
+
+	cmd := IPRestrictionListCmd(ipRestrictionHelper(c, org, dbSvc, cidrSvc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dbSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(cidrSvc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, []*IPRestrictionEntry{{orig: entry}})
+}
+
+func TestIPRestriction_ListCmd_RejectsMySQL(t *testing.T) {
+	c := qt.New(t)
+
+	org := "planetscale"
+	db := "mysql-db"
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return mysqlDB(db), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{}
+
+	cmd := IPRestrictionListCmd(ipRestrictionHelper(c, org, dbSvc, cidrSvc, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{db})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*only available for PostgreSQL.*mysql.*`)
+	c.Assert(cidrSvc.ListFnInvoked, qt.IsFalse)
+}
+
+func TestIPRestriction_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	entry := ipRestrictionTestEntry()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{
+		GetFn: func(ctx context.Context, req *ps.GetPostgresCIDRRequest) (*ps.PostgresCIDR, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.ID, qt.Equals, entry.ID)
+			return entry, nil
+		},
+	}
+
+	cmd := IPRestrictionShowCmd(ipRestrictionHelper(c, org, dbSvc, cidrSvc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, entry.ID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cidrSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &IPRestrictionEntry{orig: entry})
+}
+
+func TestIPRestriction_CreateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	entry := ipRestrictionTestEntry()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{
+		CreateFn: func(ctx context.Context, req *ps.CreatePostgresCIDRRequest) (*ps.PostgresCIDR, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Schema, qt.Equals, "public")
+			c.Assert(req.Role, qt.Equals, "reader")
+			c.Assert(req.CIDRs, qt.DeepEquals, []string{"192.168.1.0/24", "10.0.0.1/32"})
+			c.Assert(req.Description, qt.Equals, "office")
+			return entry, nil
+		},
+	}
+
+	cmd := IPRestrictionCreateCmd(ipRestrictionHelper(c, org, dbSvc, cidrSvc, printer.JSON, &buf))
+	cmd.SetArgs([]string{
+		db,
+		"--cidrs", "192.168.1.0/24,10.0.0.1/32",
+		"--schema", "public",
+		"--role", "reader",
+		"--description", "office",
+	})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cidrSvc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &IPRestrictionEntry{orig: entry})
+}
+
+func TestIPRestriction_CreateCmd_RequiresCIDRs(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := IPRestrictionCreateCmd(ipRestrictionHelper(c, "planetscale", &mock.DatabaseService{}, &mock.PostgresCIDRsService{}, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"mydb"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "required flag")
+}
+
+func TestIPRestriction_UpdateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	entry := ipRestrictionTestEntry()
+	entry.CIDRs = []string{"10.0.0.0/8"}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdatePostgresCIDRRequest) (*ps.PostgresCIDR, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.ID, qt.Equals, "cidr-1")
+			c.Assert(req.CIDRs, qt.DeepEquals, []string{"10.0.0.0/8"})
+			c.Assert(req.Description, qt.IsNotNil)
+			c.Assert(*req.Description, qt.Equals, "updated")
+			c.Assert(req.Schema, qt.IsNil)
+			return entry, nil
+		},
+	}
+
+	cmd := IPRestrictionUpdateCmd(ipRestrictionHelper(c, org, dbSvc, cidrSvc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, "cidr-1", "--cidrs", "10.0.0.0/8", "--description", "updated"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cidrSvc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &IPRestrictionEntry{orig: entry})
+}
+
+func TestIPRestriction_UpdateCmd_RequiresFlag(t *testing.T) {
+	c := qt.New(t)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB("mydb"), nil
+		},
+	}
+
+	cmd := IPRestrictionUpdateCmd(ipRestrictionHelper(c, "planetscale", dbSvc, &mock.PostgresCIDRsService{}, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"mydb", "cidr-1"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*at least one of --cidrs.*`)
+}
+
+func TestIPRestriction_DeleteCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	entryID := "cidr-1"
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{
+		DeleteFn: func(ctx context.Context, req *ps.DeletePostgresCIDRRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.ID, qt.Equals, entryID)
+			return nil
+		},
+	}
+
+	cmd := IPRestrictionDeleteCmd(ipRestrictionHelper(c, org, dbSvc, cidrSvc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, entryID, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cidrSvc.DeleteFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result": "IP restriction entry deleted",
+		"id":     entryID,
+	})
+}
+
+func TestIPRestriction_DeleteCmd_RequiresForceInJSON(t *testing.T) {
+	c := qt.New(t)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB("mydb"), nil
+		},
+	}
+	cidrSvc := &mock.PostgresCIDRsService{}
+
+	cmd := IPRestrictionDeleteCmd(ipRestrictionHelper(c, "planetscale", dbSvc, cidrSvc, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"mydb", "cidr-1"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*run with --force.*`)
+	c.Assert(cidrSvc.DeleteFnInvoked, qt.IsFalse)
+}

--- a/internal/cmd/database/ip_restriction_update.go
+++ b/internal/cmd/database/ip_restriction_update.go
@@ -1,0 +1,98 @@
+package database
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// IPRestrictionUpdateCmd updates an IP restriction entry.
+func IPRestrictionUpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		cidrs       []string
+		schema      string
+		role        string
+		description string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <database> <entry-id>",
+		Short: "Update an IP restriction entry",
+		Long: `Update an IP restriction entry for a PostgreSQL database.
+
+Only provided flags are changed. Pass an empty --description to clear it.
+Pass an empty --schema or --role to allow access for all schemas or roles.`,
+		Args: cmdutil.RequiredArgs("database", "entry-id"),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return cmdutil.DatabaseCompletionFunc(ch, cmd, args, toComplete)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			entryID := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requirePostgresDatabase(ctx, ch, client, database); err != nil {
+				return err
+			}
+
+			req := &ps.UpdatePostgresCIDRRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           entryID,
+			}
+
+			changed := false
+			if cmd.Flags().Changed("cidrs") {
+				req.CIDRs = flags.cidrs
+				changed = true
+			}
+			if cmd.Flags().Changed("schema") {
+				req.Schema = &flags.schema
+				changed = true
+			}
+			if cmd.Flags().Changed("role") {
+				req.Role = &flags.role
+				changed = true
+			}
+			if cmd.Flags().Changed("description") {
+				req.Description = &flags.description
+				changed = true
+			}
+			if !changed {
+				return fmt.Errorf("at least one of --cidrs, --schema, --role, or --description must be provided")
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating IP restriction entry %s for %s", printer.BoldBlue(entryID), printer.BoldBlue(database)))
+			defer end()
+
+			entry, err := client.PostgresCIDRs.Update(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("IP restriction entry %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(entryID), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toIPRestrictionEntry(entry))
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&flags.cidrs, "cidrs", nil, "IPv4 CIDR ranges to allow (replaces the existing list)")
+	cmd.Flags().StringVar(&flags.schema, "schema", "", "Postgres schema to restrict (empty for all schemas)")
+	cmd.Flags().StringVar(&flags.role, "role", "", "Postgres role to restrict (empty for all roles)")
+	cmd.Flags().StringVar(&flags.description, "description", "", "Description for the IP restriction entry (empty to clear)")
+
+	return cmd
+}

--- a/internal/mock/postgres_cidr.go
+++ b/internal/mock/postgres_cidr.go
@@ -1,0 +1,49 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+type PostgresCIDRsService struct {
+	ListFn        func(context.Context, *ps.ListPostgresCIDRsRequest, ...ps.ListOption) ([]*ps.PostgresCIDR, error)
+	ListFnInvoked bool
+
+	GetFn        func(context.Context, *ps.GetPostgresCIDRRequest) (*ps.PostgresCIDR, error)
+	GetFnInvoked bool
+
+	CreateFn        func(context.Context, *ps.CreatePostgresCIDRRequest) (*ps.PostgresCIDR, error)
+	CreateFnInvoked bool
+
+	UpdateFn        func(context.Context, *ps.UpdatePostgresCIDRRequest) (*ps.PostgresCIDR, error)
+	UpdateFnInvoked bool
+
+	DeleteFn        func(context.Context, *ps.DeletePostgresCIDRRequest) error
+	DeleteFnInvoked bool
+}
+
+func (s *PostgresCIDRsService) List(ctx context.Context, req *ps.ListPostgresCIDRsRequest, opts ...ps.ListOption) ([]*ps.PostgresCIDR, error) {
+	s.ListFnInvoked = true
+	return s.ListFn(ctx, req, opts...)
+}
+
+func (s *PostgresCIDRsService) Get(ctx context.Context, req *ps.GetPostgresCIDRRequest) (*ps.PostgresCIDR, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
+}
+
+func (s *PostgresCIDRsService) Create(ctx context.Context, req *ps.CreatePostgresCIDRRequest) (*ps.PostgresCIDR, error) {
+	s.CreateFnInvoked = true
+	return s.CreateFn(ctx, req)
+}
+
+func (s *PostgresCIDRsService) Update(ctx context.Context, req *ps.UpdatePostgresCIDRRequest) (*ps.PostgresCIDR, error) {
+	s.UpdateFnInvoked = true
+	return s.UpdateFn(ctx, req)
+}
+
+func (s *PostgresCIDRsService) Delete(ctx context.Context, req *ps.DeletePostgresCIDRRequest) error {
+	s.DeleteFnInvoked = true
+	return s.DeleteFn(ctx, req)
+}

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -65,6 +65,7 @@ type Client struct {
 	Passwords             PasswordsService
 	PlannedReparentShard  PlannedReparentShardService
 	PostgresBranches      PostgresBranchesService
+	PostgresCIDRs         PostgresCIDRsService
 	PostgresRoles         PostgresRolesService
 	Processlist           ProcesslistService
 	QueryInsights         QueryInsightsService
@@ -335,6 +336,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.PlannedReparentShard = &plannedReparentShardService{client: c}
 	c.Processlist = &processlistService{client: c}
 	c.PostgresBranches = &postgresBranchesService{client: c}
+	c.PostgresCIDRs = &postgresCIDRsService{client: c}
 	c.PostgresRoles = &postgresRolesService{client: c}
 	c.QueryInsights = &queryInsightsService{client: c}
 	c.QueryPatterns = &queryPatternsService{client: c}

--- a/internal/planetscale/postgres_cidrs.go
+++ b/internal/planetscale/postgres_cidrs.go
@@ -1,0 +1,168 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"time"
+)
+
+// PostgresCIDR represents a Postgres IP restriction (CIDR restriction) entry.
+type PostgresCIDR struct {
+	ID          string     `json:"id"`
+	Schema      string     `json:"schema"`
+	Role        string     `json:"role"`
+	CIDRs       []string   `json:"cidrs"`
+	Description *string    `json:"description"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at"`
+	Actor       Actor      `json:"actor"`
+}
+
+type postgresCIDRsResponse struct {
+	CIDRs []*PostgresCIDR `json:"data"`
+}
+
+// ListPostgresCIDRsRequest encapsulates listing IP restriction entries for a database.
+type ListPostgresCIDRsRequest struct {
+	Organization string
+	Database     string
+}
+
+// GetPostgresCIDRRequest encapsulates getting a single IP restriction entry.
+type GetPostgresCIDRRequest struct {
+	Organization string
+	Database     string
+	ID           string
+}
+
+// CreatePostgresCIDRRequest encapsulates creating an IP restriction entry.
+type CreatePostgresCIDRRequest struct {
+	Organization string   `json:"-"`
+	Database     string   `json:"-"`
+	Schema       string   `json:"schema,omitempty"`
+	Role         string   `json:"role,omitempty"`
+	CIDRs        []string `json:"cidrs"`
+	Description  string   `json:"description,omitempty"`
+}
+
+// UpdatePostgresCIDRRequest encapsulates updating an IP restriction entry.
+// Only set fields are sent. Pass an empty string for Description to clear it.
+type UpdatePostgresCIDRRequest struct {
+	Organization string   `json:"-"`
+	Database     string   `json:"-"`
+	ID           string   `json:"-"`
+	Schema       *string  `json:"schema,omitempty"`
+	Role         *string  `json:"role,omitempty"`
+	CIDRs        []string `json:"cidrs,omitempty"`
+	Description  *string  `json:"description,omitempty"`
+}
+
+// DeletePostgresCIDRRequest encapsulates deleting an IP restriction entry.
+type DeletePostgresCIDRRequest struct {
+	Organization string
+	Database     string
+	ID           string
+}
+
+// PostgresCIDRsService is an interface for the PlanetScale Postgres IP restriction API.
+type PostgresCIDRsService interface {
+	List(context.Context, *ListPostgresCIDRsRequest, ...ListOption) ([]*PostgresCIDR, error)
+	Get(context.Context, *GetPostgresCIDRRequest) (*PostgresCIDR, error)
+	Create(context.Context, *CreatePostgresCIDRRequest) (*PostgresCIDR, error)
+	Update(context.Context, *UpdatePostgresCIDRRequest) (*PostgresCIDR, error)
+	Delete(context.Context, *DeletePostgresCIDRRequest) error
+}
+
+type postgresCIDRsService struct {
+	client *Client
+}
+
+var _ PostgresCIDRsService = &postgresCIDRsService{}
+
+// NewPostgresCIDRsService returns a PostgresCIDRsService that uses the given client.
+func NewPostgresCIDRsService(client *Client) *postgresCIDRsService {
+	return &postgresCIDRsService{client: client}
+}
+
+func (s *postgresCIDRsService) List(ctx context.Context, listReq *ListPostgresCIDRsRequest, opts ...ListOption) ([]*PostgresCIDR, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, postgresCIDRsAPIPath(listReq.Organization, listReq.Database), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list postgres cidrs: %w", err)
+	}
+
+	resp := &postgresCIDRsResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.CIDRs, nil
+}
+
+func (s *postgresCIDRsService) Get(ctx context.Context, getReq *GetPostgresCIDRRequest) (*PostgresCIDR, error) {
+	req, err := s.client.newRequest(http.MethodGet, postgresCIDRAPIPath(getReq.Organization, getReq.Database, getReq.ID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get postgres cidr: %w", err)
+	}
+
+	entry := &PostgresCIDR{}
+	if err := s.client.do(ctx, req, &entry); err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func (s *postgresCIDRsService) Create(ctx context.Context, createReq *CreatePostgresCIDRRequest) (*PostgresCIDR, error) {
+	req, err := s.client.newRequest(http.MethodPost, postgresCIDRsAPIPath(createReq.Organization, createReq.Database), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for create postgres cidr: %w", err)
+	}
+
+	entry := &PostgresCIDR{}
+	if err := s.client.do(ctx, req, &entry); err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func (s *postgresCIDRsService) Update(ctx context.Context, updateReq *UpdatePostgresCIDRRequest) (*PostgresCIDR, error) {
+	req, err := s.client.newRequest(http.MethodPatch, postgresCIDRAPIPath(updateReq.Organization, updateReq.Database, updateReq.ID), updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for update postgres cidr: %w", err)
+	}
+
+	entry := &PostgresCIDR{}
+	if err := s.client.do(ctx, req, &entry); err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func (s *postgresCIDRsService) Delete(ctx context.Context, deleteReq *DeletePostgresCIDRRequest) error {
+	req, err := s.client.newRequest(http.MethodDelete, postgresCIDRAPIPath(deleteReq.Organization, deleteReq.Database, deleteReq.ID), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for delete postgres cidr: %w", err)
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+func postgresCIDRsAPIPath(org, db string) string {
+	return path.Join("v1/organizations", org, "databases", db, "cidrs")
+}
+
+func postgresCIDRAPIPath(org, db, id string) string {
+	return path.Join(postgresCIDRsAPIPath(org, db), id)
+}

--- a/internal/planetscale/postgres_cidrs_test.go
+++ b/internal/planetscale/postgres_cidrs_test.go
@@ -1,0 +1,207 @@
+package planetscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPostgresCIDRs_List(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/cidrs")
+		w.WriteHeader(200)
+		out := `{
+			"data":[{
+				"id":"cidr-1",
+				"schema":"public",
+				"role":"reader",
+				"cidrs":["192.168.1.0/24","10.0.0.1/32"],
+				"description":"office network",
+				"created_at":"2021-01-14T10:19:23.000Z",
+				"updated_at":"2021-01-14T10:19:23.000Z",
+				"deleted_at":null,
+				"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"}
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	entries, err := client.PostgresCIDRs.List(context.Background(), &ListPostgresCIDRsRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 1)
+	c.Assert(entries[0].ID, qt.Equals, "cidr-1")
+	c.Assert(entries[0].Schema, qt.Equals, "public")
+	c.Assert(entries[0].Role, qt.Equals, "reader")
+	c.Assert(entries[0].CIDRs, qt.DeepEquals, []string{"192.168.1.0/24", "10.0.0.1/32"})
+	c.Assert(entries[0].Description, qt.IsNotNil)
+	c.Assert(*entries[0].Description, qt.Equals, "office network")
+	c.Assert(entries[0].Actor.Name, qt.Equals, "Alice")
+	c.Assert(entries[0].DeletedAt, qt.IsNil)
+}
+
+func TestPostgresCIDRs_Get(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/cidrs/cidr-1")
+		w.WriteHeader(200)
+		out := `{
+			"id":"cidr-1",
+			"schema":"",
+			"role":"",
+			"cidrs":["203.0.113.0/24"],
+			"description":null,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z",
+			"deleted_at":null,
+			"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"}
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	entry, err := client.PostgresCIDRs.Get(context.Background(), &GetPostgresCIDRRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		ID:           "cidr-1",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.ID, qt.Equals, "cidr-1")
+	c.Assert(entry.Schema, qt.Equals, "")
+	c.Assert(entry.Role, qt.Equals, "")
+	c.Assert(entry.Description, qt.IsNil)
+	c.Assert(entry.CIDRs, qt.DeepEquals, []string{"203.0.113.0/24"})
+}
+
+func TestPostgresCIDRs_Create(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/cidrs")
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["schema"], qt.Equals, "public")
+		c.Assert(body["role"], qt.Equals, "writer")
+		c.Assert(body["cidrs"], qt.DeepEquals, []any{"192.168.1.0/24"})
+		c.Assert(body["description"], qt.Equals, "vpn")
+
+		w.WriteHeader(201)
+		out := `{
+			"id":"cidr-2",
+			"schema":"public",
+			"role":"writer",
+			"cidrs":["192.168.1.0/24"],
+			"description":"vpn",
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z",
+			"deleted_at":null,
+			"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"}
+		}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	entry, err := client.PostgresCIDRs.Create(context.Background(), &CreatePostgresCIDRRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Schema:       "public",
+		Role:         "writer",
+		CIDRs:        []string{"192.168.1.0/24"},
+		Description:  "vpn",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.ID, qt.Equals, "cidr-2")
+	c.Assert(entry.CreatedAt.Equal(time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)), qt.IsTrue)
+}
+
+func TestPostgresCIDRs_Update(t *testing.T) {
+	c := qt.New(t)
+
+	desc := "updated"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/cidrs/cidr-1")
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["cidrs"], qt.DeepEquals, []any{"10.0.0.0/8"})
+		c.Assert(body["description"], qt.Equals, "updated")
+		_, ok := body["schema"]
+		c.Assert(ok, qt.IsFalse)
+
+		w.WriteHeader(200)
+		out := `{
+			"id":"cidr-1",
+			"schema":"",
+			"role":"",
+			"cidrs":["10.0.0.0/8"],
+			"description":"updated",
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-15T10:19:23.000Z",
+			"deleted_at":null,
+			"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"}
+		}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	entry, err := client.PostgresCIDRs.Update(context.Background(), &UpdatePostgresCIDRRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		ID:           "cidr-1",
+		CIDRs:        []string{"10.0.0.0/8"},
+		Description:  &desc,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(entry.CIDRs, qt.DeepEquals, []string{"10.0.0.0/8"})
+	c.Assert(*entry.Description, qt.Equals, "updated")
+}
+
+func TestPostgresCIDRs_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/cidrs/cidr-1")
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.PostgresCIDRs.Delete(context.Background(), &DeletePostgresCIDRRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		ID:           "cidr-1",
+	})
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
## Summary

Adds `pscale database ip-restriction` for managing database-level IP restrictions on PostgreSQL databases (Settings → IP restrictions in the dashboard). Alias: `cidr` / `cidrs`.

This maps to the `/organizations/{org}/databases/{db}/cidrs` API. Vitess databases are rejected before the API is called — Vitess IP limits live on passwords, not this surface.

## Commands

- `pscale database ip-restriction list <database>`
- `pscale database ip-restriction show <database> <entry-id>`
- `pscale database ip-restriction create <database> --cidrs <range>[,<range>…]`
- `pscale database ip-restriction update <database> <entry-id>`
- `pscale database ip-restriction delete <database> <entry-id>`

Optional create/update flags: `--schema`, `--role`, `--description`. Delete requires `--force` in non-interactive / JSON mode.

## Test plan

- [x] Unit tests for client, mocks, and commands (including Vitess rejection and `--force` gate)
- [x] Manual round-trip against local pscaledev: list, create, show, update (verified persisted), delete, alias `cidr`, MySQL reject, not-found paths