### PR TITLE
Add pscale pgbouncer commands for dedicated Postgres poolers

### DIFF
--- a/internal/cmd/pgbouncer/create.go
+++ b/internal/cmd/pgbouncer/create.go
@@ -1,0 +1,84 @@
+package pgbouncer
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// CreateCmd creates a dedicated PgBouncer.
+func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		name            string
+		target          string
+		size            string
+		replicasPerCell int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "create <database> <branch>",
+		Short: "Create a dedicated PgBouncer",
+		Long: `Create a dedicated PgBouncer for a PostgreSQL database branch.
+
+Target must be one of: primary, replica, replica_az_affinity.
+Size is a PgBouncer SKU name (for example PGB_10). If omitted, the API picks
+a default size. Name is optional and auto-generated when omitted (max 12
+characters; "primary" and "replica" are reserved).`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			req := &ps.CreatePostgresBouncerRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Name:         flags.name,
+				Target:       flags.target,
+				BouncerSize:  flags.size,
+			}
+			if cmd.Flags().Changed("replicas-per-cell") {
+				req.ReplicasPerCell = &flags.replicasPerCell
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating PgBouncer for %s/%s", printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			bouncer, err := client.PostgresBouncers.Create(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s or branch %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toPgBouncer(bouncer))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.name, "name", "", "Name for the PgBouncer (optional; auto-generated if omitted)")
+	cmd.Flags().StringVar(&flags.target, "target", "", "Traffic target: primary, replica, or replica_az_affinity (required)")
+	cmd.Flags().StringVar(&flags.size, "size", "", "PgBouncer size SKU (e.g. PGB_10)")
+	cmd.Flags().IntVar(&flags.replicasPerCell, "replicas-per-cell", 1, "Number of replica servers per cell")
+
+	cmd.MarkFlagRequired("target") // nolint:errcheck
+
+	return cmd
+}

--- a/internal/cmd/pgbouncer/delete.go
+++ b/internal/cmd/pgbouncer/delete.go
@@ -1,0 +1,79 @@
+package pgbouncer
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCmd deletes a dedicated PgBouncer by name.
+func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <database> <branch> <name>",
+		Short:   "Delete a dedicated PgBouncer",
+		Args:    cmdutil.RequiredArgs("database", "branch", "name"),
+		Aliases: []string{"rm"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+			name := args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			if !force {
+				if err := ch.Printer.ConfirmCommand(name, "delete PgBouncer", "deletion of PgBouncer"); err != nil {
+					return err
+				}
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting PgBouncer %s from %s/%s", printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			err = client.PostgresBouncers.Delete(ctx, &ps.DeletePostgresBouncerRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Bouncer:      name,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("PgBouncer %s does not exist on %s/%s (organization: %s)",
+						printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("PgBouncer %s was successfully deleted from %s/%s.\n",
+					printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result":   "PgBouncer deleted",
+				"name":     name,
+				"database": database,
+				"branch":   branch,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Delete a PgBouncer without confirmation")
+	return cmd
+}

--- a/internal/cmd/pgbouncer/list.go
+++ b/internal/cmd/pgbouncer/list.go
@@ -1,0 +1,62 @@
+package pgbouncer
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// ListCmd lists dedicated PgBouncers for a branch.
+func ListCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list <database> <branch>",
+		Short:   "List dedicated PgBouncers for a Postgres branch",
+		Args:    cmdutil.RequiredArgs("database", "branch"),
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching PgBouncers for %s/%s", printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			bouncers, err := client.PostgresBouncers.List(ctx, &ps.ListPostgresBouncersRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s or branch %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(bouncers) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No dedicated PgBouncers exist for %s/%s.\n", printer.BoldBlue(database), printer.BoldBlue(branch))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toPgBouncers(bouncers))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/pgbouncer/pgbouncer.go
+++ b/internal/cmd/pgbouncer/pgbouncer.go
@@ -1,0 +1,95 @@
+package pgbouncer
+
+import (
+	"encoding/json"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// Cmd manages dedicated PgBouncers for Postgres branches.
+func Cmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pgbouncer <command>",
+		Short: "Manage dedicated PgBouncers for a Postgres branch",
+		Long: `Manage dedicated PgBouncers for a PostgreSQL database branch.
+
+Dedicated PgBouncers run separately from the database nodes and provide
+connection pooling for primary or replica traffic. This is distinct from the
+local PgBouncer on port 6432 and from pgbouncer.* parameters on
+'pscale branch resize'.
+
+This command is only available for PostgreSQL databases.`,
+		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
+	}
+
+	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
+	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
+
+	cmd.AddCommand(ListCmd(ch))
+	cmd.AddCommand(ShowCmd(ch))
+	cmd.AddCommand(CreateCmd(ch))
+	cmd.AddCommand(DeleteCmd(ch))
+
+	return cmd
+}
+
+// PgBouncer is the human/JSON/CSV view of a dedicated PgBouncer.
+type PgBouncer struct {
+	ID              string `header:"id" json:"id"`
+	Name            string `header:"name" json:"name"`
+	Target          string `header:"target" json:"target"`
+	Size            string `header:"size" json:"size"`
+	ReplicasPerCell int    `header:"replicas_per_cell" json:"replicas_per_cell"`
+	Actor           string `header:"actor" json:"actor"`
+	CreatedAt       int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
+	UpdatedAt       int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+
+	orig *ps.PostgresBouncer
+}
+
+func (b *PgBouncer) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(b.orig, "", "  ")
+}
+
+func (b *PgBouncer) MarshalCSVValue() interface{} {
+	return []*PgBouncer{b}
+}
+
+func toPgBouncer(bouncer *ps.PostgresBouncer) *PgBouncer {
+	out := &PgBouncer{
+		ID:              bouncer.ID,
+		Name:            bouncer.Name,
+		Target:          bouncer.Target,
+		ReplicasPerCell: bouncer.ReplicasPerCell,
+		Actor:           bouncer.Actor.Name,
+		CreatedAt:       printer.GetMilliseconds(bouncer.CreatedAt),
+		UpdatedAt:       printer.GetMilliseconds(bouncer.UpdatedAt),
+		orig:            bouncer,
+	}
+	if bouncer.SKU != nil {
+		if bouncer.SKU.DisplayName != "" {
+			out.Size = bouncer.SKU.DisplayName
+		} else {
+			out.Size = bouncer.SKU.Name
+		}
+	} else if bouncer.BouncerSize != "" {
+		out.Size = bouncer.BouncerSize
+	} else {
+		out.Size = "-"
+	}
+	if out.Actor == "" {
+		out.Actor = "-"
+	}
+	return out
+}
+
+func toPgBouncers(bouncers []*ps.PostgresBouncer) []*PgBouncer {
+	out := make([]*PgBouncer, 0, len(bouncers))
+	for _, bouncer := range bouncers {
+		out = append(out, toPgBouncer(bouncer))
+	}
+	return out
+}

