### PR TITLE
Add pscale keyspace delete command

### DIFF
--- a/internal/cmd/keyspace/delete.go
+++ b/internal/cmd/keyspace/delete.go
@@ -1,0 +1,120 @@
+package keyspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCmd encapsulates the command for deleting a keyspace from a branch.
+func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <database> <branch> <keyspace>",
+		Short:   "Delete a keyspace from a branch",
+		Args:    cmdutil.RequiredArgs("database", "branch", "keyspace"),
+		Aliases: []string{"rm"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, keyspace := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if !force {
+				if ch.Printer.Format() != printer.Human {
+					return fmt.Errorf(`cannot delete keyspace with the output format "%s" (run with --force to override)`, ch.Printer.Format())
+				}
+
+				_, err := client.Keyspaces.Get(ctx, &planetscale.GetKeyspaceRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+					Branch:       branch,
+					Keyspace:     keyspace,
+				})
+				if err != nil {
+					switch cmdutil.ErrCode(err) {
+					case planetscale.ErrNotFound:
+						return fmt.Errorf("keyspace %s does not exist in branch %s of %s (organization: %s)",
+							printer.BoldBlue(keyspace), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+					default:
+						return cmdutil.HandleError(err)
+					}
+				}
+
+				confirmationName := fmt.Sprintf("%s/%s/%s", database, branch, keyspace)
+				if !printer.IsTTY {
+					return fmt.Errorf("cannot confirm deletion of keyspace %q (run with --force to override)", confirmationName)
+				}
+
+				confirmationMessage := fmt.Sprintf("%s %s %s", printer.Bold("Please type"),
+					printer.BoldBlue(confirmationName), printer.Bold("to confirm:"))
+
+				prompt := &survey.Input{
+					Message: confirmationMessage,
+				}
+
+				var userInput string
+				err = survey.AskOne(prompt, &userInput)
+				if err != nil {
+					if err == terminal.InterruptErr {
+						os.Exit(0)
+					}
+					return err
+				}
+
+				if userInput != confirmationName {
+					return errors.New("incorrect database, branch, and keyspace name entered, skipping keyspace deletion")
+				}
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting keyspace %s from %s/%s",
+				printer.BoldBlue(keyspace), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			err = client.Keyspaces.Delete(ctx, &planetscale.DeleteKeyspaceRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Keyspace:     keyspace,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("keyspace %s does not exist in branch %s of %s (organization: %s)",
+						printer.BoldBlue(keyspace), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Keyspace %s was successfully deleted from %s/%s.\n",
+					printer.BoldBlue(keyspace), printer.BoldBlue(database), printer.BoldBlue(branch))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result":   "keyspace deleted",
+				"keyspace": keyspace,
+				"branch":   branch,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Delete a keyspace without confirmation")
+	return cmd
+}

--- a/internal/cmd/keyspace/delete_test.go
+++ b/internal/cmd/keyspace/delete_test.go
@@ -1,0 +1,62 @@
+package keyspace
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestKeyspace_DeleteCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+	keyspace := "sharded"
+
+	svc := &mock.KeyspacesService{
+		DeleteFn: func(ctx context.Context, req *ps.DeleteKeyspaceRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Keyspace, qt.Equals, keyspace)
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Keyspaces: svc,
+			}, nil
+		},
+	}
+
+	cmd := DeleteCmd(ch)
+	cmd.SetArgs([]string{db, branch, keyspace, "--force"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.DeleteFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result":   "keyspace deleted",
+		"keyspace": keyspace,
+		"branch":   branch,
+	})
+}

--- a/internal/cmd/keyspace/keyspace.go
+++ b/internal/cmd/keyspace/keyspace.go
@@ -25,6 +25,7 @@ func KeyspaceCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(VSchemaCmd(ch))
 	cmd.AddCommand(CreateCmd(ch))
+	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(ResizeCmd(ch))
 	cmd.AddCommand(RolloutStatusCmd(ch))
 	cmd.AddCommand(ReadOnlyRegionsCmd(ch))

