### PR TITLE
Add pscale insights recommendations dismiss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,6 +227,7 @@ pscale insights queries <database> <branch> --org <org> --format json --sort tot
 pscale insights errors <database> <branch> --org <org> --format json                     # failing queries with error messages
 pscale insights anomalies <database> <branch> --org <org> --format json                  # detected resource anomalies (CPU, memory, IOPS, rows)
 pscale insights recommendations <database> --org <org> --format json                     # schema recommendations with ready-to-apply DDL
+pscale insights recommendations dismiss <database> <number> --org <org> --format json --force  # dismiss a recommendation
 ```
 
 **`pscale inspect`** — live, point-in-time checks run over a direct connection (same credentials model as `pscale sql`, always read-only):

--- a/internal/cmd/insights/queries_test.go
+++ b/internal/cmd/insights/queries_test.go
@@ -166,3 +166,53 @@ func TestInsights_RecommendationsCmd(t *testing.T) {
 	c.Assert(out[0]["recommendation_type"], qt.Equals, "duplicate_index")
 	c.Assert(out[0]["ddl_statement"], qt.Equals, "ALTER TABLE users DROP INDEX idx_email")
 }
+
+func TestInsights_RecommendationDismissCmd(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.SchemaRecommendationService{
+		DismissFn: func(ctx context.Context, req *ps.DismissSchemaRecommendationRequest) (*ps.SchemaRecommendation, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.ID, qt.Equals, "42")
+			c.Assert(req.Reason, qt.Equals, "false positive")
+			return &ps.SchemaRecommendation{
+				ID:                 "rec-42",
+				Number:             42,
+				State:              "dismissed",
+				RecommendationType: "unused_index",
+				Table:              "users",
+				Title:              "Drop unused index",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{SchemaRecommendations: svc})
+
+	cmd := RecommendationDismissCmd(ch)
+	cmd.SetArgs([]string{"mydb", "42", "--force", "--reason", "false positive"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.DismissFnInvoked, qt.IsTrue)
+
+	var out map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out["state"], qt.Equals, "dismissed")
+	c.Assert(out["number"], qt.Equals, float64(42))
+}
+
+func TestInsights_RecommendationDismissCmd_RequiresForceInJSON(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.SchemaRecommendationService{}
+	ch := testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{SchemaRecommendations: svc})
+
+	cmd := RecommendationDismissCmd(ch)
+	cmd.SetArgs([]string{"mydb", "42"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*run with --force.*`)
+	c.Assert(svc.DismissFnInvoked, qt.IsFalse)
+}

--- a/internal/cmd/insights/recommendation_dismiss.go
+++ b/internal/cmd/insights/recommendation_dismiss.go
@@ -1,0 +1,86 @@
+package insights
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+// RecommendationDismissCmd dismisses a schema recommendation.
+func RecommendationDismissCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		reason string
+		force  bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "dismiss <database> <number>",
+		Short: "Dismiss a schema recommendation",
+		Long: `Dismiss a schema recommendation so it no longer appears as open.
+
+<number> is the recommendation sequence number from
+'pscale insights recommendations <database>'.`,
+		Args: cmdutil.RequiredArgs("database", "number"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			number := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if !flags.force {
+				if err := ch.Printer.ConfirmCommand(number, "dismiss schema recommendation", "dismissal of schema recommendation"); err != nil {
+					return err
+				}
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Dismissing schema recommendation %s for %s...",
+				printer.BoldBlue(number), printer.BoldBlue(database)))
+			defer end()
+
+			recommendation, err := client.SchemaRecommendations.Dismiss(ctx, &ps.DismissSchemaRecommendationRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           number,
+				Reason:       flags.reason,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("schema recommendation %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(number), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(recommendation)
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Schema recommendation %s was dismissed from %s.\n",
+					printer.BoldBlue(number), printer.BoldBlue(database))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "schema recommendation dismissed",
+				"number": number,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.reason, "reason", "", "Optional reason for dismissing the recommendation")
+	cmd.Flags().BoolVar(&flags.force, "force", false, "Dismiss without confirmation")
+
+	return cmd
+}

