### PR TITLE
Add pscale database aggressive-cutover commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,18 @@ pscale database throttler update <database> --org <org> --format json \
 
 `--ratio` is 0–95 (0 disables throttling; 95 is slowest). Use either `--ratio` or `--configuration keyspace=ratio`, not both. Vitess only.
 
+## Vitess aggressive cutover
+
+Database-level setting for future deploy requests (not the same as `deploy-request force-cutover`):
+
+```bash
+pscale database aggressive-cutover show <database> --org <org> --format json
+pscale database aggressive-cutover enable <database> --org <org> --format json
+pscale database aggressive-cutover disable <database> --org <org> --format json
+```
+
+Vitess only. See https://planetscale.com/docs/vitess/schema-changes/aggressive-cutover
+
 ## Vitess deploy requests (inspect + throttler)
 
 Core lifecycle is already covered (`list/create/show/diff/review/deploy/apply/edit/cancel/close/revert/skip-revert`). These inspect commands are read-only:

--- a/internal/cmd/database/aggressive_cutover.go
+++ b/internal/cmd/database/aggressive_cutover.go
@@ -1,0 +1,204 @@
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/spf13/cobra"
+)
+
+// AggressiveCutoverCmd groups database-level aggressive cutover commands.
+func AggressiveCutoverCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "aggressive-cutover <command>",
+		Short: "Show or change aggressive cutover for a database",
+		Long: `Show, enable, or disable aggressive cutover for a Vitess database.
+
+When enabled, future deploy requests on this database cut over more
+aggressively when waiting on table locks. This is a database-level setting,
+not the same as forcing cutover on a single deploy request
+(pscale deploy-request force-cutover).
+
+See https://planetscale.com/docs/vitess/schema-changes/aggressive-cutover`,
+	}
+
+	cmd.AddCommand(AggressiveCutoverShowCmd(ch))
+	cmd.AddCommand(AggressiveCutoverEnableCmd(ch))
+	cmd.AddCommand(AggressiveCutoverDisableCmd(ch))
+	return cmd
+}
+
+// AggressiveCutoverShowCmd shows whether aggressive cutover is enabled.
+func AggressiveCutoverShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <database>",
+		Short: "Show whether aggressive cutover is enabled",
+		Args:  cmdutil.RequiredArgs("database"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requireVitessDatabase(ctx, ch, client, database, "aggressive cutover"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching aggressive cutover status for %s",
+				printer.BoldBlue(database)))
+			defer end()
+
+			status, err := client.Databases.GetAggressiveCutover(ctx, &planetscale.AggressiveCutoverRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return printAggressiveCutover(ch, database, status)
+		},
+	}
+
+	return cmd
+}
+
+// AggressiveCutoverEnableCmd enables aggressive cutover for a database.
+func AggressiveCutoverEnableCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable <database>",
+		Short: "Enable aggressive cutover for a database",
+		Args:  cmdutil.RequiredArgs("database"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requireVitessDatabase(ctx, ch, client, database, "aggressive cutover"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Enabling aggressive cutover for %s",
+				printer.BoldBlue(database)))
+			defer end()
+
+			status, err := client.Databases.EnableAggressiveCutover(ctx, &planetscale.AggressiveCutoverRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return printAggressiveCutover(ch, database, status)
+		},
+	}
+
+	return cmd
+}
+
+// AggressiveCutoverDisableCmd disables aggressive cutover for a database.
+func AggressiveCutoverDisableCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disable <database>",
+		Short: "Disable aggressive cutover for a database",
+		Args:  cmdutil.RequiredArgs("database"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := requireVitessDatabase(ctx, ch, client, database, "aggressive cutover"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Disabling aggressive cutover for %s",
+				printer.BoldBlue(database)))
+			defer end()
+
+			status, err := client.Databases.DisableAggressiveCutover(ctx, &planetscale.AggressiveCutoverRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return printAggressiveCutover(ch, database, status)
+		},
+	}
+
+	return cmd
+}
+
+type aggressiveCutoverView struct {
+	Database string `header:"database" json:"database"`
+	Enabled  bool   `header:"enabled" json:"enabled"`
+
+	orig *planetscale.AggressiveCutover
+}
+
+func (a *aggressiveCutoverView) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(a.orig, "", "  ")
+}
+
+func (a *aggressiveCutoverView) MarshalCSVValue() interface{} {
+	return []*aggressiveCutoverView{a}
+}
+
+func toAggressiveCutover(database string, status *planetscale.AggressiveCutover) *aggressiveCutoverView {
+	return &aggressiveCutoverView{
+		Database: database,
+		Enabled:  status.Enabled,
+		orig:     status,
+	}
+}
+
+func printAggressiveCutover(ch *cmdutil.Helper, database string, status *planetscale.AggressiveCutover) error {
+	view := toAggressiveCutover(database, status)
+	if ch.Printer.Format() == printer.Human {
+		state := "disabled"
+		if status.Enabled {
+			state = "enabled"
+		}
+		ch.Printer.Printf("Aggressive cutover is %s for %s\n", state, printer.BoldBlue(database))
+		return nil
+	}
+	return ch.Printer.PrintResource(view)
+}

