### PR TITLE
Add insights query samples and query tags commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,8 +224,11 @@ Two complementary read-only surfaces. When diagnosing database health or perform
 
 ```bash
 pscale insights queries <database> <branch> --org <org> --format json --sort totalTime   # top queries; sorts: totalTime, count, p99Latency, rowsRead, rowsReadPerReturned, errorCount, ...
+pscale insights queries samples <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # recent executions; keyspace from queries list
 pscale insights errors <database> <branch> --org <org> --format json                     # failing queries with error messages
 pscale insights anomalies <database> <branch> --org <org> --format json                  # detected resource anomalies (CPU, memory, IOPS, rows)
+pscale insights tags <database> <branch> --org <org> --format json                       # query tag keys (sqlcommenter / system); use names with summaries
+pscale insights tags summaries <database> <branch> --org <org> --format json --tags username  # stats grouped by tag; names match the Insights UI Key picker
 pscale insights recommendations <database> --org <org> --format json                     # schema recommendations with ready-to-apply DDL
 pscale insights recommendations dismiss <database> <number> --org <org> --format json --force  # dismiss a recommendation
 ```

--- a/internal/cmd/insights/errors.go
+++ b/internal/cmd/insights/errors.go
@@ -76,7 +76,7 @@ func ErrorsCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&flags.limit, "limit", 15, "Number of errors to return")
-	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 24h)")
+	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 1d)")
 
 	return cmd
 }