--- a/internal/mock/keyspace.go
+++ b/internal/mock/keyspace.go
@@ -25,6 +25,9 @@ type KeyspacesService struct {
 	CreateFn        func(context.Context, *ps.CreateKeyspaceRequest) (*ps.Keyspace, error)
 	CreateFnInvoked bool
 
+	DeleteFn        func(context.Context, *ps.DeleteKeyspaceRequest) error
+	DeleteFnInvoked bool
+
 	ResizeFn        func(context.Context, *ps.ResizeKeyspaceRequest) (*ps.KeyspaceResizeRequest, error)
 	ResizeFnInvoked bool
 
@@ -48,7 +51,6 @@ func (s *KeyspacesService) List(ctx context.Context, req *ps.ListKeyspacesReques
 
 func (s *KeyspacesService) Get(ctx context.Context, req *ps.GetKeyspaceRequest) (*ps.Keyspace, error) {
 	s.GetFnInvoked = true
-	s.GetFnInvoked = true
 	return s.GetFn(ctx, req)
 }
 
@@ -70,6 +72,11 @@ func (s *KeyspacesService) UpdateVSchema(ctx context.Context, req *ps.UpdateKeys
 func (s *KeyspacesService) Create(ctx context.Context, req *ps.CreateKeyspaceRequest) (*ps.Keyspace, error) {
 	s.CreateFnInvoked = true
 	return s.CreateFn(ctx, req)
+}
+
+func (s *KeyspacesService) Delete(ctx context.Context, req *ps.DeleteKeyspaceRequest) error {
+	s.DeleteFnInvoked = true
+	return s.DeleteFn(ctx, req)
 }
 
 func (s *KeyspacesService) Resize(ctx context.Context, req *ps.ResizeKeyspaceRequest) (*ps.KeyspaceResizeRequest, error) {

--- a/internal/planetscale/keyspaces.go
+++ b/internal/planetscale/keyspaces.go
@@ -70,6 +70,13 @@ type GetKeyspaceRequest struct {
 	Full         bool   `json:"-"`
 }
 
+type DeleteKeyspaceRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+	Keyspace     string `json:"-"`
+}
+
 type UpdateReadOnlyRegionsRequest struct {
 	Organization    string                          `json:"-"`
 	Database        string                          `json:"-"`
@@ -184,6 +191,7 @@ type KeyspacesService interface {
 	Create(context.Context, *CreateKeyspaceRequest) (*Keyspace, error)
 	List(context.Context, *ListKeyspacesRequest) ([]*Keyspace, error)
 	Get(context.Context, *GetKeyspaceRequest) (*Keyspace, error)
+	Delete(context.Context, *DeleteKeyspaceRequest) error
 	UpdateReadOnlyRegions(context.Context, *UpdateReadOnlyRegionsRequest) ([]*ReadOnlyRegionKeyspace, error)
 	VSchema(context.Context, *GetKeyspaceVSchemaRequest) (*VSchema, error)
 	UpdateVSchema(context.Context, *UpdateKeyspaceVSchemaRequest) (*VSchema, error)
@@ -268,6 +276,16 @@ func (s *keyspacesService) Create(ctx context.Context, createReq *CreateKeyspace
 	}
 
 	return keyspace, nil
+}
+
+// Delete deletes a keyspace from a branch.
+func (s *keyspacesService) Delete(ctx context.Context, deleteReq *DeleteKeyspaceRequest) error {
+	req, err := s.client.newRequest(http.MethodDelete, keyspaceAPIPath(deleteReq.Organization, deleteReq.Database, deleteReq.Branch, deleteReq.Keyspace), nil)
+	if err != nil {
+		return fmt.Errorf("error creating http request: %w", err)
+	}
+
+	return s.client.do(ctx, req, nil)
 }
 
 // VSchema returns the VSchema for a keyspace in a branch

--- a/internal/planetscale/keyspaces_test.go
+++ b/internal/planetscale/keyspaces_test.go
@@ -195,6 +195,27 @@ func TestKeyspaces_Create(t *testing.T) {
 	c.Assert(keyspace.Shards, qt.Equals, 2)
 }
 
+func TestKeyspaces_Delete(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/foo/databases/bar/branches/baz/keyspaces/qux")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.Keyspaces.Delete(context.Background(), &DeleteKeyspaceRequest{
+		Organization: "foo",
+		Database:     "bar",
+		Branch:       "baz",
+		Keyspace:     "qux",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
 func TestKeyspaces_VSchema(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- Add `pscale keyspace delete` (alias `rm`) with interactive confirmation and `--force` for non-interactive/JSON use
- Wire `Keyspaces.Delete` in the API client against `DELETE …/keyspaces/{name}` (204)
- Cover client and command with unit tests

## Test plan
- [x] `go test ./internal/planetscale/ ./internal/cmd/keyspace/ -count=1`
- [x] `go build ./cmd/pscale`
- [x] Manually: `pscale keyspace delete <db> <branch> <keyspace> --org <org> --force --format json`
- [x] Confirm human mode prompts for `database/branch/keyspace` before deleting