--- a/internal/cmd/database/aggressive_cutover_test.go
+++ b/internal/cmd/database/aggressive_cutover_test.go
@@ -1,0 +1,164 @@
+package database
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestDatabase_AggressiveCutoverShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	status := &ps.AggressiveCutover{Enabled: true}
+
+	svc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEngineMySQL}, nil
+		},
+		GetAggressiveCutoverFn: func(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return status, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: svc}, nil
+		},
+	}
+
+	cmd := AggressiveCutoverShowCmd(ch)
+	cmd.SetArgs([]string{db})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetAggressiveCutoverFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, status)
+}
+
+func TestDatabase_AggressiveCutoverEnableCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	status := &ps.AggressiveCutover{Enabled: true}
+
+	svc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEngineMySQL}, nil
+		},
+		EnableAggressiveCutoverFn: func(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return status, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: svc}, nil
+		},
+	}
+
+	cmd := AggressiveCutoverEnableCmd(ch)
+	cmd.SetArgs([]string{db})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.EnableAggressiveCutoverFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, status)
+}
+
+func TestDatabase_AggressiveCutoverDisableCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	status := &ps.AggressiveCutover{Enabled: false}
+
+	svc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEngineMySQL}, nil
+		},
+		DisableAggressiveCutoverFn: func(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			return status, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: svc}, nil
+		},
+	}
+
+	cmd := AggressiveCutoverDisableCmd(ch)
+	cmd.SetArgs([]string{db})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.DisableAggressiveCutoverFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, status)
+}
+
+func TestDatabase_AggressiveCutoverCmd_RejectsPostgres(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	org := "planetscale"
+	db := "planetscale"
+
+	svc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEnginePostgres}, nil
+		},
+		GetAggressiveCutoverFn: func(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+			c.Fatal("GetAggressiveCutover should not be called for Postgres")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: svc}, nil
+		},
+	}
+
+	cmd := AggressiveCutoverShowCmd(ch)
+	cmd.SetArgs([]string{db})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "only available for Vitess")
+	c.Assert(svc.GetAggressiveCutoverFnInvoked, qt.IsFalse)
+}

--- a/internal/cmd/database/database.go
+++ b/internal/cmd/database/database.go
@@ -31,6 +31,7 @@ func DatabaseCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(UpdateCmd(ch))
 	cmd.AddCommand(ThrottlerCmd(ch))
+	cmd.AddCommand(AggressiveCutoverCmd(ch))
 	cmd.AddCommand(IPRestrictionCmd(ch))
 	cmd.AddCommand(DumpCmd(ch))
 	cmd.AddCommand(RestoreCmd(ch))

--- a/internal/cmd/database/throttler.go
+++ b/internal/cmd/database/throttler.go
@@ -46,7 +46,7 @@ func ThrottlerShowCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			if err := requireVitessDatabase(ctx, ch, client, database); err != nil {
+			if err := requireVitessDatabase(ctx, ch, client, database, "database throttler"); err != nil {
 				return err
 			}
 
@@ -131,7 +131,7 @@ This is the database default for future deploy requests, not a single deploy req
 				return err
 			}
 