--- a/internal/cmd/insights/insights.go
+++ b/internal/cmd/insights/insights.go
@@ -32,6 +32,7 @@ see pscale inspect.`,
 	cmd.AddCommand(QueriesCmd(ch))
 	cmd.AddCommand(ErrorsCmd(ch))
 	cmd.AddCommand(AnomaliesCmd(ch))
+	cmd.AddCommand(TagsCmd(ch))
 	cmd.AddCommand(RecommendationsCmd(ch))
 
 	return cmd

--- a/internal/cmd/insights/queries.go
+++ b/internal/cmd/insights/queries.go
@@ -32,6 +32,8 @@ var sortMetrics = []string{
 
 // QueryRow is a query statistics row formatted for table output.
 type QueryRow struct {
+	Fingerprint   string  `header:"fingerprint" json:"fingerprint"`
+	Keyspace      string  `header:"keyspace" json:"keyspace"`
 	Count         int64   `header:"count" json:"query_count"`
 	TotalTimeMs   float64 `header:"total time (ms)" json:"sum_total_duration_millis"`
 	TimePerQryMs  float64 `header:"per query (ms)" json:"time_per_query"`
@@ -63,7 +65,10 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
   pscale insights queries mydb main --org myorg --sort rowsReadPerReturned
 
   # Highest p99 latency over the last hour
-  pscale insights queries mydb main --org myorg --sort p99Latency --period 1h`,
+  pscale insights queries mydb main --org myorg --sort p99Latency --period 1h
+
+  # Recent executions for a fingerprint from the list (keyspace is required)
+  pscale insights queries samples mydb main b129e8fa --org myorg --keyspace mydb`,
 		Args: cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -112,7 +117,9 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 		fmt.Sprintf("Metric to rank queries by, one of: %s", strings.Join(sortMetrics, ", ")))
 	cmd.Flags().StringVar(&flags.dir, "dir", "desc", "Sort direction: asc or desc")
 	cmd.Flags().IntVar(&flags.limit, "limit", 15, "Number of queries to return")
-	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 24h)")
+	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 1d)")
+
+	cmd.AddCommand(QuerySamplesCmd(ch))
 
 	return cmd
 }
@@ -121,6 +128,8 @@ func toQueryRows(insights []*ps.QueryInsight) []*QueryRow {
 	rows := make([]*QueryRow, 0, len(insights))
 	for _, in := range insights {
 		rows = append(rows, &QueryRow{
+			Fingerprint:   in.Fingerprint,
+			Keyspace:      in.Keyspace,
 			Count:         in.QueryCount,
 			TotalTimeMs:   round2(in.SumTotalDurationMillis),
 			TimePerQryMs:  round2(in.TimePerQuery),

--- a/internal/cmd/insights/queries_test.go
+++ b/internal/cmd/insights/queries_test.go
@@ -253,7 +253,6 @@ func TestInsights_QuerySamplesCmd(t *testing.T) {
 	c.Assert(out[0]["username"], qt.Equals, "app")
 }
 
-
 func TestInsights_QuerySamplesCmd_RequiresKeyspace(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/cmd/insights/queries_test.go
+++ b/internal/cmd/insights/queries_test.go
@@ -216,3 +216,156 @@ func TestInsights_RecommendationDismissCmd_RequiresForceInJSON(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `(?s).*run with --force.*`)
 	c.Assert(svc.DismissFnInvoked, qt.IsFalse)
 }
+
+func TestInsights_QuerySamplesCmd(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.QueryInsightsService{
+		ListQuerySamplesFn: func(ctx context.Context, req *ps.ListQuerySamplesRequest, opts ...ps.ListOption) ([]*ps.QuerySample, error) {
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.Branch, qt.Equals, "main")
+			c.Assert(req.Fingerprint, qt.Equals, "b129e8fa")
+			return []*ps.QuerySample{{
+				ID:                  "exec-1",
+				Fingerprint:         "b129e8fa",
+				NormalizedSQL:       "select 1",
+				Username:            "app",
+				TotalDurationMillis: 1.5,
+				StartedAt:           time.Date(2026, 8, 11, 18, 0, 0, 0, time.UTC),
+				Tags:                []ps.QuerySampleTag{{Name: "Sapp", Value: "web"}},
+			}}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := QuerySamplesCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--keyspace", "mydb"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListQuerySamplesFnInvoked, qt.IsTrue)
+
+	var out []map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out[0]["id"], qt.Equals, "exec-1")
+	c.Assert(out[0]["username"], qt.Equals, "app")
+}
+
+
+func TestInsights_QuerySamplesCmd_RequiresKeyspace(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.QueryInsightsService{}
+	ch := testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := QuerySamplesCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "keyspace")
+	c.Assert(svc.ListQuerySamplesFnInvoked, qt.IsFalse)
+}
+
+func TestInsights_TagsCmd(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.QueryInsightsService{
+		ListTagsFn: func(ctx context.Context, req *ps.ListQueryTagsRequest, opts ...ps.ListOption) ([]*ps.QueryTag, error) {
+			return []*ps.QueryTag{{
+				ID:         "Sapp",
+				Name:       "app",
+				Source:     "sql",
+				QueryCount: 100,
+				Values:     []ps.QueryTagValue{{Name: "web", QueryCount: 80, Kind: "literal"}},
+			}}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := TagsCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListTagsFnInvoked, qt.IsTrue)
+
+	var out []map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out[0]["name"], qt.Equals, "app")
+	c.Assert(out[0]["id"], qt.Equals, "Sapp")
+}
+
+func TestInsights_TagSummariesCmd(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.QueryInsightsService{
+		ListTagsFn: func(ctx context.Context, req *ps.ListQueryTagsRequest, opts ...ps.ListOption) ([]*ps.QueryTag, error) {
+			return []*ps.QueryTag{
+				{ID: "Busername", Name: "username", Source: "system"},
+				{ID: "Sapp", Name: "app", Source: "sql"},
+			}, nil
+		},
+		ListTagSummariesFn: func(ctx context.Context, req *ps.ListTagSummariesRequest, opts ...ps.ListOption) ([]*ps.TagSummary, error) {
+			c.Assert(req.Tags, qt.DeepEquals, []string{"Busername", "Sapp"})
+			return []*ps.TagSummary{{
+				Dimensions:             map[string]string{"Busername": "alice", "Sapp": "web"},
+				QueryCount:             10,
+				SumTotalDurationMillis: 42,
+			}}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := TagSummariesCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "--tags", "username", "--tags", "app"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListTagsFnInvoked, qt.IsTrue)
+	c.Assert(svc.ListTagSummariesFnInvoked, qt.IsTrue)
+
+	var out []map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out[0]["query_count"], qt.Equals, float64(10))
+}
+
+func TestInsights_TagShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.QueryInsightsService{
+		ListTagsFn: func(ctx context.Context, req *ps.ListQueryTagsRequest, opts ...ps.ListOption) ([]*ps.QueryTag, error) {
+			return []*ps.QueryTag{{ID: "Sapp", Name: "app", Source: "sql"}}, nil
+		},
+		GetTagFn: func(ctx context.Context, req *ps.GetQueryTagRequest, opts ...ps.ListOption) (*ps.QueryTag, error) {
+			c.Assert(req.Tag, qt.Equals, "Sapp")
+			return &ps.QueryTag{
+				ID:         "Sapp",
+				Name:       "app",
+				Source:     "sql",
+				QueryCount: 100,
+				Values:     []ps.QueryTagValue{{Name: "web", QueryCount: 80, Kind: "literal"}},
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := TagShowCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "app"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetTagFnInvoked, qt.IsTrue)
+
+	var out map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out["id"], qt.Equals, "Sapp")
+}

--- a/internal/cmd/insights/query_samples.go
+++ b/internal/cmd/insights/query_samples.go
@@ -1,0 +1,101 @@
+package insights
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+// QuerySampleRow is an individual query execution for table output.
+type QuerySampleRow struct {
+	ID           string  `header:"id" json:"id"`
+	StartedAt    string  `header:"started" json:"started_at"`
+	DurationMs   float64 `header:"duration (ms)" json:"total_duration_millis"`
+	Username     string  `header:"user" json:"username"`
+	RowsRead     int64   `header:"rows read" json:"rows_read"`
+	RowsReturned int64   `header:"rows returned" json:"rows_returned"`
+	Error        string  `header:"error" json:"error_message"`
+	Query        string  `header:"query" json:"normalized_sql"`
+}
+
+// QuerySamplesCmd lists recent individual executions for a query fingerprint.
+func QuerySamplesCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		limit    int
+		period   string
+		keyspace string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "samples <database> <branch> <fingerprint>",
+		Short: "List recent executions for a query fingerprint",
+		Long: `List individual query executions for a fingerprint from
+'pscale insights queries <database> <branch>'.
+
+--keyspace is required (use the keyspace column from the queries list).
+Useful for seeing who ran the query, when, duration, and any error message.`,
+		Example: `  pscale insights queries samples mydb main b129e8fa --org myorg --keyspace mydb
+  pscale insights queries samples mydb main b129e8fa --org myorg --keyspace mydb --period 1h --limit 25`,
+		Args: cmdutil.RequiredArgs("database", "branch", "fingerprint"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, fingerprint := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching query samples for fingerprint %s on %s/%s...",
+				printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			samples, err := client.QueryInsights.ListQuerySamples(ctx, &ps.ListQuerySamplesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Fingerprint:  fingerprint,
+			}, ps.WithPerPage(flags.limit), ps.WithPeriod(flags.period), ps.WithKeyspace(flags.keyspace))
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if len(samples) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No query samples for fingerprint %s on %s/%s.\n",
+					printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch))
+				return nil
+			}
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(samples)
+			}
+
+			rows := make([]*QuerySampleRow, 0, len(samples))
+			for _, s := range samples {
+				rows = append(rows, &QuerySampleRow{
+					ID:           s.ID,
+					StartedAt:    s.StartedAt.Format("2006-01-02 15:04:05"),
+					DurationMs:   round2(s.TotalDurationMillis),
+					Username:     s.Username,
+					RowsRead:     s.RowsRead,
+					RowsReturned: s.RowsReturned,
+					Error:        truncate(s.ErrorMessage, 60),
+					Query:        truncate(s.NormalizedSQL, 60),
+				})
+			}
+			return ch.Printer.PrintResource(rows)
+		},
+	}
+
+	cmd.Flags().IntVar(&flags.limit, "limit", 25, "Number of samples to return")
+	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to look back (e.g. 1h, 1d)")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the fingerprint (required; from insights queries)")
+	cmd.MarkFlagRequired("keyspace") // nolint:errcheck
+
+	return cmd
+}

--- a/internal/cmd/insights/tags.go
+++ b/internal/cmd/insights/tags.go
@@ -1,0 +1,122 @@
+package insights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+// TagRow is a tag key for table output.
+type TagRow struct {
+	Name       string `header:"name" json:"name"`
+	Source     string `header:"source" json:"source"`
+	QueryCount int64  `header:"queries" json:"query_count"`
+	TopValues  string `header:"top values" json:"top_values"`
+}
+
+// TagsCmd lists query tags and groups related subcommands.
+func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		period      string
+		fingerprint string
+		keyspace    string
+		limit       int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "tags <database> <branch>",
+		Short: "List query tag keys (sqlcommenter / system)",
+		Long: `List query tag keys observed on a branch.
+
+Tag names match the Key picker in the PlanetScale Insights UI (e.g. app,
+username, controller). Use those names with "tags summaries --tags".
+
+Typical agent flow:
+  1. pscale insights tags <database> <branch> --format json
+  2. pscale insights tags summaries <database> <branch> --tags <name> --format json`,
+		Example: `  pscale insights tags mydb main --org myorg
+  pscale insights tags mydb main --org myorg --period 1h`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching query tags for %s in %s...",
+				printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+
+			opts := []ps.ListOption{ps.WithPeriod(flags.period)}
+			if flags.fingerprint != "" {
+				opts = append(opts, ps.WithFingerprint(flags.fingerprint))
+			}
+			if flags.keyspace != "" {
+				opts = append(opts, ps.WithKeyspace(flags.keyspace))
+			}
+
+			tags, err := client.QueryInsights.ListTags(ctx, &ps.ListQueryTagsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}, opts...)
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if len(tags) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No query tags recorded for %s in %s.\n",
+					printer.BoldBlue(branch), printer.BoldBlue(database))
+				return nil
+			}
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(tags)
+			}
+
+			rows := make([]*TagRow, 0, len(tags))
+			for _, t := range tags {
+				rows = append(rows, &TagRow{
+					Name:       t.Name,
+					Source:     t.Source,
+					QueryCount: t.QueryCount,
+					TopValues:  formatTopValues(t.Values, flags.limit),
+				})
+			}
+			return ch.Printer.PrintResource(rows)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to look back (e.g. 1h, 1d)")
+	cmd.Flags().StringVar(&flags.fingerprint, "fingerprint", "", "Only tags seen on this query fingerprint")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Filter tags to a keyspace")
+	cmd.Flags().IntVar(&flags.limit, "limit", 3, "Number of top values to show in human output")
+
+	cmd.AddCommand(TagShowCmd(ch))
+	cmd.AddCommand(TagSummariesCmd(ch))
+
+	return cmd
+}
+
+func formatTopValues(values []ps.QueryTagValue, limit int) string {
+	if limit <= 0 {
+		limit = 3
+	}
+	parts := make([]string, 0, limit)
+	for i, v := range values {
+		if i >= limit {
+			break
+		}
+		parts = append(parts, fmt.Sprintf("%s (%d)", v.Name, v.QueryCount))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/cmd/insights/tags_resolve.go
+++ b/internal/cmd/insights/tags_resolve.go
@@ -1,0 +1,87 @@
+package insights
+
+import (
+	"fmt"
+	"strings"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+// tagSourcePrefixes maps UI/source names to the API dimension id prefix.
+var tagSourcePrefixes = map[string]string{
+	"sql":    "S",
+	"system": "B",
+	"sys":    "B",
+}
+
+// resolveTagIDs maps friendly tag names (as shown in the app Key picker) to
+// API dimension ids (e.g. "app" -> "Sapp"). Inputs may also be:
+//   - already-prefixed ids ("Sapp", "Busername")
+//   - source-qualified names ("sql:app", "system:username")
+func resolveTagIDs(available []*ps.QueryTag, inputs []string) ([]string, error) {
+	byID := make(map[string]*ps.QueryTag, len(available))
+	byName := make(map[string][]*ps.QueryTag, len(available))
+	for _, t := range available {
+		byID[t.ID] = t
+		byName[t.Name] = append(byName[t.Name], t)
+	}
+
+	ids := make([]string, 0, len(inputs))
+	for _, raw := range inputs {
+		input := strings.TrimSpace(raw)
+		if input == "" {
+			continue
+		}
+
+		if t, ok := byID[input]; ok {
+			ids = append(ids, t.ID)
+			continue
+		}
+
+		source, name, hasSource := strings.Cut(input, ":")
+		if hasSource {
+			prefix, ok := tagSourcePrefixes[strings.ToLower(source)]
+			if !ok {
+				return nil, fmt.Errorf("invalid tag source %q in %q; use sql: or system: (e.g. sql:app)", source, input)
+			}
+			id := prefix + name
+			if _, ok := byID[id]; !ok {
+				return nil, fmt.Errorf("tag %q not found; run 'pscale insights tags' to list available keys", input)
+			}
+			ids = append(ids, id)
+			continue
+		}
+
+		// Prefer friendly names (UI Key picker) before treating S*/B* as ids,
+		// so names like "Status" still resolve via byName.
+		matches := byName[input]
+		switch len(matches) {
+		case 1:
+			ids = append(ids, matches[0].ID)
+			continue
+		case 0:
+			// Fall through to prefixed-id passthrough for agents.
+		default:
+			opts := make([]string, 0, len(matches))
+			for _, m := range matches {
+				opts = append(opts, m.Source+":"+m.Name)
+			}
+			return nil, fmt.Errorf("tag %q matches multiple sources (%s); disambiguate with sql:%s or system:%s",
+				input, strings.Join(opts, ", "), input, input)
+		}
+
+		// Bare prefixed id not in the current list still accepted so agents
+		// can pass ids from a prior list call.
+		if len(input) > 1 && (input[0] == 'S' || input[0] == 'B') {
+			ids = append(ids, input)
+			continue
+		}
+
+		return nil, fmt.Errorf("tag %q not found; run 'pscale insights tags' to list available keys", input)
+	}
+
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("at least one --tags value is required")
+	}
+	return ids, nil
+}

--- a/internal/cmd/insights/tags_resolve_test.go
+++ b/internal/cmd/insights/tags_resolve_test.go
@@ -1,0 +1,64 @@
+package insights
+
+import (
+	"testing"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestResolveTagIDs(t *testing.T) {
+	c := qt.New(t)
+
+	available := []*ps.QueryTag{
+		{ID: "Sapp", Name: "app", Source: "sql"},
+		{ID: "Busername", Name: "username", Source: "system"},
+		{ID: "Scontroller", Name: "controller", Source: "sql"},
+		{ID: "Bcontroller", Name: "controller", Source: "system"},
+		{ID: "SStatus", Name: "Status", Source: "sql"},
+	}
+
+	c.Run("friendly name", func(c *qt.C) {
+		ids, err := resolveTagIDs(available, []string{"app", "username"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(ids, qt.DeepEquals, []string{"Sapp", "Busername"})
+	})
+
+	c.Run("friendly name starting with S", func(c *qt.C) {
+		ids, err := resolveTagIDs(available, []string{"Status"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(ids, qt.DeepEquals, []string{"SStatus"})
+	})
+
+	c.Run("prefixed id", func(c *qt.C) {
+		ids, err := resolveTagIDs(available, []string{"Sapp"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(ids, qt.DeepEquals, []string{"Sapp"})
+	})
+
+	c.Run("source qualified", func(c *qt.C) {
+		ids, err := resolveTagIDs(available, []string{"sql:controller", "system:controller"})
+		c.Assert(err, qt.IsNil)
+		c.Assert(ids, qt.DeepEquals, []string{"Scontroller", "Bcontroller"})
+	})
+
+	c.Run("ambiguous name", func(c *qt.C) {
+		_, err := resolveTagIDs(available, []string{"controller"})
+		c.Assert(err, qt.ErrorMatches, `(?s).*matches multiple sources.*`)
+	})
+
+	c.Run("missing", func(c *qt.C) {
+		_, err := resolveTagIDs(available, []string{"nope"})
+		c.Assert(err, qt.ErrorMatches, `(?s).*not found.*`)
+	})
+}
+
+func TestFormatDimensions(t *testing.T) {
+	c := qt.New(t)
+	got := formatDimensions(map[string]string{
+		"Scontroller": "users",
+		"Bcontroller": "admin",
+	})
+	c.Assert(got, qt.Equals, "sql:controller=users system:controller=admin")
+}

--- a/internal/cmd/insights/tags_show.go
+++ b/internal/cmd/insights/tags_show.go
@@ -1,0 +1,105 @@
+package insights
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+// TagValueRow is a tag value for table output.
+type TagValueRow struct {
+	Name       string `header:"value" json:"name"`
+	Kind       string `header:"kind" json:"kind"`
+	QueryCount int64  `header:"queries" json:"query_count"`
+}
+
+// TagShowCmd shows one tag key and its values.
+func TagShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		period   string
+		keyspace string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "show <database> <branch> <tag>",
+		Short: "Show a query tag key and its values",
+		Long: `Show one tag key and the values observed for it.
+
+<tag> is the friendly name from 'pscale insights tags' (e.g. app, username),
+matching the Insights UI Key picker. Source-qualified names (sql:app,
+system:username) are accepted when a name exists in both sources.`,
+		Example: `  pscale insights tags show mydb main app --org myorg
+  pscale insights tags show mydb main username --org myorg --period 1h`,
+		Args: cmdutil.RequiredArgs("database", "branch", "tag"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, tagInput := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching tag %s for %s in %s...",
+				printer.BoldBlue(tagInput), printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+
+			listOpts := []ps.ListOption{ps.WithPeriod(flags.period)}
+			if flags.keyspace != "" {
+				listOpts = append(listOpts, ps.WithKeyspace(flags.keyspace))
+			}
+
+			tags, err := client.QueryInsights.ListTags(ctx, &ps.ListQueryTagsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}, listOpts...)
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+
+			ids, err := resolveTagIDs(tags, []string{tagInput})
+			if err != nil {
+				end()
+				return err
+			}
+
+			tag, err := client.QueryInsights.GetTag(ctx, &ps.GetQueryTagRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Tag:          ids[0],
+			}, listOpts...)
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(tag)
+			}
+
+			ch.Printer.Printf("Tag %s (%s) — %d queries\n",
+				printer.BoldBlue(tag.Name), tag.Source, tag.QueryCount)
+
+			rows := make([]*TagValueRow, 0, len(tag.Values))
+			for _, v := range tag.Values {
+				rows = append(rows, &TagValueRow{
+					Name:       v.Name,
+					Kind:       v.Kind,
+					QueryCount: v.QueryCount,
+				})
+			}
+			return ch.Printer.PrintResource(rows)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to look back (e.g. 1h, 1d)")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Filter tag values to a keyspace")
+
+	return cmd
+}

--- a/internal/cmd/insights/tags_summaries.go
+++ b/internal/cmd/insights/tags_summaries.go
@@ -1,0 +1,163 @@
+package insights
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+// TagSummaryRow is a tag-grouped query stats row for table output.
+type TagSummaryRow struct {
+	Dimensions    string  `header:"dimensions" json:"dimensions"`
+	Count         int64   `header:"count" json:"query_count"`
+	TotalTimeMs   float64 `header:"total time (ms)" json:"sum_total_duration_millis"`
+	TimePerQryMs  float64 `header:"per query (ms)" json:"time_per_query"`
+	P99Ms         float64 `header:"p99 (ms)" json:"p99_latency"`
+	RowsRead      int64   `header:"rows read" json:"sum_rows_read"`
+	ReadPerReturn float64 `header:"read/returned" json:"rows_read_per_returned"`
+	Errors        int64   `header:"errors" json:"error_count"`
+}
+
+// TagSummariesCmd lists query statistics grouped by tag keys.
+func TagSummariesCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		tags   []string
+		sort   string
+		dir    string
+		limit  int
+		period string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "summaries <database> <branch>",
+		Short: "List query statistics grouped by tag keys",
+		Long: `Group query statistics by one or more tag keys.
+
+--tags takes friendly names from 'pscale insights tags' / the Insights UI Key
+picker (e.g. app, username, controller) — not the internal S/B ids.
+
+If a name exists as both sql and system, disambiguate with sql:name or
+system:name.`,
+		Example: `  # List keys first, then summarize (matches the app Tags page)
+  pscale insights tags mydb main --org myorg
+  pscale insights tags summaries mydb main --org myorg --tags username
+
+  # Group by multiple keys
+  pscale insights tags summaries mydb main --org myorg --tags app --tags controller --sort totalTime`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			if len(flags.tags) == 0 {
+				return fmt.Errorf("--tags is required (friendly names from 'pscale insights tags', e.g. --tags username)")
+			}
+			if !slices.Contains(sortMetrics, flags.sort) && flags.sort != "dimensions" {
+				// summaries also allow "dimensions"; reuse query sort list + dimensions
+				allowed := append([]string{"dimensions"}, sortMetrics...)
+				return fmt.Errorf("invalid --sort %q, must be one of: %s", flags.sort, strings.Join(allowed, ", "))
+			}
+			if flags.dir != "asc" && flags.dir != "desc" {
+				return fmt.Errorf("invalid --dir %q, must be asc or desc", flags.dir)
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching tag summaries for %s in %s...",
+				printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+
+			tags, err := client.QueryInsights.ListTags(ctx, &ps.ListQueryTagsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}, ps.WithPeriod(flags.period))
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+
+			ids, err := resolveTagIDs(tags, flags.tags)
+			if err != nil {
+				end()
+				return err
+			}
+
+			summaries, err := client.QueryInsights.ListTagSummaries(ctx, &ps.ListTagSummariesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Tags:         ids,
+			}, ps.WithPerPage(flags.limit), ps.WithSort(flags.sort, flags.dir), ps.WithPeriod(flags.period))
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if len(summaries) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No tag summaries for %s in %s.\n",
+					printer.BoldBlue(branch), printer.BoldBlue(database))
+				return nil
+			}
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(summaries)
+			}
+
+			rows := make([]*TagSummaryRow, 0, len(summaries))
+			for _, s := range summaries {
+				rows = append(rows, &TagSummaryRow{
+					Dimensions:    formatDimensions(s.Dimensions),
+					Count:         s.QueryCount,
+					TotalTimeMs:   round2(s.SumTotalDurationMillis),
+					TimePerQryMs:  round2(s.TimePerQuery),
+					P99Ms:         round2(s.P99Latency),
+					RowsRead:      s.SumRowsRead,
+					ReadPerReturn: round2(s.RowsReadPerReturned),
+					Errors:        s.ErrorCount,
+				})
+			}
+			return ch.Printer.PrintResource(rows)
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&flags.tags, "tags", nil,
+		"Tag key name from 'pscale insights tags' (repeatable; e.g. --tags username --tags app)")
+	cmd.Flags().StringVar(&flags.sort, "sort", "totalTime",
+		fmt.Sprintf("Metric to rank by, one of: dimensions, %s", strings.Join(sortMetrics, ", ")))
+	cmd.Flags().StringVar(&flags.dir, "dir", "desc", "Sort direction: asc or desc")
+	cmd.Flags().IntVar(&flags.limit, "limit", 25, "Number of summary rows to return")
+	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 1d)")
+	cmd.MarkFlagRequired("tags") // nolint:errcheck
+
+	return cmd
+}
+
+func formatDimensions(dims map[string]string) string {
+	if len(dims) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(dims))
+	for k, v := range dims {
+		label := k
+		if len(k) > 1 {
+			switch k[0] {
+			case 'S':
+				label = "sql:" + k[1:]
+			case 'B':
+				label = "system:" + k[1:]
+			}
+		}
+		parts = append(parts, label+"="+v)
+	}
+	slices.Sort(parts)
+	return strings.Join(parts, " ")
+}

--- a/internal/mock/insights.go
+++ b/internal/mock/insights.go
@@ -10,16 +10,33 @@ type QueryInsightsService struct {
 	ListQueriesFn        func(context.Context, *ps.ListQueryInsightsRequest, ...ps.ListOption) ([]*ps.QueryInsight, error)
 	ListQueriesFnInvoked bool
 
+	ListQuerySamplesFn        func(context.Context, *ps.ListQuerySamplesRequest, ...ps.ListOption) ([]*ps.QuerySample, error)
+	ListQuerySamplesFnInvoked bool
+
 	ListErrorsFn        func(context.Context, *ps.ListQueryInsightsErrorsRequest, ...ps.ListOption) ([]*ps.QueryInsightError, error)
 	ListErrorsFnInvoked bool
 
 	ListAnomaliesFn        func(context.Context, *ps.ListAnomaliesRequest, ...ps.ListOption) ([]*ps.Anomaly, error)
 	ListAnomaliesFnInvoked bool
+
+	ListTagsFn        func(context.Context, *ps.ListQueryTagsRequest, ...ps.ListOption) ([]*ps.QueryTag, error)
+	ListTagsFnInvoked bool
+
+	GetTagFn        func(context.Context, *ps.GetQueryTagRequest, ...ps.ListOption) (*ps.QueryTag, error)
+	GetTagFnInvoked bool
+
+	ListTagSummariesFn        func(context.Context, *ps.ListTagSummariesRequest, ...ps.ListOption) ([]*ps.TagSummary, error)
+	ListTagSummariesFnInvoked bool
 }
 
 func (s *QueryInsightsService) ListQueries(ctx context.Context, req *ps.ListQueryInsightsRequest, opts ...ps.ListOption) ([]*ps.QueryInsight, error) {
 	s.ListQueriesFnInvoked = true
 	return s.ListQueriesFn(ctx, req, opts...)
+}
+
+func (s *QueryInsightsService) ListQuerySamples(ctx context.Context, req *ps.ListQuerySamplesRequest, opts ...ps.ListOption) ([]*ps.QuerySample, error) {
+	s.ListQuerySamplesFnInvoked = true
+	return s.ListQuerySamplesFn(ctx, req, opts...)
 }
 
 func (s *QueryInsightsService) ListErrors(ctx context.Context, req *ps.ListQueryInsightsErrorsRequest, opts ...ps.ListOption) ([]*ps.QueryInsightError, error) {
@@ -30,6 +47,21 @@ func (s *QueryInsightsService) ListErrors(ctx context.Context, req *ps.ListQuery
 func (s *QueryInsightsService) ListAnomalies(ctx context.Context, req *ps.ListAnomaliesRequest, opts ...ps.ListOption) ([]*ps.Anomaly, error) {
 	s.ListAnomaliesFnInvoked = true
 	return s.ListAnomaliesFn(ctx, req, opts...)
+}
+
+func (s *QueryInsightsService) ListTags(ctx context.Context, req *ps.ListQueryTagsRequest, opts ...ps.ListOption) ([]*ps.QueryTag, error) {
+	s.ListTagsFnInvoked = true
+	return s.ListTagsFn(ctx, req, opts...)
+}
+
+func (s *QueryInsightsService) GetTag(ctx context.Context, req *ps.GetQueryTagRequest, opts ...ps.ListOption) (*ps.QueryTag, error) {
+	s.GetTagFnInvoked = true
+	return s.GetTagFn(ctx, req, opts...)
+}
+
+func (s *QueryInsightsService) ListTagSummaries(ctx context.Context, req *ps.ListTagSummariesRequest, opts ...ps.ListOption) ([]*ps.TagSummary, error) {
+	s.ListTagSummariesFnInvoked = true
+	return s.ListTagSummariesFn(ctx, req, opts...)
 }
 
 type SchemaRecommendationService struct {

--- a/internal/planetscale/insights.go
+++ b/internal/planetscale/insights.go
@@ -10,12 +10,16 @@ import (
 var _ QueryInsightsService = &queryInsightsService{}
 
 // QueryInsightsService is an interface for communicating with the PlanetScale
-// Query Insights API: aggregated query statistics, query errors, and detected
-// anomalies for a database branch.
+// Query Insights API: aggregated query statistics, query errors, detected
+// anomalies, per-fingerprint samples, and query tags for a database branch.
 type QueryInsightsService interface {
 	ListQueries(context.Context, *ListQueryInsightsRequest, ...ListOption) ([]*QueryInsight, error)
+	ListQuerySamples(context.Context, *ListQuerySamplesRequest, ...ListOption) ([]*QuerySample, error)
 	ListErrors(context.Context, *ListQueryInsightsErrorsRequest, ...ListOption) ([]*QueryInsightError, error)
 	ListAnomalies(context.Context, *ListAnomaliesRequest, ...ListOption) ([]*Anomaly, error)
+	ListTags(context.Context, *ListQueryTagsRequest, ...ListOption) ([]*QueryTag, error)
+	GetTag(context.Context, *GetQueryTagRequest, ...ListOption) (*QueryTag, error)
+	ListTagSummaries(context.Context, *ListTagSummariesRequest, ...ListOption) ([]*TagSummary, error)
 }
 
 // QueryInsight is an aggregated statistics record for a normalized query
@@ -99,6 +103,39 @@ type ListAnomaliesRequest struct {
 	Branch       string
 }
 
+// QuerySampleTag is a name/value tag attached to an individual query execution.
+type QuerySampleTag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// QuerySample is an individual query execution recorded for a fingerprint.
+type QuerySample struct {
+	ID                  string           `json:"id"`
+	Fingerprint         string           `json:"fingerprint"`
+	NormalizedSQL       string           `json:"normalized_sql"`
+	StatementType       string           `json:"statement_type"`
+	Keyspace            string           `json:"keyspace"`
+	Tables              []string         `json:"tables"`
+	Username            string           `json:"username"`
+	RemoteAddress       string           `json:"remote_address"`
+	RowsRead            int64            `json:"rows_read"`
+	RowsAffected        int64            `json:"rows_affected"`
+	RowsReturned        int64            `json:"rows_returned"`
+	TotalDurationMillis float64          `json:"total_duration_millis"`
+	ErrorMessage        string           `json:"error_message"`
+	StartedAt           time.Time        `json:"started_at"`
+	Tags                []QuerySampleTag `json:"tags"`
+}
+
+// ListQuerySamplesRequest lists individual executions for a query fingerprint.
+type ListQuerySamplesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Fingerprint  string
+}
+
 // WithSort returns a ListOption that sets the "sort" and "dir" URL parameters.
 func WithSort(sort, dir string) ListOption {
 	return func(opt *ListOptions) error {
@@ -113,7 +150,7 @@ func WithSort(sort, dir string) ListOption {
 }
 
 // WithPeriod returns a ListOption that sets the "period" URL parameter
-// (e.g. "1h", "24h").
+// (e.g. "1h", "1d").
 func WithPeriod(period string) ListOption {
 	return func(opt *ListOptions) error {
 		if period != "" {
@@ -187,6 +224,30 @@ func (s *queryInsightsService) ListAnomalies(ctx context.Context, request *ListA
 	return resp.Anomalies, nil
 }
 
+type querySamplesResponse struct {
+	Data []*QuerySample `json:"data"`
+}
+
+func (s *queryInsightsService) ListQuerySamples(ctx context.Context, request *ListQuerySamplesRequest, opts ...ListOption) ([]*QuerySample, error) {
+	listOpts := defaultListOptions(opts...)
+
+	req, err := s.client.newRequest(http.MethodGet, insightsFingerprintAPIPath(request.Organization, request.Database, request.Branch, request.Fingerprint), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &querySamplesResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
 func insightsAPIPath(org, db, branch string) string {
 	return path.Join("v1/organizations", org, "databases", db, "branches", branch, "insights")
+}
+
+func insightsFingerprintAPIPath(org, db, branch, fingerprint string) string {
+	return path.Join(insightsAPIPath(org, db, branch), fingerprint)
 }

--- a/internal/planetscale/insights_tags.go
+++ b/internal/planetscale/insights_tags.go
@@ -1,0 +1,173 @@
+package planetscale
+
+import (
+	"context"
+	"net/http"
+	"path"
+)
+
+// QueryTag is a tag key observed on branch queries (sqlcommenter / system).
+// ID is the dimension key used by the API (e.g. "Sapp", "Busername").
+// Name is the friendly key users see in the app (e.g. "app", "username").
+// Source is "sql" or "system".
+type QueryTag struct {
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	Source     string          `json:"source"`
+	QueryCount int64           `json:"query_count"`
+	Values     []QueryTagValue `json:"values"`
+}
+
+// QueryTagValue is one observed value for a tag key.
+type QueryTagValue struct {
+	Name       string `json:"name"`
+	QueryCount int64  `json:"query_count"`
+	Kind       string `json:"kind"`
+}
+
+// TagSummary is query statistics grouped by one or more tag dimensions.
+type TagSummary struct {
+	Dimensions             map[string]string `json:"dimensions"`
+	QueryCount             int64             `json:"query_count"`
+	ErrorCount             int64             `json:"error_count"`
+	Tables                 []string          `json:"tables"`
+	SumRowsRead            int64             `json:"sum_rows_read"`
+	SumRowsReturned        int64             `json:"sum_rows_returned"`
+	SumRowsAffected        int64             `json:"sum_rows_affected"`
+	RowsReadPerReturned    float64           `json:"rows_read_per_returned"`
+	SumTotalDurationMillis float64           `json:"sum_total_duration_millis"`
+	SumTotalDurationPct    float64           `json:"sum_total_duration_percent"`
+	SumCPUDurationMillis   float64           `json:"sum_cpu_duration_millis"`
+	SumIODurationMillis    float64           `json:"sum_io_duration_millis"`
+	LastRunAt              string            `json:"last_run_at"`
+	TimePerQuery           float64           `json:"time_per_query"`
+	P50Latency             float64           `json:"p50_latency"`
+	P99Latency             float64           `json:"p99_latency"`
+	MaxLatency             float64           `json:"max_latency"`
+}
+
+// ListQueryTagsRequest lists tag keys for a branch.
+type ListQueryTagsRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+}
+
+// GetQueryTagRequest retrieves one tag key and its values.
+// Tag is the dimension id (e.g. "Sapp"), not the display name.
+type GetQueryTagRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Tag          string
+}
+
+// ListTagSummariesRequest lists query stats grouped by tag dimensions.
+// Tags are dimension ids from the tags list endpoint (e.g. "Sapp").
+type ListTagSummariesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Tags         []string
+}
+
+type queryTagsResponse struct {
+	Data []*QueryTag `json:"data"`
+}
+
+type tagSummariesResponse struct {
+	Data []*TagSummary `json:"data"`
+}
+
+// WithTags sets the tags[] query parameters (dimension ids for summaries).
+func WithTags(tags []string) ListOption {
+	return func(opt *ListOptions) error {
+		for _, tag := range tags {
+			if tag != "" {
+				opt.URLValues.Add("tags[]", tag)
+			}
+		}
+		return nil
+	}
+}
+
+// WithFingerprint sets the fingerprint query parameter.
+func WithFingerprint(fingerprint string) ListOption {
+	return func(opt *ListOptions) error {
+		if fingerprint != "" {
+			opt.URLValues.Set("fingerprint", fingerprint)
+		}
+		return nil
+	}
+}
+
+// WithKeyspace sets the keyspace query parameter.
+func WithKeyspace(keyspace string) ListOption {
+	return func(opt *ListOptions) error {
+		if keyspace != "" {
+			opt.URLValues.Set("keyspace", keyspace)
+		}
+		return nil
+	}
+}
+
+func (s *queryInsightsService) ListTags(ctx context.Context, request *ListQueryTagsRequest, opts ...ListOption) ([]*QueryTag, error) {
+	listOpts := defaultListOptions(opts...)
+
+	req, err := s.client.newRequest(http.MethodGet, insightsTagsAPIPath(request.Organization, request.Database, request.Branch), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &queryTagsResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
+func (s *queryInsightsService) GetTag(ctx context.Context, request *GetQueryTagRequest, opts ...ListOption) (*QueryTag, error) {
+	listOpts := defaultListOptions(opts...)
+
+	req, err := s.client.newRequest(http.MethodGet, insightsTagAPIPath(request.Organization, request.Database, request.Branch, request.Tag), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, err
+	}
+
+	tag := &QueryTag{}
+	if err := s.client.do(ctx, req, &tag); err != nil {
+		return nil, err
+	}
+
+	return tag, nil
+}
+
+func (s *queryInsightsService) ListTagSummaries(ctx context.Context, request *ListTagSummariesRequest, opts ...ListOption) ([]*TagSummary, error) {
+	opts = append([]ListOption{WithTags(request.Tags)}, opts...)
+	listOpts := defaultListOptions(opts...)
+
+	req, err := s.client.newRequest(http.MethodGet, insightsTagSummariesAPIPath(request.Organization, request.Database, request.Branch), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &tagSummariesResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
+func insightsTagsAPIPath(org, db, branch string) string {
+	return path.Join(insightsAPIPath(org, db, branch), "tags")
+}
+
+func insightsTagAPIPath(org, db, branch, tag string) string {
+	return path.Join(insightsTagsAPIPath(org, db, branch), tag)
+}
+
+func insightsTagSummariesAPIPath(org, db, branch string) string {
+	return path.Join(insightsTagsAPIPath(org, db, branch), "summaries")
+}

--- a/internal/planetscale/insights_test.go
+++ b/internal/planetscale/insights_test.go
@@ -166,3 +166,156 @@ func TestQueryInsights_ListAnomalies(t *testing.T) {
 	c.Assert(anomalies[0].Active, qt.Equals, false)
 	c.Assert(anomalies[0].Duration, qt.Equals, 1800.0)
 }
+
+func TestQueryInsights_ListQuerySamples(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/b129e8fa")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "10")
+		c.Assert(r.URL.Query().Get("period"), qt.Equals, "1h")
+		c.Assert(r.URL.Query().Get("keyspace"), qt.Equals, "public")
+
+		out := `{
+			"type": "list",
+			"data": [{
+				"id": "exec-1",
+				"fingerprint": "b129e8fa",
+				"normalized_sql": "select * from users where id = ?",
+				"username": "app",
+				"rows_read": 1,
+				"rows_returned": 1,
+				"total_duration_millis": 2.5,
+				"started_at": "2026-08-11T18:00:00.000Z",
+				"error_message": "",
+				"tags": [{"name": "Sapp", "value": "web"}, {"name": "Busername", "value": "alice"}]
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	samples, err := client.QueryInsights.ListQuerySamples(context.Background(), &ListQuerySamplesRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+		Fingerprint:  "b129e8fa",
+	}, WithPerPage(10), WithPeriod("1h"), WithKeyspace("public"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(samples, qt.HasLen, 1)
+	c.Assert(samples[0].ID, qt.Equals, "exec-1")
+	c.Assert(samples[0].Username, qt.Equals, "app")
+	c.Assert(samples[0].TotalDurationMillis, qt.Equals, 2.5)
+	c.Assert(samples[0].Tags, qt.DeepEquals, []QuerySampleTag{
+		{Name: "Sapp", Value: "web"},
+		{Name: "Busername", Value: "alice"},
+	})
+}
+
+func TestQueryInsights_ListTags(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/tags")
+
+		out := `{
+			"type": "list",
+			"data": [{
+				"id": "Sapp",
+				"name": "app",
+				"source": "sql",
+				"query_count": 100,
+				"values": [{"name": "web", "query_count": 80, "kind": "literal"}]
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	tags, err := client.QueryInsights.ListTags(context.Background(), &ListQueryTagsRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(tags, qt.HasLen, 1)
+	c.Assert(tags[0].ID, qt.Equals, "Sapp")
+	c.Assert(tags[0].Name, qt.Equals, "app")
+	c.Assert(tags[0].Source, qt.Equals, "sql")
+}
+
+func TestQueryInsights_GetTag(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/tags/Sapp")
+
+		out := `{"id":"Sapp","name":"app","source":"sql","query_count":100,"values":[{"name":"web","query_count":80,"kind":"literal"}]}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	tag, err := client.QueryInsights.GetTag(context.Background(), &GetQueryTagRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+		Tag:          "Sapp",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(tag.ID, qt.Equals, "Sapp")
+	c.Assert(tag.Values, qt.HasLen, 1)
+}
+
+func TestQueryInsights_ListTagSummaries(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/tags/summaries")
+		c.Assert(r.URL.Query()["tags[]"], qt.DeepEquals, []string{"Sapp", "Busername"})
+		c.Assert(r.URL.Query().Get("sort"), qt.Equals, "totalTime")
+
+		out := `{
+			"type": "list",
+			"data": [{
+				"dimensions": {"Sapp": "web", "Busername": "alice"},
+				"query_count": 10,
+				"sum_total_duration_millis": 50.5,
+				"p99_latency": 3.2
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	summaries, err := client.QueryInsights.ListTagSummaries(context.Background(), &ListTagSummariesRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+		Tags:         []string{"Sapp", "Busername"},
+	}, WithSort("totalTime", "desc"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(summaries, qt.HasLen, 1)
+	c.Assert(summaries[0].QueryCount, qt.Equals, int64(10))
+	c.Assert(summaries[0].Dimensions["Sapp"], qt.Equals, "web")
+}


### PR DESCRIPTION
## Summary
- Adds `pscale insights queries samples` for per-fingerprint executions (`get_query_statistics`), with required `--keyspace` and fingerprint/keyspace columns on the queries list.
- Adds `pscale insights tags` / `show` / `summaries` for query-tag discovery and attribution; `--tags` takes UI Key-picker names (e.g. `username`, `app`) and maps to API `S*`/`B*` ids.
- Documents the agent flow in `AGENTS.md`. Skips `queries show` / `get_query_summary` and per-execution `get_branch_query` (list already covers aggregates).

## Test plan
- [x] Unit tests for API client + CLI (`go test ./internal/planetscale/ ./internal/cmd/insights/`)
- [x] Live read-only on prod `benchmarks`/`beam`: queries, tags, tags show, tags summaries (incl. multi `--tags`)
- [x] Samples without `--keyspace` rejected; with keyspace API returns empty list on beam (API-side, CLI decode OK)
- [ ] CI green