### PR TITLE
Enable auto-merge on planetscale-go sync PRs

### DIFF
--- a/.github/workflows/sync-planetscale-go.yml
+++ b/.github/workflows/sync-planetscale-go.yml
@@ -140,9 +140,31 @@ jobs:
             echo
             cat /tmp/gorelease-report.md
           } > /tmp/pr-body.md
-          pr_url=$(gh pr create \
+          gh pr create \
             --repo planetscale/planetscale-go \
             --head "$branch" \
             --title "Sync API client from cli@${source_sha}" \
-            --body-file /tmp/pr-body.md)
+            --body-file /tmp/pr-body.md
+
+      # Runs for both newly created sync PRs and re-runs where the branch
+      # already exists (e.g. create succeeded but enabling auto-merge failed).
+      - name: Enable auto-merge
+        if: steps.changes.outputs.changed == 'true'
+        working-directory: planetscale-go
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          branch="${{ steps.commit.outputs.branch }}"
+          pr_json=$(gh pr view --repo planetscale/planetscale-go "$branch" \
+            --json url,state,autoMergeRequest)
+          state=$(printf '%s' "$pr_json" | jq -r .state)
+          if [ "$state" != "OPEN" ]; then
+            echo "PR for $branch is $state; nothing to do"
+            exit 0
+          fi
+          if [ "$(printf '%s' "$pr_json" | jq -r '.autoMergeRequest != null')" = "true" ]; then
+            echo "Auto-merge already enabled for $branch"
+            exit 0
+          fi
+          pr_url=$(printf '%s' "$pr_json" | jq -r .url)
           gh pr merge --repo planetscale/planetscale-go --auto --merge "$pr_url"

--- a/.github/workflows/sync-planetscale-go.yml
+++ b/.github/workflows/sync-planetscale-go.yml
@@ -3,8 +3,11 @@ name: Sync client to planetscale-go
 # The API client at internal/planetscale is canonical (see doc/api-client.md).
 # This workflow copies it into planetscale/planetscale-go and opens a PR there
 # so external users of the module can pick up new endpoints. It never pushes
-# to main directly: a human reviews the PR, including the gorelease API report,
-# and decides the version to tag.
+# to main directly. Cursor PR Routing & Approval (see APPROVAL_POLICY.md in
+# planetscale-go) can approve mechanical sync PRs; this job enables GitHub
+# auto-merge so the PR merges once that approval and required checks land.
+# Version tagging after merge remains a separate step (use the gorelease
+# report in the PR body).
 #
 # Auth comes from the CLI GitHub App (same as release.yml); the app must be
 # installed on planetscale-go with contents and pull request write access.
@@ -131,13 +134,15 @@ jobs:
             echo "The client in the cli repo (internal/planetscale) is the source of"
             echo "truth; this repo is a read-only mirror for external module users."
             echo
-            echo "Review the API report below before merging. If it lists incompatible"
-            echo "changes, the next tag needs to reflect that."
+            echo "Auto-merge is enabled. Cursor Approval Agent may approve per"
+            echo "APPROVAL_POLICY.md. Use the gorelease report below when choosing"
+            echo "the next tag; incompatible changes need a matching semver bump."
             echo
             cat /tmp/gorelease-report.md
           } > /tmp/pr-body.md
-          gh pr create \
+          pr_url=$(gh pr create \
             --repo planetscale/planetscale-go \
             --head "$branch" \
             --title "Sync API client from cli@${source_sha}" \
-            --body-file /tmp/pr-body.md
+            --body-file /tmp/pr-body.md)
+          gh pr merge --repo planetscale/planetscale-go --auto --merge "$pr_url"


### PR DESCRIPTION
## Summary
- After opening a planetscale-go sync PR, enable GitHub auto-merge with `gh pr merge --auto --merge`.
- Update the workflow/PR copy to reflect Approval Agent + auto-merge (tagging remains manual via the gorelease report).

Pairs with the `APPROVAL_POLICY.md` change in planetscale-go so sync PRs can land without a human +1 once Cursor approves and Buildkite is green.

## Test plan
- [x] Merge the planetscale-go `APPROVAL_POLICY.md` PR first (or alongside)
- [x] Run `sync-planetscale-go` via `workflow_dispatch` (or next CLI release)
- [x] Confirm the opened PR has auto-merge enabled
- [x] Confirm it merges after Approval Agent +1 and required checks