--- a/internal/cmd/pgbouncer/pgbouncer.go
+++ b/internal/cmd/pgbouncer/pgbouncer.go
@@ -31,6 +31,7 @@ This command is only available for PostgreSQL databases.`,
 	cmd.AddCommand(ListCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(CreateCmd(ch))
+	cmd.AddCommand(ResizeCmd(ch))
 	cmd.AddCommand(DeleteCmd(ch))
 
 	return cmd

--- a/internal/cmd/pgbouncer/pgbouncer_test.go
+++ b/internal/cmd/pgbouncer/pgbouncer_test.go
@@ -254,3 +254,148 @@ func TestPgBouncer_ListCmd_RejectsMySQL(t *testing.T) {
 	c.Assert(dbSvc.GetFnInvoked, qt.IsTrue)
 	c.Assert(svc.ListFnInvoked, qt.IsFalse)
 }
+
+func testResize() *ps.PostgresBouncerResizeRequest {
+	return &ps.PostgresBouncerResizeRequest{
+		ID:                      "resize-1",
+		State:                   ps.PostgresBouncerResizeStatePending,
+		ReplicasPerCell:         2,
+		Target:                  "replica",
+		PreviousReplicasPerCell: 1,
+		PreviousTarget:          "replica",
+		CreatedAt:               time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt:               time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		Actor:                   ps.Actor{ID: "user-1", Name: "Alice"},
+		Bouncer:                 ps.PostgresBouncerBranch{ID: "bouncer-1", Name: "read-pool"},
+		SKU: &ps.PostgresBouncerSKU{
+			Name:        "PGB_10",
+			DisplayName: "PS-10",
+		},
+		PreviousSKU: &ps.PostgresBouncerSKU{
+			Name:        "PGB_5",
+			DisplayName: "PS-5",
+		},
+	}
+}
+
+func TestPgBouncer_ResizeCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	name := "read-pool"
+	resize := testResize()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		ResizeFn: func(ctx context.Context, req *ps.ResizePostgresBouncerRequest) (*ps.PostgresBouncerResizeRequest, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Bouncer, qt.Equals, name)
+			c.Assert(req.BouncerSize, qt.Equals, "PGB_10")
+			c.Assert(req.ReplicasPerCell, qt.IsNotNil)
+			c.Assert(*req.ReplicasPerCell, qt.Equals, 2)
+			c.Assert(req.Parameters["pgbouncer"]["default_pool_size"], qt.Equals, "100")
+			return resize, nil
+		},
+	}
+
+	cmd := ResizeCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{
+		db, branch, name,
+		"--size", "PGB_10",
+		"--replicas-per-cell", "2",
+		"--parameters", "pgbouncer.default_pool_size=100",
+	})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ResizeFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &PgBouncerResize{orig: resize})
+}
+
+func TestPgBouncer_ResizeCmd_RequiresChange(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := ResizeCmd(testHelper("planetscale", &mock.DatabaseService{}, &mock.PostgresBouncersService{}, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"mydb", "main", "read-pool"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*nothing to change.*`)
+}
+
+func TestPgBouncer_ResizeStatusCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	name := "read-pool"
+	resize := testResize()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		ListResizesFn: func(ctx context.Context, req *ps.ListPostgresBouncerResizesRequest, opts ...ps.ListOption) ([]*ps.PostgresBouncerResizeRequest, error) {
+			c.Assert(req.Bouncer, qt.Equals, name)
+			return []*ps.PostgresBouncerResizeRequest{resize}, nil
+		},
+	}
+
+	cmd := ResizeStatusCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, branch, name})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListResizesFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &PgBouncerResize{orig: resize})
+}
+
+func TestPgBouncer_ResizeCancelCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	name := "read-pool"
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		CancelResizesFn: func(ctx context.Context, req *ps.CancelPostgresBouncerResizesRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Bouncer, qt.Equals, name)
+			return nil
+		},
+	}
+
+	cmd := ResizeCancelCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, branch, name})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CancelResizesFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result":   "canceled",
+		"name":     name,
+		"database": db,
+		"branch":   branch,
+	})
+}

--- a/internal/cmd/pgbouncer/pgbouncer_test.go
+++ b/internal/cmd/pgbouncer/pgbouncer_test.go
@@ -399,3 +399,38 @@ func TestPgBouncer_ResizeCancelCmd(t *testing.T) {
 		"branch":   branch,
 	})
 }
+
+func TestPgBouncer_ResizeCmd_NoChange(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	name := "read-pool"
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		ResizeFn: func(ctx context.Context, req *ps.ResizePostgresBouncerRequest) (*ps.PostgresBouncerResizeRequest, error) {
+			return nil, nil
+		},
+	}
+
+	cmd := ResizeCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, branch, name, "--size", "PGB_10", "--wait"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ResizeFnInvoked, qt.IsTrue)
+	c.Assert(svc.ListResizesFnInvoked, qt.IsFalse)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result":   "no_change",
+		"name":     name,
+		"database": db,
+		"branch":   branch,
+	})
+}