--- a/internal/cmd/insights/recommendations.go
+++ b/internal/cmd/insights/recommendations.go
@@ -28,7 +28,9 @@ func RecommendationsCmd(ch *cmdutil.Helper) *cobra.Command {
 		Long: `List PlanetScale's schema recommendations for a database: unused tables and
 indexes, duplicate indexes, bloated tables and indexes, missing indexes
 derived from production query patterns, and sequence overflow risks. Each
-recommendation includes ready-to-apply DDL (shown with --format json).`,
+recommendation includes ready-to-apply DDL (shown with --format json).
+
+Use "pscale insights recommendations dismiss" to dismiss a recommendation.`,
 		Aliases: []string{"recommendation"},
 		Args:    cmdutil.RequiredArgs("database"),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -77,6 +79,8 @@ recommendation includes ready-to-apply DDL (shown with --format json).`,
 			return ch.Printer.PrintResource(rows)
 		},
 	}
+
+	cmd.AddCommand(RecommendationDismissCmd(ch))
 
 	return cmd
 }

--- a/internal/planetscale/schema_recommendations.go
+++ b/internal/planetscale/schema_recommendations.go
@@ -60,10 +60,12 @@ type GetSchemaRecommendationRequest struct {
 }
 
 // DismissSchemaRecommendationRequest is the request for dismissing a schema recommendation.
+// ID is the recommendation sequence number from list/show (path param `number`).
 type DismissSchemaRecommendationRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	ID           string `json:"-"`
+	Reason       string `json:"reason,omitempty"`
 }
 
 type schemaRecommendationService struct {
@@ -101,7 +103,7 @@ func (s *schemaRecommendationService) Get(ctx context.Context, request *GetSchem
 }
 
 func (s *schemaRecommendationService) Dismiss(ctx context.Context, request *DismissSchemaRecommendationRequest) (*SchemaRecommendation, error) {
-	req, err := s.client.newRequest(http.MethodPost, dismissSchemaRecommendationAPIPath(request.Organization, request.Database, request.ID), nil)
+	req, err := s.client.newRequest(http.MethodPost, dismissSchemaRecommendationAPIPath(request.Organization, request.Database, request.ID), request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/planetscale/schema_recommendations_test.go
+++ b/internal/planetscale/schema_recommendations_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -158,7 +159,11 @@ func TestSchemaRecommendations_Dismiss(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		c.Assert(r.Method, qt.Equals, http.MethodPost)
-		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/schema-recommendations/recommendation-123/dismiss")
+		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/schema-recommendations/1/dismiss")
+
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body["reason"], qt.Equals, "not applicable")
 
 		out := `{
 			"id": "recommendation-123",
@@ -191,7 +196,8 @@ func TestSchemaRecommendations_Dismiss(t *testing.T) {
 	recommendation, err := client.SchemaRecommendations.Dismiss(ctx, &DismissSchemaRecommendationRequest{
 		Organization: testOrg,
 		Database:     testDatabase,
-		ID:           "recommendation-123",
+		ID:           "1",
+		Reason:       "not applicable",
 	})
 
 	c.Assert(err, qt.IsNil)


### PR DESCRIPTION
## Summary
- Adds `pscale insights recommendations dismiss <database> <number>` with optional `--reason` and `--force` (required for non-human formats).
- Sends the dismiss reason in the API request body; path uses the recommendation sequence `number` from list.
- Documents the command in `AGENTS.md`. Skips `show`/`get` since list already returns the full recommendation objects including DDL.

Closes the schema-recommendations get/dismiss gap from planetscale/surfaces#3859 (dismiss only; get deferred).

## Test plan
- [x] Unit tests for API client dismiss body + CLI dismiss/`--force` gate
- [x] `go test ./internal/cmd/insights/ ./internal/planetscale/ -count=1`
- [x] Live: `pscale insights recommendations <db> --org <org> --format json` then dismiss an open `number` with `--force`
- [x] Confirm human mode prompts without `--force`; JSON mode requires `--force`