-			if err := requireVitessDatabase(ctx, ch, client, database); err != nil {
+			if err := requireVitessDatabase(ctx, ch, client, database, "database throttler"); err != nil {
 				return err
 			}
 
@@ -167,7 +167,7 @@ This is the database default for future deploy requests, not a single deploy req
 	return cmd
 }
 
-func requireVitessDatabase(ctx context.Context, ch *cmdutil.Helper, client *planetscale.Client, database string) error {
+func requireVitessDatabase(ctx context.Context, ch *cmdutil.Helper, client *planetscale.Client, database, feature string) error {
 	db, err := client.Databases.Get(ctx, &planetscale.GetDatabaseRequest{
 		Organization: ch.Config.Organization,
 		Database:     database,
@@ -182,8 +182,8 @@ func requireVitessDatabase(ctx context.Context, ch *cmdutil.Helper, client *plan
 		}
 	}
 	if db.Kind != planetscale.DatabaseEngineMySQL {
-		return fmt.Errorf("database throttler is only available for Vitess (MySQL) databases; %s is %s",
-			printer.BoldBlue(database), printer.BoldBlue(string(db.Kind)))
+		return fmt.Errorf("%s is only available for Vitess (MySQL) databases; %s is %s",
+			feature, printer.BoldBlue(database), printer.BoldBlue(string(db.Kind)))
 	}
 	return nil
 }

--- a/internal/mock/database.go
+++ b/internal/mock/database.go
@@ -27,6 +27,15 @@ type DatabaseService struct {
 
 	UpdateThrottlerFn        func(context.Context, *ps.UpdateDatabaseThrottlerRequest) (*ps.DatabaseThrottler, error)
 	UpdateThrottlerFnInvoked bool
+
+	GetAggressiveCutoverFn        func(context.Context, *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error)
+	GetAggressiveCutoverFnInvoked bool
+
+	EnableAggressiveCutoverFn        func(context.Context, *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error)
+	EnableAggressiveCutoverFnInvoked bool
+
+	DisableAggressiveCutoverFn        func(context.Context, *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error)
+	DisableAggressiveCutoverFnInvoked bool
 }
 
 func (d *DatabaseService) Create(ctx context.Context, req *ps.CreateDatabaseRequest) (*ps.Database, error) {
@@ -62,4 +71,19 @@ func (d *DatabaseService) GetThrottler(ctx context.Context, req *ps.GetDatabaseT
 func (d *DatabaseService) UpdateThrottler(ctx context.Context, req *ps.UpdateDatabaseThrottlerRequest) (*ps.DatabaseThrottler, error) {
 	d.UpdateThrottlerFnInvoked = true
 	return d.UpdateThrottlerFn(ctx, req)
+}
+
+func (d *DatabaseService) GetAggressiveCutover(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+	d.GetAggressiveCutoverFnInvoked = true
+	return d.GetAggressiveCutoverFn(ctx, req)
+}
+
+func (d *DatabaseService) EnableAggressiveCutover(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+	d.EnableAggressiveCutoverFnInvoked = true
+	return d.EnableAggressiveCutoverFn(ctx, req)
+}
+
+func (d *DatabaseService) DisableAggressiveCutover(ctx context.Context, req *ps.AggressiveCutoverRequest) (*ps.AggressiveCutover, error) {
+	d.DisableAggressiveCutoverFnInvoked = true
+	return d.DisableAggressiveCutoverFn(ctx, req)
 }

--- a/internal/planetscale/databases.go
+++ b/internal/planetscale/databases.go
@@ -97,6 +97,19 @@ type DatabaseThrottler struct {
 	Configurations []*ThrottlerConfiguration `json:"configurations"`
 }
 
+// AggressiveCutoverRequest identifies a database for aggressive cutover ops.
+type AggressiveCutoverRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+}
+
+// AggressiveCutover is the database-level Vitess setting that makes future
+// deploy requests cut over more aggressively when waiting on table locks.
+// Distinct from per-deploy-request force cutover.
+type AggressiveCutover struct {
+	Enabled bool `json:"enabled"`
+}
+
 // DatabaseService is an interface for communicating with the PlanetScale
 // Databases API endpoint.
 type DatabasesService interface {
@@ -107,6 +120,9 @@ type DatabasesService interface {
 	UpdateSettings(context.Context, *UpdateDatabaseSettingsRequest) (*Database, error)
 	GetThrottler(context.Context, *GetDatabaseThrottlerRequest) (*DatabaseThrottler, error)
 	UpdateThrottler(context.Context, *UpdateDatabaseThrottlerRequest) (*DatabaseThrottler, error)
+	GetAggressiveCutover(context.Context, *AggressiveCutoverRequest) (*AggressiveCutover, error)
+	EnableAggressiveCutover(context.Context, *AggressiveCutoverRequest) (*AggressiveCutover, error)
+	DisableAggressiveCutover(context.Context, *AggressiveCutoverRequest) (*AggressiveCutover, error)
 }
 
 // DatabaseDeletionRequest encapsulates the request for deleting a database from
@@ -284,6 +300,33 @@ func (ds *databasesService) UpdateThrottler(ctx context.Context, updateReq *Upda
 	}
 
 	return throttler, nil
+}
+
+func (ds *databasesService) GetAggressiveCutover(ctx context.Context, getReq *AggressiveCutoverRequest) (*AggressiveCutover, error) {
+	return ds.doAggressiveCutover(ctx, http.MethodGet, getReq, "get")
+}
+
+func (ds *databasesService) EnableAggressiveCutover(ctx context.Context, enableReq *AggressiveCutoverRequest) (*AggressiveCutover, error) {
+	return ds.doAggressiveCutover(ctx, http.MethodPost, enableReq, "enable")
+}
+
+func (ds *databasesService) DisableAggressiveCutover(ctx context.Context, disableReq *AggressiveCutoverRequest) (*AggressiveCutover, error) {
+	return ds.doAggressiveCutover(ctx, http.MethodDelete, disableReq, "disable")
+}
+
+func (ds *databasesService) doAggressiveCutover(ctx context.Context, method string, acReq *AggressiveCutoverRequest, action string) (*AggressiveCutover, error) {
+	pathStr := path.Join(databasesAPIPath(acReq.Organization), acReq.Database, "aggressive-cutover")
+	req, err := ds.client.newRequest(method, pathStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for %s database aggressive cutover: %w", action, err)
+	}
+
+	status := &AggressiveCutover{}
+	if err := ds.client.do(ctx, req, status); err != nil {
+		return nil, err
+	}
+
+	return status, nil
 }
 
 func databasesAPIPath(org string) string {

--- a/internal/planetscale/databases_test.go
+++ b/internal/planetscale/databases_test.go
@@ -605,6 +605,72 @@ func TestDatabases_GetThrottler(t *testing.T) {
 	c.Assert(throttler.Configurations[0].Ratio, qt.Equals, float64(50))
 }
 
+func TestDatabases_GetAggressiveCutover(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/aggressive-cutover")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"enabled":true}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	status, err := client.Databases.GetAggressiveCutover(context.Background(), &AggressiveCutoverRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.Enabled, qt.IsTrue)
+}
+
+func TestDatabases_EnableAggressiveCutover(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/aggressive-cutover")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"enabled":true}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	status, err := client.Databases.EnableAggressiveCutover(context.Background(), &AggressiveCutoverRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.Enabled, qt.IsTrue)
+}
+
+func TestDatabases_DisableAggressiveCutover(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/aggressive-cutover")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"enabled":false}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	status, err := client.Databases.DisableAggressiveCutover(context.Background(), &AggressiveCutoverRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.Enabled, qt.IsFalse)
+}
+
 func TestDatabases_UpdateThrottler(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Adds `pscale database aggressive-cutover show|enable|disable` for the Vitess database-level setting that applies to future deploy requests.

Distinct from `pscale deploy-request force-cutover`.