--- a/internal/cmd/pgbouncer/pgbouncer_test.go
+++ b/internal/cmd/pgbouncer/pgbouncer_test.go
@@ -1,0 +1,256 @@
+package pgbouncer
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func testBouncer() *ps.PostgresBouncer {
+	return &ps.PostgresBouncer{
+		ID:   "bouncer-1",
+		Name: "read-pool",
+		SKU: &ps.PostgresBouncerSKU{
+			Name:        "PGB_10",
+			DisplayName: "PS-10",
+			CPU:         "0.25",
+			RAM:         268435456,
+		},
+		Target:          "replica",
+		ReplicasPerCell: 1,
+		CreatedAt:       time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt:       time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		Actor:           ps.Actor{ID: "user-1", Name: "Alice"},
+		Branch:          ps.PostgresBouncerBranch{ID: "branch-1", Name: "main"},
+	}
+}
+
+func testHelper(org string, dbSvc *mock.DatabaseService, svc *mock.PostgresBouncersService, format printer.Format, buf *bytes.Buffer) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(buf)
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:        dbSvc,
+				PostgresBouncers: svc,
+			}, nil
+		},
+	}
+}
+
+func postgresDB(name string) *ps.Database {
+	return &ps.Database{Name: name, Kind: ps.DatabaseEnginePostgres}
+}
+
+func mysqlDB(name string) *ps.Database {
+	return &ps.Database{Name: name, Kind: ps.DatabaseEngineMySQL}
+}
+
+func TestPgBouncer_ListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	bouncer := testBouncer()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		ListFn: func(ctx context.Context, req *ps.ListPostgresBouncersRequest, opts ...ps.ListOption) ([]*ps.PostgresBouncer, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			return []*ps.PostgresBouncer{bouncer}, nil
+		},
+	}
+
+	cmd := ListCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dbSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, []*PgBouncer{{orig: bouncer}})
+}
+
+func TestPgBouncer_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	bouncer := testBouncer()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		GetFn: func(ctx context.Context, req *ps.GetPostgresBouncerRequest) (*ps.PostgresBouncer, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Bouncer, qt.Equals, "read-pool")
+			return bouncer, nil
+		},
+	}
+
+	cmd := ShowCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, branch, "read-pool"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &PgBouncer{orig: bouncer})
+}
+
+func TestPgBouncer_CreateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	bouncer := testBouncer()
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		CreateFn: func(ctx context.Context, req *ps.CreatePostgresBouncerRequest) (*ps.PostgresBouncer, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Name, qt.Equals, "read-pool")
+			c.Assert(req.Target, qt.Equals, "replica")
+			c.Assert(req.BouncerSize, qt.Equals, "PGB_10")
+			c.Assert(req.ReplicasPerCell, qt.IsNotNil)
+			c.Assert(*req.ReplicasPerCell, qt.Equals, 2)
+			return bouncer, nil
+		},
+	}
+
+	cmd := CreateCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{
+		db, branch,
+		"--name", "read-pool",
+		"--target", "replica",
+		"--size", "PGB_10",
+		"--replicas-per-cell", "2",
+	})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &PgBouncer{orig: bouncer})
+}
+
+func TestPgBouncer_CreateCmd_RequiresTarget(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := CreateCmd(testHelper("planetscale", &mock.DatabaseService{}, &mock.PostgresBouncersService{}, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"mydb", "main", "--name", "read-pool"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "required flag")
+}
+
+func TestPgBouncer_DeleteCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	org := "planetscale"
+	db := "mydb"
+	branch := "main"
+	name := "read-pool"
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{
+		DeleteFn: func(ctx context.Context, req *ps.DeletePostgresBouncerRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Bouncer, qt.Equals, name)
+			return nil
+		},
+	}
+
+	cmd := DeleteCmd(testHelper(org, dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{db, branch, name, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result":   "PgBouncer deleted",
+		"name":     name,
+		"database": db,
+		"branch":   branch,
+	})
+}
+
+func TestPgBouncer_DeleteCmd_RequiresForceInJSON(t *testing.T) {
+	c := qt.New(t)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return postgresDB("mydb"), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{}
+	cmd := DeleteCmd(testHelper("planetscale", dbSvc, svc, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{"mydb", "main", "read-pool"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*run with --force.*`)
+	c.Assert(svc.DeleteFnInvoked, qt.IsFalse)
+}
+
+func TestPgBouncer_ListCmd_RejectsMySQL(t *testing.T) {
+	c := qt.New(t)
+
+	org := "planetscale"
+	db := "mysql-db"
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			return mysqlDB(db), nil
+		},
+	}
+	svc := &mock.PostgresBouncersService{}
+
+	cmd := ListCmd(testHelper(org, dbSvc, svc, printer.JSON, &bytes.Buffer{}))
+	cmd.SetArgs([]string{db, "main"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*only available for PostgreSQL.*mysql.*`)
+	c.Assert(dbSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(svc.ListFnInvoked, qt.IsFalse)
+}

--- a/internal/cmd/pgbouncer/resize.go
+++ b/internal/cmd/pgbouncer/resize.go
@@ -89,6 +89,21 @@ configure the local PgBouncer on database nodes.`,
 			}
 			end()
 
+			// A nil resize request means the bouncer already matches the
+			// requested configuration (the API responded with no content).
+			if resize == nil {
+				if ch.Printer.Format() == printer.Human {
+					ch.Printer.Printf("PgBouncer %s already matches the requested configuration; no changes applied.\n", printer.BoldBlue(name))
+					return nil
+				}
+				return ch.Printer.PrintResource(map[string]string{
+					"result":   "no_change",
+					"name":     name,
+					"database": database,
+					"branch":   branch,
+				})
+			}
+
 			if flags.wait {
 				resize, err = waitForBouncerResize(ctx, ch, client, database, branch, name, resize, flags.waitTimeout)
 				if err != nil {

--- a/internal/cmd/pgbouncer/resize.go
+++ b/internal/cmd/pgbouncer/resize.go
@@ -1,0 +1,371 @@
+package pgbouncer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// ResizeCmd changes a dedicated PgBouncer's size, replicas, target, or parameters.
+func ResizeCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		size            string
+		replicasPerCell int
+		target          string
+		parameters      []string
+		wait            bool
+		waitTimeout     time.Duration
+	}
+
+	cmd := &cobra.Command{
+		Use:   "resize <database> <branch> <name>",
+		Short: "Change a dedicated PgBouncer's size, replicas, target, or parameters",
+		Long: `Change a dedicated PgBouncer's size, replicas-per-cell, traffic target, and/or
+pgbouncer configuration parameters. Changes are queued as an asynchronous
+resize request. Use "pscale pgbouncer resize status" to track it and
+"pscale pgbouncer resize cancel" to cancel it while unfinished.
+
+This is distinct from "pscale branch resize" pgbouncer.* parameters, which
+configure the local PgBouncer on database nodes.`,
+		Example: `  pscale pgbouncer resize mydb main read-pool --size PGB_10
+  pscale pgbouncer resize mydb main read-pool --replicas-per-cell 2 --wait
+  pscale pgbouncer resize mydb main read-pool --parameters pgbouncer.default_pool_size=100`,
+		Args: cmdutil.RequiredArgs("database", "branch", "name"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, name := args[0], args[1], args[2]
+
+			if flags.size == "" && !cmd.Flags().Changed("replicas-per-cell") && flags.target == "" && len(flags.parameters) == 0 {
+				return errors.New("nothing to change: pass at least one of --size, --replicas-per-cell, --target, or --parameters")
+			}
+
+			parameters, err := parseBouncerParameters(flags.parameters)
+			if err != nil {
+				return err
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			req := &ps.ResizePostgresBouncerRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Bouncer:      name,
+				BouncerSize:  flags.size,
+				Target:       flags.target,
+				Parameters:   parameters,
+			}
+			if cmd.Flags().Changed("replicas-per-cell") {
+				req.ReplicasPerCell = &flags.replicasPerCell
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Requesting changes to PgBouncer %s on %s/%s...", printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			resize, err := client.PostgresBouncers.Resize(ctx, req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("PgBouncer %s does not exist on %s/%s (organization: %s)",
+						printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if flags.wait {
+				resize, err = waitForBouncerResize(ctx, ch, client, database, branch, name, resize, flags.waitTimeout)
+				if err != nil {
+					return err
+				}
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Change to PgBouncer %s %s (state: %s).\n",
+					printer.BoldBlue(name), resizeVerb(resize.State), printer.BoldBlue(resize.State))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toPgBouncerResize(resize))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.size, "size", "", "PgBouncer size SKU (e.g. PGB_10)")
+	cmd.Flags().IntVar(&flags.replicasPerCell, "replicas-per-cell", 1, "Number of PgBouncer replica servers per cell")
+	cmd.Flags().StringVar(&flags.target, "target", "", "Traffic target: primary, replica, or replica_az_affinity")
+	cmd.Flags().StringArrayVar(&flags.parameters, "parameters", nil, "Set a PgBouncer parameter as namespace.name=value (e.g. pgbouncer.default_pool_size=100). Repeatable.")
+	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait for the resize request to complete before returning")
+	cmd.Flags().DurationVar(&flags.waitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait for the resize request to complete with --wait")
+
+	cmd.AddCommand(ResizeStatusCmd(ch))
+	cmd.AddCommand(ResizeCancelCmd(ch))
+
+	return cmd
+}
+
+// ResizeStatusCmd shows the most recent resize request for a PgBouncer.
+func ResizeStatusCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status <database> <branch> <name>",
+		Short: "Show the latest resize request for a dedicated PgBouncer",
+		Args:  cmdutil.RequiredArgs("database", "branch", "name"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, name := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching resize requests for PgBouncer %s on %s/%s...", printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			resizes, err := client.PostgresBouncers.ListResizes(ctx, &ps.ListPostgresBouncerResizesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Bouncer:      name,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("PgBouncer %s does not exist on %s/%s (organization: %s)",
+						printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(resizes) == 0 {
+				if ch.Printer.Format() == printer.Human {
+					ch.Printer.Printf("PgBouncer %s has no resize requests.\n", printer.BoldBlue(name))
+					return nil
+				}
+				return ch.Printer.PrintResource([]*PgBouncerResize{})
+			}
+
+			return ch.Printer.PrintResource(toPgBouncerResize(resizes[0]))
+		},
+	}
+
+	return cmd
+}
+
+// ResizeCancelCmd cancels unfinished resize requests for a PgBouncer.
+func ResizeCancelCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel <database> <branch> <name>",
+		Short: "Cancel unfinished resize requests for a dedicated PgBouncer",
+		Args:  cmdutil.RequiredArgs("database", "branch", "name"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, name := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Cancelling resize requests for PgBouncer %s on %s/%s...", printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			err = client.PostgresBouncers.CancelResizes(ctx, &ps.CancelPostgresBouncerResizesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Bouncer:      name,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("PgBouncer %s does not exist on %s/%s (organization: %s)",
+						printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Canceled unfinished resize requests for PgBouncer %s.\n", printer.BoldBlue(name))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result":   "canceled",
+				"name":     name,
+				"database": database,
+				"branch":   branch,
+			})
+		},
+	}
+
+	return cmd
+}
+
+func parseBouncerParameters(sets []string) (map[string]map[string]string, error) {
+	if len(sets) == 0 {
+		return nil, nil
+	}
+
+	parameters := make(map[string]map[string]string)
+	for _, set := range sets {
+		key, value, found := strings.Cut(set, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid --parameters %q: expected namespace.name=value (e.g. pgbouncer.default_pool_size=100)", set)
+		}
+
+		namespace, name, found := strings.Cut(key, ".")
+		if !found || namespace == "" || name == "" {
+			return nil, fmt.Errorf("invalid --parameters %q: parameter must be prefixed with its namespace, e.g. pgbouncer.%s=%s", set, key, value)
+		}
+
+		if parameters[namespace] == nil {
+			parameters[namespace] = make(map[string]string)
+		}
+		parameters[namespace][name] = value
+	}
+
+	return parameters, nil
+}
+
+func waitForBouncerResize(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch, name string, resize *ps.PostgresBouncerResizeRequest, timeout time.Duration) (*ps.PostgresBouncerResizeRequest, error) {
+	end := ch.Printer.PrintProgress(fmt.Sprintf("Waiting for resize %s to complete...", printer.BoldBlue(resize.ID)))
+	defer end()
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		if resize.Finished() {
+			end()
+			return resize, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("resize %s did not complete within %s (current state: %s). Check progress with 'pscale pgbouncer resize status %s %s %s'",
+				resize.ID, timeout, resize.State, database, branch, name)
+		case <-ticker.C:
+		}
+
+		resizes, err := client.PostgresBouncers.ListResizes(ctx, &ps.ListPostgresBouncerResizesRequest{
+			Organization: ch.Config.Organization,
+			Database:     database,
+			Branch:       branch,
+			Bouncer:      name,
+		})
+		if err != nil {
+			continue
+		}
+		for _, candidate := range resizes {
+			if candidate.ID == resize.ID {
+				resize = candidate
+				break
+			}
+		}
+	}
+}
+
+func resizeVerb(state string) string {
+	switch state {
+	case ps.PostgresBouncerResizeStateCompleted:
+		return "completed"
+	case ps.PostgresBouncerResizeStateCanceled:
+		return "was canceled"
+	default:
+		return "queued"
+	}
+}
+
+// PgBouncerResize is the human/JSON/CSV view of a bouncer resize request.
+type PgBouncerResize struct {
+	ID              string `header:"id" json:"id"`
+	Bouncer         string `header:"bouncer" json:"bouncer"`
+	State           string `header:"state" json:"state"`
+	Size            string `header:"size" json:"size"`
+	PreviousSize    string `header:"previous_size" json:"previous_size"`
+	Target          string `header:"target" json:"target"`
+	ReplicasPerCell int    `header:"replicas_per_cell" json:"replicas_per_cell"`
+	Actor           string `header:"actor" json:"actor"`
+	CreatedAt       int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
+	UpdatedAt       int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
+
+	orig *ps.PostgresBouncerResizeRequest
+}
+
+func (r *PgBouncerResize) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(r.orig, "", "  ")
+}
+
+func (r *PgBouncerResize) MarshalCSVValue() interface{} {
+	return []*PgBouncerResize{r}
+}
+
+func toPgBouncerResize(resize *ps.PostgresBouncerResizeRequest) *PgBouncerResize {
+	out := &PgBouncerResize{
+		ID:              resize.ID,
+		Bouncer:         resize.Bouncer.Name,
+		State:           resize.State,
+		Target:          resize.Target,
+		ReplicasPerCell: resize.ReplicasPerCell,
+		Actor:           resize.Actor.Name,
+		CreatedAt:       printer.GetMilliseconds(resize.CreatedAt),
+		UpdatedAt:       printer.GetMilliseconds(resize.UpdatedAt),
+		orig:            resize,
+	}
+	if resize.SKU != nil {
+		if resize.SKU.DisplayName != "" {
+			out.Size = resize.SKU.DisplayName
+		} else {
+			out.Size = resize.SKU.Name
+		}
+	} else {
+		out.Size = "-"
+	}
+	if resize.PreviousSKU != nil {
+		if resize.PreviousSKU.DisplayName != "" {
+			out.PreviousSize = resize.PreviousSKU.DisplayName
+		} else {
+			out.PreviousSize = resize.PreviousSKU.Name
+		}
+	} else {
+		out.PreviousSize = "-"
+	}
+	if out.Actor == "" {
+		out.Actor = "-"
+	}
+	if out.Bouncer == "" {
+		out.Bouncer = "-"
+	}
+	return out
+}

--- a/internal/cmd/pgbouncer/show.go
+++ b/internal/cmd/pgbouncer/show.go
@@ -1,0 +1,58 @@
+package pgbouncer
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// ShowCmd shows a dedicated PgBouncer by name.
+func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <database> <branch> <name>",
+		Short: "Show a dedicated PgBouncer",
+		Args:  cmdutil.RequiredArgs("database", "branch", "name"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+			name := args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "PgBouncers"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching PgBouncer %s for %s/%s", printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			bouncer, err := client.PostgresBouncers.Get(ctx, &ps.GetPostgresBouncerRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Bouncer:      name,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("PgBouncer %s does not exist on %s/%s (organization: %s)",
+						printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toPgBouncer(bouncer))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -50,6 +50,7 @@ import (
 	"github.com/planetscale/cli/internal/cmd/keyspace"
 	"github.com/planetscale/cli/internal/cmd/org"
 	"github.com/planetscale/cli/internal/cmd/password"
+	"github.com/planetscale/cli/internal/cmd/pgbouncer"
 	"github.com/planetscale/cli/internal/cmd/ping"
 	"github.com/planetscale/cli/internal/cmd/region"
 	"github.com/planetscale/cli/internal/cmd/shell"
@@ -381,6 +382,10 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	roleCmd := role.RoleCmd(ch)
 	roleCmd.GroupID = "postgres"
 	rootCmd.AddCommand(roleCmd)
+
+	pgbouncerCmd := pgbouncer.Cmd(ch)
+	pgbouncerCmd.GroupID = "postgres"
+	rootCmd.AddCommand(pgbouncerCmd)
 
 	trafficCmd := trafficcontrol.TrafficCmd(ch)
 	trafficCmd.GroupID = "postgres"

--- a/internal/cmdutil/postgres.go
+++ b/internal/cmdutil/postgres.go
@@ -1,0 +1,33 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+// RequirePostgresDatabase fetches the database and errors if it is missing or
+// not PostgreSQL. Use this before calling Postgres-only APIs that return a
+// generic not_found for Vitess/MySQL databases.
+func RequirePostgresDatabase(ctx context.Context, client *ps.Client, org, database, resourcePlural string) error {
+	db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
+		Organization: org,
+		Database:     database,
+	})
+	if err != nil {
+		switch ErrCode(err) {
+		case ps.ErrNotFound:
+			return fmt.Errorf("database %s does not exist in organization %s",
+				printer.BoldBlue(database), printer.BoldBlue(org))
+		default:
+			return HandleError(err)
+		}
+	}
+	if db.Kind != ps.DatabaseEnginePostgres {
+		return fmt.Errorf("%s are only available for PostgreSQL databases; %s is %s",
+			resourcePlural, printer.BoldBlue(database), printer.BoldBlue(string(db.Kind)))
+	}
+	return nil
+}

--- a/internal/cmdutil/postgres_test.go
+++ b/internal/cmdutil/postgres_test.go
@@ -1,0 +1,49 @@
+package cmdutil
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+func TestRequirePostgresDatabase_MySQL(t *testing.T) {
+	c := qt.New(t)
+	client := &ps.Client{
+		Databases: &mock.DatabaseService{
+			GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+				return &ps.Database{Name: req.Database, Kind: ps.DatabaseEngineMySQL}, nil
+			},
+		},
+	}
+	err := RequirePostgresDatabase(context.Background(), client, "org", "mydb", "PgBouncers")
+	c.Assert(err, qt.ErrorMatches, `(?s).*only available for PostgreSQL.*mysql.*`)
+}
+
+func TestRequirePostgresDatabase_Postgres(t *testing.T) {
+	c := qt.New(t)
+	client := &ps.Client{
+		Databases: &mock.DatabaseService{
+			GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+				return &ps.Database{Name: req.Database, Kind: ps.DatabaseEnginePostgres}, nil
+			},
+		},
+	}
+	err := RequirePostgresDatabase(context.Background(), client, "org", "mydb", "PgBouncers")
+	c.Assert(err, qt.IsNil)
+}
+
+func TestRequirePostgresDatabase_Missing(t *testing.T) {
+	c := qt.New(t)
+	client := &ps.Client{
+		Databases: &mock.DatabaseService{
+			GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+				return nil, &ps.Error{Code: ps.ErrNotFound}
+			},
+		},
+	}
+	err := RequirePostgresDatabase(context.Background(), client, "org", "missing", "PgBouncers")
+	c.Assert(err, qt.ErrorMatches, `(?s).*database.*does not exist.*`)
+}

--- a/internal/mock/postgres_bouncer.go
+++ b/internal/mock/postgres_bouncer.go
@@ -1,0 +1,41 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+type PostgresBouncersService struct {
+	ListFn        func(context.Context, *ps.ListPostgresBouncersRequest, ...ps.ListOption) ([]*ps.PostgresBouncer, error)
+	ListFnInvoked bool
+
+	GetFn        func(context.Context, *ps.GetPostgresBouncerRequest) (*ps.PostgresBouncer, error)
+	GetFnInvoked bool
+
+	CreateFn        func(context.Context, *ps.CreatePostgresBouncerRequest) (*ps.PostgresBouncer, error)
+	CreateFnInvoked bool
+
+	DeleteFn        func(context.Context, *ps.DeletePostgresBouncerRequest) error
+	DeleteFnInvoked bool
+}
+
+func (s *PostgresBouncersService) List(ctx context.Context, req *ps.ListPostgresBouncersRequest, opts ...ps.ListOption) ([]*ps.PostgresBouncer, error) {
+	s.ListFnInvoked = true
+	return s.ListFn(ctx, req, opts...)
+}
+
+func (s *PostgresBouncersService) Get(ctx context.Context, req *ps.GetPostgresBouncerRequest) (*ps.PostgresBouncer, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
+}
+
+func (s *PostgresBouncersService) Create(ctx context.Context, req *ps.CreatePostgresBouncerRequest) (*ps.PostgresBouncer, error) {
+	s.CreateFnInvoked = true
+	return s.CreateFn(ctx, req)
+}
+
+func (s *PostgresBouncersService) Delete(ctx context.Context, req *ps.DeletePostgresBouncerRequest) error {
+	s.DeleteFnInvoked = true
+	return s.DeleteFn(ctx, req)
+}

--- a/internal/mock/postgres_bouncer.go
+++ b/internal/mock/postgres_bouncer.go
@@ -18,6 +18,15 @@ type PostgresBouncersService struct {
 
 	DeleteFn        func(context.Context, *ps.DeletePostgresBouncerRequest) error
 	DeleteFnInvoked bool
+
+	ListResizesFn        func(context.Context, *ps.ListPostgresBouncerResizesRequest, ...ps.ListOption) ([]*ps.PostgresBouncerResizeRequest, error)
+	ListResizesFnInvoked bool
+
+	ResizeFn        func(context.Context, *ps.ResizePostgresBouncerRequest) (*ps.PostgresBouncerResizeRequest, error)
+	ResizeFnInvoked bool
+
+	CancelResizesFn        func(context.Context, *ps.CancelPostgresBouncerResizesRequest) error
+	CancelResizesFnInvoked bool
 }
 
 func (s *PostgresBouncersService) List(ctx context.Context, req *ps.ListPostgresBouncersRequest, opts ...ps.ListOption) ([]*ps.PostgresBouncer, error) {
@@ -38,4 +47,19 @@ func (s *PostgresBouncersService) Create(ctx context.Context, req *ps.CreatePost
 func (s *PostgresBouncersService) Delete(ctx context.Context, req *ps.DeletePostgresBouncerRequest) error {
 	s.DeleteFnInvoked = true
 	return s.DeleteFn(ctx, req)
+}
+
+func (s *PostgresBouncersService) ListResizes(ctx context.Context, req *ps.ListPostgresBouncerResizesRequest, opts ...ps.ListOption) ([]*ps.PostgresBouncerResizeRequest, error) {
+	s.ListResizesFnInvoked = true
+	return s.ListResizesFn(ctx, req, opts...)
+}
+
+func (s *PostgresBouncersService) Resize(ctx context.Context, req *ps.ResizePostgresBouncerRequest) (*ps.PostgresBouncerResizeRequest, error) {
+	s.ResizeFnInvoked = true
+	return s.ResizeFn(ctx, req)
+}
+
+func (s *PostgresBouncersService) CancelResizes(ctx context.Context, req *ps.CancelPostgresBouncerResizesRequest) error {
+	s.CancelResizesFnInvoked = true
+	return s.CancelResizesFn(ctx, req)
 }

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -66,6 +66,7 @@ type Client struct {
 	Passwords             PasswordsService
 	PlannedReparentShard  PlannedReparentShardService
 	PostgresBranches      PostgresBranchesService
+	PostgresBouncers      PostgresBouncersService
 	PostgresRoles         PostgresRolesService
 	Processlist           ProcesslistService
 	QueryInsights         QueryInsightsService
@@ -337,6 +338,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.PlannedReparentShard = &plannedReparentShardService{client: c}
 	c.Processlist = &processlistService{client: c}
 	c.PostgresBranches = &postgresBranchesService{client: c}
+	c.PostgresBouncers = &postgresBouncersService{client: c}
 	c.PostgresRoles = &postgresRolesService{client: c}
 	c.QueryInsights = &queryInsightsService{client: c}
 	c.QueryPatterns = &queryPatternsService{client: c}

--- a/internal/planetscale/postgres_bouncer_resizes.go
+++ b/internal/planetscale/postgres_bouncer_resizes.go
@@ -17,22 +17,22 @@ const (
 
 // PostgresBouncerResizeRequest is an asynchronous dedicated-PgBouncer change.
 type PostgresBouncerResizeRequest struct {
-	ID                      string                      `json:"id"`
-	State                   string                      `json:"state"`
-	ReplicasPerCell         int                         `json:"replicas_per_cell"`
-	Target                  string                      `json:"target"`
-	Parameters              map[string]any              `json:"parameters"`
-	PreviousReplicasPerCell int                         `json:"previous_replicas_per_cell"`
-	PreviousTarget          string                      `json:"previous_target"`
-	PreviousParameters      map[string]any              `json:"previous_parameters"`
-	StartedAt               *time.Time                  `json:"started_at"`
-	CompletedAt             *time.Time                  `json:"completed_at"`
-	CreatedAt               time.Time                   `json:"created_at"`
-	UpdatedAt               time.Time                   `json:"updated_at"`
-	Actor       Actor                 `json:"actor"`
-	Bouncer     PostgresBouncerBranch `json:"bouncer"`
-	SKU         *PostgresBouncerSKU   `json:"sku"`
-	PreviousSKU *PostgresBouncerSKU   `json:"previous_sku"`
+	ID                      string                `json:"id"`
+	State                   string                `json:"state"`
+	ReplicasPerCell         int                   `json:"replicas_per_cell"`
+	Target                  string                `json:"target"`
+	Parameters              map[string]any        `json:"parameters"`
+	PreviousReplicasPerCell int                   `json:"previous_replicas_per_cell"`
+	PreviousTarget          string                `json:"previous_target"`
+	PreviousParameters      map[string]any        `json:"previous_parameters"`
+	StartedAt               *time.Time            `json:"started_at"`
+	CompletedAt             *time.Time            `json:"completed_at"`
+	CreatedAt               time.Time             `json:"created_at"`
+	UpdatedAt               time.Time             `json:"updated_at"`
+	Actor                   Actor                 `json:"actor"`
+	Bouncer                 PostgresBouncerBranch `json:"bouncer"`
+	SKU                     *PostgresBouncerSKU   `json:"sku"`
+	PreviousSKU             *PostgresBouncerSKU   `json:"previous_sku"`
 }
 
 // Finished reports whether the resize request is in a terminal state.
@@ -104,6 +104,13 @@ func (s *postgresBouncersService) Resize(ctx context.Context, resizeReq *ResizeP
 	out := &PostgresBouncerResizeRequest{}
 	if err := s.client.do(ctx, req, &out); err != nil {
 		return nil, err
+	}
+
+	// An empty body (for example a 204 when the bouncer already matches the
+	// requested configuration) leaves the ID empty. Surface that as a nil
+	// resize request so callers can detect the no-op.
+	if out.ID == "" {
+		return nil, nil
 	}
 
 	return out, nil

--- a/internal/planetscale/postgres_bouncer_resizes.go
+++ b/internal/planetscale/postgres_bouncer_resizes.go
@@ -1,0 +1,124 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"time"
+)
+
+const (
+	PostgresBouncerResizeStatePending   = "pending"
+	PostgresBouncerResizeStateResizing  = "resizing"
+	PostgresBouncerResizeStateCanceled  = "canceled"
+	PostgresBouncerResizeStateCompleted = "completed"
+)
+
+// PostgresBouncerResizeRequest is an asynchronous dedicated-PgBouncer change.
+type PostgresBouncerResizeRequest struct {
+	ID                      string                      `json:"id"`
+	State                   string                      `json:"state"`
+	ReplicasPerCell         int                         `json:"replicas_per_cell"`
+	Target                  string                      `json:"target"`
+	Parameters              map[string]any              `json:"parameters"`
+	PreviousReplicasPerCell int                         `json:"previous_replicas_per_cell"`
+	PreviousTarget          string                      `json:"previous_target"`
+	PreviousParameters      map[string]any              `json:"previous_parameters"`
+	StartedAt               *time.Time                  `json:"started_at"`
+	CompletedAt             *time.Time                  `json:"completed_at"`
+	CreatedAt               time.Time                   `json:"created_at"`
+	UpdatedAt               time.Time                   `json:"updated_at"`
+	Actor       Actor                 `json:"actor"`
+	Bouncer     PostgresBouncerBranch `json:"bouncer"`
+	SKU         *PostgresBouncerSKU   `json:"sku"`
+	PreviousSKU *PostgresBouncerSKU   `json:"previous_sku"`
+}
+
+// Finished reports whether the resize request is in a terminal state.
+func (r *PostgresBouncerResizeRequest) Finished() bool {
+	return r.State == PostgresBouncerResizeStateCompleted || r.State == PostgresBouncerResizeStateCanceled
+}
+
+type postgresBouncerResizesResponse struct {
+	Resizes []*PostgresBouncerResizeRequest `json:"data"`
+}
+
+// ListPostgresBouncerResizesRequest lists resize requests for one bouncer.
+type ListPostgresBouncerResizesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Bouncer      string
+}
+
+// ResizePostgresBouncerRequest upserts a resize request for a bouncer.
+type ResizePostgresBouncerRequest struct {
+	Organization    string                       `json:"-"`
+	Database        string                       `json:"-"`
+	Branch          string                       `json:"-"`
+	Bouncer         string                       `json:"-"`
+	BouncerSize     string                       `json:"bouncer_size,omitempty"`
+	ReplicasPerCell *int                         `json:"replicas_per_cell,omitempty"`
+	Target          string                       `json:"target,omitempty"`
+	Parameters      map[string]map[string]string `json:"parameters,omitempty"`
+}
+
+// CancelPostgresBouncerResizesRequest cancels unfinished resize requests.
+type CancelPostgresBouncerResizesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Bouncer      string
+}
+
+// ListResizes lists resize requests for a dedicated PgBouncer (newest first).
+func (s *postgresBouncersService) ListResizes(ctx context.Context, listReq *ListPostgresBouncerResizesRequest, opts ...ListOption) ([]*PostgresBouncerResizeRequest, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, postgresBouncerResizesAPIPath(listReq.Organization, listReq.Database, listReq.Branch, listReq.Bouncer), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list postgres bouncer resizes: %w", err)
+	}
+
+	resp := &postgresBouncerResizesResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Resizes, nil
+}
+
+// Resize upserts a resize request for a dedicated PgBouncer.
+func (s *postgresBouncersService) Resize(ctx context.Context, resizeReq *ResizePostgresBouncerRequest) (*PostgresBouncerResizeRequest, error) {
+	req, err := s.client.newRequest(http.MethodPatch, postgresBouncerResizesAPIPath(resizeReq.Organization, resizeReq.Database, resizeReq.Branch, resizeReq.Bouncer), resizeReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for resize postgres bouncer: %w", err)
+	}
+
+	out := &PostgresBouncerResizeRequest{}
+	if err := s.client.do(ctx, req, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// CancelResizes cancels unfinished resize requests for a dedicated PgBouncer.
+func (s *postgresBouncersService) CancelResizes(ctx context.Context, cancelReq *CancelPostgresBouncerResizesRequest) error {
+	req, err := s.client.newRequest(http.MethodDelete, postgresBouncerResizesAPIPath(cancelReq.Organization, cancelReq.Database, cancelReq.Branch, cancelReq.Bouncer), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for cancel postgres bouncer resizes: %w", err)
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+func postgresBouncerResizesAPIPath(org, db, branch, bouncer string) string {
+	return path.Join(postgresBouncerAPIPath(org, db, branch, bouncer), "resizes")
+}

--- a/internal/planetscale/postgres_bouncers.go
+++ b/internal/planetscale/postgres_bouncers.go
@@ -1,0 +1,180 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"time"
+)
+
+// PostgresBouncerSKU represents the size of a dedicated PgBouncer.
+type PostgresBouncerSKU struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	CPU         string `json:"cpu"`
+	RAM         int64  `json:"ram"`
+	SortOrder   int    `json:"sort_order"`
+}
+
+// PostgresBouncerBranch is the branch identity embedded on a bouncer response.
+type PostgresBouncerBranch struct {
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+	DeletedAt *time.Time `json:"deleted_at"`
+}
+
+// PostgresBouncerParameter is a configured PgBouncer parameter on a bouncer.
+type PostgresBouncerParameter struct {
+	ID            string    `json:"id"`
+	Namespace     string    `json:"namespace"`
+	Name          string    `json:"name"`
+	DisplayName   string    `json:"display_name"`
+	Category      string    `json:"category"`
+	Description   string    `json:"description"`
+	Immutable     bool      `json:"immutable"`
+	ParameterType string    `json:"parameter_type"`
+	DefaultValue  string    `json:"default_value"`
+	Value         string    `json:"value"`
+	Required      bool      `json:"required"`
+	Restart       bool      `json:"restart"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// PostgresBouncer represents a dedicated PgBouncer for a Postgres branch.
+type PostgresBouncer struct {
+	ID              string                      `json:"id"`
+	Name            string                      `json:"name"`
+	SKU             *PostgresBouncerSKU         `json:"sku"`
+	Target          string                      `json:"target"`
+	ReplicasPerCell int                         `json:"replicas_per_cell"`
+	CreatedAt       time.Time                   `json:"created_at"`
+	UpdatedAt       time.Time                   `json:"updated_at"`
+	DeletedAt       *time.Time                  `json:"deleted_at"`
+	Actor           Actor                       `json:"actor"`
+	Branch          PostgresBouncerBranch       `json:"branch"`
+	Parameters      []*PostgresBouncerParameter `json:"parameters"`
+	// Deprecated response fields retained for compatibility with older API payloads.
+	BouncerSize string `json:"bouncer_size,omitempty"`
+}
+
+type postgresBouncersResponse struct {
+	Bouncers []*PostgresBouncer `json:"data"`
+}
+
+// ListPostgresBouncersRequest encapsulates listing PgBouncers for a branch.
+type ListPostgresBouncersRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+}
+
+// GetPostgresBouncerRequest encapsulates getting a PgBouncer by name.
+type GetPostgresBouncerRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Bouncer      string
+}
+
+// CreatePostgresBouncerRequest encapsulates creating a dedicated PgBouncer.
+type CreatePostgresBouncerRequest struct {
+	Organization    string `json:"-"`
+	Database        string `json:"-"`
+	Branch          string `json:"-"`
+	Name            string `json:"name,omitempty"`
+	Target          string `json:"target"`
+	BouncerSize     string `json:"bouncer_size,omitempty"`
+	ReplicasPerCell *int   `json:"replicas_per_cell,omitempty"`
+}
+
+// DeletePostgresBouncerRequest encapsulates deleting a PgBouncer by name.
+type DeletePostgresBouncerRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Bouncer      string
+}
+
+// PostgresBouncersService is an interface for the PlanetScale PgBouncer API.
+type PostgresBouncersService interface {
+	List(context.Context, *ListPostgresBouncersRequest, ...ListOption) ([]*PostgresBouncer, error)
+	Get(context.Context, *GetPostgresBouncerRequest) (*PostgresBouncer, error)
+	Create(context.Context, *CreatePostgresBouncerRequest) (*PostgresBouncer, error)
+	Delete(context.Context, *DeletePostgresBouncerRequest) error
+}
+
+type postgresBouncersService struct {
+	client *Client
+}
+
+var _ PostgresBouncersService = &postgresBouncersService{}
+
+func (s *postgresBouncersService) List(ctx context.Context, listReq *ListPostgresBouncersRequest, opts ...ListOption) ([]*PostgresBouncer, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, postgresBouncersAPIPath(listReq.Organization, listReq.Database, listReq.Branch), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list postgres bouncers: %w", err)
+	}
+
+	resp := &postgresBouncersResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Bouncers, nil
+}
+
+func (s *postgresBouncersService) Get(ctx context.Context, getReq *GetPostgresBouncerRequest) (*PostgresBouncer, error) {
+	req, err := s.client.newRequest(http.MethodGet, postgresBouncerAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.Bouncer), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get postgres bouncer: %w", err)
+	}
+
+	bouncer := &PostgresBouncer{}
+	if err := s.client.do(ctx, req, &bouncer); err != nil {
+		return nil, err
+	}
+
+	return bouncer, nil
+}
+
+func (s *postgresBouncersService) Create(ctx context.Context, createReq *CreatePostgresBouncerRequest) (*PostgresBouncer, error) {
+	req, err := s.client.newRequest(http.MethodPost, postgresBouncersAPIPath(createReq.Organization, createReq.Database, createReq.Branch), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for create postgres bouncer: %w", err)
+	}
+
+	bouncer := &PostgresBouncer{}
+	if err := s.client.do(ctx, req, &bouncer); err != nil {
+		return nil, err
+	}
+
+	return bouncer, nil
+}
+
+func (s *postgresBouncersService) Delete(ctx context.Context, deleteReq *DeletePostgresBouncerRequest) error {
+	req, err := s.client.newRequest(http.MethodDelete, postgresBouncerAPIPath(deleteReq.Organization, deleteReq.Database, deleteReq.Branch, deleteReq.Bouncer), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for delete postgres bouncer: %w", err)
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+func postgresBouncersAPIPath(org, db, branch string) string {
+	return path.Join("v1/organizations", org, "databases", db, "branches", branch, "bouncers")
+}
+
+func postgresBouncerAPIPath(org, db, branch, bouncer string) string {
+	return path.Join(postgresBouncersAPIPath(org, db, branch), bouncer)
+}

--- a/internal/planetscale/postgres_bouncers.go
+++ b/internal/planetscale/postgres_bouncers.go
@@ -105,6 +105,9 @@ type PostgresBouncersService interface {
 	Get(context.Context, *GetPostgresBouncerRequest) (*PostgresBouncer, error)
 	Create(context.Context, *CreatePostgresBouncerRequest) (*PostgresBouncer, error)
 	Delete(context.Context, *DeletePostgresBouncerRequest) error
+	ListResizes(context.Context, *ListPostgresBouncerResizesRequest, ...ListOption) ([]*PostgresBouncerResizeRequest, error)
+	Resize(context.Context, *ResizePostgresBouncerRequest) (*PostgresBouncerResizeRequest, error)
+	CancelResizes(context.Context, *CancelPostgresBouncerResizesRequest) error
 }
 
 type postgresBouncersService struct {

--- a/internal/planetscale/postgres_bouncers_test.go
+++ b/internal/planetscale/postgres_bouncers_test.go
@@ -163,3 +163,129 @@ func TestPostgresBouncers_Delete(t *testing.T) {
 	})
 	c.Assert(err, qt.IsNil)
 }
+
+func TestPostgresBouncers_ListResizes(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers/read-pool/resizes")
+		w.WriteHeader(200)
+		out := `{
+			"data":[{
+				"id":"resize-1",
+				"state":"pending",
+				"replicas_per_cell":2,
+				"target":"replica",
+				"parameters":{},
+				"previous_replicas_per_cell":1,
+				"previous_target":"replica",
+				"previous_parameters":{},
+				"started_at":null,
+				"completed_at":null,
+				"created_at":"2021-01-14T10:19:23.000Z",
+				"updated_at":"2021-01-14T10:19:23.000Z",
+				"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},
+				"bouncer":{"id":"bouncer-1","name":"read-pool","created_at":"2021-01-01T00:00:00.000Z","updated_at":"2021-01-01T00:00:00.000Z","deleted_at":null},
+				"sku":{"name":"PGB_10","display_name":"PS-10","cpu":"0.25","ram":268435456,"sort_order":1},
+				"previous_sku":{"name":"PGB_5","display_name":"PS-5","cpu":"0.125","ram":134217728,"sort_order":0}
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	resizes, err := client.PostgresBouncers.ListResizes(context.Background(), &ListPostgresBouncerResizesRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+		Bouncer:      "read-pool",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(resizes, qt.HasLen, 1)
+	c.Assert(resizes[0].ID, qt.Equals, "resize-1")
+	c.Assert(resizes[0].State, qt.Equals, PostgresBouncerResizeStatePending)
+	c.Assert(resizes[0].SKU.Name, qt.Equals, "PGB_10")
+	c.Assert(resizes[0].Finished(), qt.IsFalse)
+}
+
+func TestPostgresBouncers_Resize(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers/read-pool/resizes")
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body["bouncer_size"], qt.Equals, "PGB_10")
+		c.Assert(body["target"], qt.Equals, "replica")
+		w.WriteHeader(200)
+		out := `{
+			"id":"resize-1",
+			"state":"pending",
+			"replicas_per_cell":1,
+			"target":"replica",
+			"parameters":{},
+			"previous_replicas_per_cell":1,
+			"previous_target":"replica",
+			"previous_parameters":{},
+			"started_at":null,
+			"completed_at":null,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z",
+			"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},
+			"bouncer":{"id":"bouncer-1","name":"read-pool","created_at":"2021-01-01T00:00:00.000Z","updated_at":"2021-01-01T00:00:00.000Z","deleted_at":null},
+			"sku":{"name":"PGB_10","display_name":"PS-10","cpu":"0.25","ram":268435456,"sort_order":1},
+			"previous_sku":{"name":"PGB_5","display_name":"PS-5","cpu":"0.125","ram":134217728,"sort_order":0}
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	resize, err := client.PostgresBouncers.Resize(context.Background(), &ResizePostgresBouncerRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+		Bouncer:      "read-pool",
+		BouncerSize:  "PGB_10",
+		Target:       "replica",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(resize.ID, qt.Equals, "resize-1")
+	c.Assert(resize.State, qt.Equals, PostgresBouncerResizeStatePending)
+}
+
+func TestPostgresBouncers_CancelResizes(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers/read-pool/resizes")
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.PostgresBouncers.CancelResizes(context.Background(), &CancelPostgresBouncerResizesRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+		Bouncer:      "read-pool",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestPostgresBouncerResizeRequest_Finished(t *testing.T) {
+	c := qt.New(t)
+	c.Assert((&PostgresBouncerResizeRequest{State: PostgresBouncerResizeStatePending}).Finished(), qt.IsFalse)
+	c.Assert((&PostgresBouncerResizeRequest{State: PostgresBouncerResizeStateResizing}).Finished(), qt.IsFalse)
+	c.Assert((&PostgresBouncerResizeRequest{State: PostgresBouncerResizeStateCompleted}).Finished(), qt.IsTrue)
+	c.Assert((&PostgresBouncerResizeRequest{State: PostgresBouncerResizeStateCanceled}).Finished(), qt.IsTrue)
+}

--- a/internal/planetscale/postgres_bouncers_test.go
+++ b/internal/planetscale/postgres_bouncers_test.go
@@ -289,3 +289,25 @@ func TestPostgresBouncerResizeRequest_Finished(t *testing.T) {
 	c.Assert((&PostgresBouncerResizeRequest{State: PostgresBouncerResizeStateCompleted}).Finished(), qt.IsTrue)
 	c.Assert((&PostgresBouncerResizeRequest{State: PostgresBouncerResizeStateCanceled}).Finished(), qt.IsTrue)
 }
+
+func TestPostgresBouncers_Resize_NoChange(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	resize, err := client.PostgresBouncers.Resize(context.Background(), &ResizePostgresBouncerRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+		Bouncer:      "read-pool",
+		BouncerSize:  "PGB_10",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(resize, qt.IsNil)
+}

--- a/internal/planetscale/postgres_bouncers_test.go
+++ b/internal/planetscale/postgres_bouncers_test.go
@@ -1,0 +1,165 @@
+package planetscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPostgresBouncers_List(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers")
+		w.WriteHeader(200)
+		out := `{
+			"data":[{
+				"id":"bouncer-1",
+				"name":"read-pool",
+				"sku":{"name":"PGB_10","display_name":"PS-10","cpu":"0.25","ram":268435456,"sort_order":1},
+				"target":"replica",
+				"replicas_per_cell":1,
+				"created_at":"2021-01-14T10:19:23.000Z",
+				"updated_at":"2021-01-14T10:19:23.000Z",
+				"deleted_at":null,
+				"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},
+				"branch":{"id":"branch-1","name":"main","created_at":"2021-01-01T00:00:00.000Z","updated_at":"2021-01-01T00:00:00.000Z","deleted_at":null},
+				"parameters":[]
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	bouncers, err := client.PostgresBouncers.List(context.Background(), &ListPostgresBouncersRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(bouncers, qt.HasLen, 1)
+	c.Assert(bouncers[0].Name, qt.Equals, "read-pool")
+	c.Assert(bouncers[0].Target, qt.Equals, "replica")
+	c.Assert(bouncers[0].SKU.Name, qt.Equals, "PGB_10")
+	c.Assert(bouncers[0].Branch.Name, qt.Equals, "main")
+}
+
+func TestPostgresBouncers_Get(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers/read-pool")
+		w.WriteHeader(200)
+		out := `{
+			"id":"bouncer-1",
+			"name":"read-pool",
+			"sku":{"name":"PGB_10","display_name":"PS-10","cpu":"0.25","ram":268435456,"sort_order":1},
+			"target":"replica",
+			"replicas_per_cell":2,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z",
+			"deleted_at":null,
+			"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},
+			"branch":{"id":"branch-1","name":"main","created_at":"2021-01-01T00:00:00.000Z","updated_at":"2021-01-01T00:00:00.000Z","deleted_at":null},
+			"parameters":[{"id":"p1","namespace":"pgbouncer","name":"default_pool_size","display_name":"Default pool size","category":"","description":"","immutable":false,"parameter_type":"integer","default_value":"20","value":"50","required":false,"restart":false,"created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	bouncer, err := client.PostgresBouncers.Get(context.Background(), &GetPostgresBouncerRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+		Bouncer:      "read-pool",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(bouncer.ReplicasPerCell, qt.Equals, 2)
+	c.Assert(bouncer.Parameters, qt.HasLen, 1)
+	c.Assert(bouncer.Parameters[0].Value, qt.Equals, "50")
+}
+
+func TestPostgresBouncers_Create(t *testing.T) {
+	c := qt.New(t)
+
+	replicas := 2
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers")
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["name"], qt.Equals, "read-pool")
+		c.Assert(body["target"], qt.Equals, "replica")
+		c.Assert(body["bouncer_size"], qt.Equals, "PGB_10")
+		c.Assert(body["replicas_per_cell"], qt.Equals, float64(2))
+
+		w.WriteHeader(200)
+		out := `{
+			"id":"bouncer-2",
+			"name":"read-pool",
+			"sku":{"name":"PGB_10","display_name":"PS-10","cpu":"0.25","ram":268435456,"sort_order":1},
+			"target":"replica",
+			"replicas_per_cell":2,
+			"created_at":"2021-01-14T10:19:23.000Z",
+			"updated_at":"2021-01-14T10:19:23.000Z",
+			"deleted_at":null,
+			"actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},
+			"branch":{"id":"branch-1","name":"main","created_at":"2021-01-01T00:00:00.000Z","updated_at":"2021-01-01T00:00:00.000Z","deleted_at":null},
+			"parameters":[]
+		}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	bouncer, err := client.PostgresBouncers.Create(context.Background(), &CreatePostgresBouncerRequest{
+		Organization:    testOrg,
+		Database:        "my-db",
+		Branch:          "main",
+		Name:            "read-pool",
+		Target:          "replica",
+		BouncerSize:     "PGB_10",
+		ReplicasPerCell: &replicas,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(bouncer.ID, qt.Equals, "bouncer-2")
+	c.Assert(bouncer.CreatedAt.Equal(time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)), qt.IsTrue)
+}
+
+func TestPostgresBouncers_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/bouncers/read-pool")
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.PostgresBouncers.Delete(context.Background(), &DeletePostgresBouncerRequest{
+		Organization: testOrg,
+		Database:     "my-db",
+		Branch:       "main",
+		Bouncer:      "read-pool",
+	})
+	c.Assert(err, qt.IsNil)
+}


### PR DESCRIPTION
## Summary
- Adds `pscale pgbouncer list|show|create|delete|resize` for dedicated Postgres branch PgBouncers (API client + mocks + CLI).
- Resize queues an async change request (`--size`, `--replicas-per-cell`, `--target`, `--parameters`) with `resize status` / `resize cancel` and optional `--wait`.
- PrefLights with `RequirePostgresDatabase` so Vitess/MySQL get a clear engine error (API currently returns a generic `not_found`).
- Distinct from `pscale branch resize` `pgbouncer.*` parameters (local node pooler knobs).

## Test plan
- [x] `go test ./internal/cmd/pgbouncer/ ./internal/planetscale/ -count=1`
- [x] Local pscaledev: create → resize → status → cancel → delete on `speedydb/odcr-160/main`
- [x] Vitess reject on `odcr-m160-vitess`
- [x] Resize with no flags rejected client-side
