### PR TITLE
Add pscale branch update

### DIFF
--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -29,6 +29,7 @@ func BranchCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(VtgateCmd(ch))
 	cmd.AddCommand(ParametersCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
+	cmd.AddCommand(UpdateCmd(ch))
 	cmd.AddCommand(SwitchCmd(ch))
 	cmd.AddCommand(DiffCmd(ch))
 	cmd.AddCommand(SchemaCmd(ch))

--- a/internal/cmd/branch/update.go
+++ b/internal/cmd/branch/update.go
@@ -1,0 +1,138 @@
+package branch
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/spf13/cobra"
+)
+
+// UpdateCmd updates configurable branch settings.
+func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		newName           string
+		deletionProtected bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <database> <branch>",
+		Short: "Update a branch's name or deletion protection",
+		Long: `Update a branch's name or deletion protection.
+
+Only the flags you pass are sent. At least one flag is required.`,
+		Example: `  pscale branch update mydb main --new-name trunk
+  pscale branch update mydb main --deletion-protected
+  pscale branch update mydb main --deletion-protected=false`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			newNameSet := cmd.Flags().Changed("new-name")
+			protectedSet := cmd.Flags().Changed("deletion-protected")
+			if !newNameSet && !protectedSet {
+				return fmt.Errorf("at least one of --new-name or --deletion-protected must be provided")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			db, err := client.Databases.Get(ctx, &ps.GetDatabaseRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating branch %s in %s",
+				printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+
+			if db.Kind == ps.DatabaseEngineMySQL {
+				updateReq := &ps.UpdateDatabaseBranchRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+					Branch:       branch,
+				}
+				if newNameSet {
+					updateReq.NewName = flags.newName
+				}
+				if protectedSet {
+					updateReq.DeletionProtected = &flags.deletionProtected
+				}
+
+				b, err := client.DatabaseBranches.Update(ctx, updateReq)
+				if err != nil {
+					return handleBranchUpdateError(ch, err, database, branch)
+				}
+				end()
+
+				return printUpdatedBranch(ch, database, branch, flags.newName, newNameSet, ToDatabaseBranch(b))
+			}
+
+			updateReq := &ps.UpdatePostgresBranchRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}
+			if newNameSet {
+				updateReq.NewName = flags.newName
+			}
+			if protectedSet {
+				updateReq.DeletionProtected = &flags.deletionProtected
+			}
+
+			b, err := client.PostgresBranches.Update(ctx, updateReq)
+			if err != nil {
+				return handleBranchUpdateError(ch, err, database, branch)
+			}
+			end()
+
+			return printUpdatedBranch(ch, database, branch, flags.newName, newNameSet, ToPostgresBranch(b))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.newName, "new-name", "", "Rename the branch")
+	cmd.Flags().BoolVar(&flags.deletionProtected, "deletion-protected", false,
+		"Protect the branch from deletion (use --deletion-protected=false to disable)")
+
+	return cmd
+}
+
+func handleBranchUpdateError(ch *cmdutil.Helper, err error, database, branch string) error {
+	switch cmdutil.ErrCode(err) {
+	case ps.ErrNotFound:
+		return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+			printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+	default:
+		return cmdutil.HandleError(err)
+	}
+}
+
+func printUpdatedBranch(ch *cmdutil.Helper, database, branch, newName string, renamed bool, resource any) error {
+	if ch.Printer.Format() != printer.Human {
+		return ch.Printer.PrintResource(resource)
+	}
+
+	if renamed {
+		ch.Printer.Printf("Branch %s in %s was successfully updated and is now named %s.\n",
+			printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(newName))
+		return nil
+	}
+
+	ch.Printer.Printf("Branch %s in %s was successfully updated.\n",
+		printer.BoldBlue(branch), printer.BoldBlue(database))
+	return nil
+}

--- a/internal/cmd/branch/update_test.go
+++ b/internal/cmd/branch/update_test.go
@@ -1,0 +1,176 @@
+package branch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestBranch_UpdateCmd_RenamesVitessBranch(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	res := &ps.DatabaseBranch{Name: "trunk"}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEngineMySQL}, nil
+		},
+	}
+
+	svc := &mock.DatabaseBranchesService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.NewName, qt.Equals, "trunk")
+			c.Assert(req.DeletionProtected, qt.IsNil)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: dbSvc, DatabaseBranches: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--new-name", "trunk"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranch_UpdateCmd_SetsDeletionProtectionFalse(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+
+	res := &ps.DatabaseBranch{Name: branch}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEngineMySQL}, nil
+		},
+	}
+
+	svc := &mock.DatabaseBranchesService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			c.Assert(req.NewName, qt.Equals, "")
+			c.Assert(req.DeletionProtected, qt.IsNotNil)
+			c.Assert(*req.DeletionProtected, qt.IsFalse)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: dbSvc, DatabaseBranches: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--deletion-protected=false"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_UpdateCmd_UpdatesPostgresBranch(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+
+	res := &ps.PostgresBranch{Name: "trunk"}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEnginePostgres}, nil
+		},
+	}
+
+	pgSvc := &mock.PostgresBranchesService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.NewName, qt.Equals, "trunk")
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: dbSvc, PostgresBranches: pgSvc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--new-name", "trunk"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(pgSvc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranch_UpdateCmd_RequiresAFlag(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Fatal("Databases.Get should not be called without update flags")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: dbSvc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "main"})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "at least one of --new-name or --deletion-protected")
+}

--- a/internal/mock/branch.go
+++ b/internal/mock/branch.go
@@ -16,6 +16,9 @@ type DatabaseBranchesService struct {
 	GetFn        func(context.Context, *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error)
 	GetFnInvoked bool
 
+	UpdateFn        func(context.Context, *ps.UpdateDatabaseBranchRequest) (*ps.DatabaseBranch, error)
+	UpdateFnInvoked bool
+
 	DeleteFn        func(context.Context, *ps.DeleteDatabaseBranchRequest) error
 	DeleteFnInvoked bool
 
@@ -78,6 +81,11 @@ func (d *DatabaseBranchesService) List(ctx context.Context, req *ps.ListDatabase
 func (d *DatabaseBranchesService) Get(ctx context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
 	d.GetFnInvoked = true
 	return d.GetFn(ctx, req)
+}
+
+func (d *DatabaseBranchesService) Update(ctx context.Context, req *ps.UpdateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+	d.UpdateFnInvoked = true
+	return d.UpdateFn(ctx, req)
 }
 
 func (d *DatabaseBranchesService) Delete(ctx context.Context, req *ps.DeleteDatabaseBranchRequest) error {
@@ -170,6 +178,9 @@ type PostgresBranchesService struct {
 	GetFn        func(context.Context, *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error)
 	GetFnInvoked bool
 
+	UpdateFn        func(context.Context, *ps.UpdatePostgresBranchRequest) (*ps.PostgresBranch, error)
+	UpdateFnInvoked bool
+
 	DeleteFn        func(context.Context, *ps.DeletePostgresBranchRequest) error
 	DeleteFnInvoked bool
 
@@ -208,6 +219,11 @@ func (p *PostgresBranchesService) List(ctx context.Context, req *ps.ListPostgres
 func (p *PostgresBranchesService) Get(ctx context.Context, req *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error) {
 	p.GetFnInvoked = true
 	return p.GetFn(ctx, req)
+}
+
+func (p *PostgresBranchesService) Update(ctx context.Context, req *ps.UpdatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+	p.UpdateFnInvoked = true
+	return p.UpdateFn(ctx, req)
 }
 
 func (p *PostgresBranchesService) Delete(ctx context.Context, req *ps.DeletePostgresBranchRequest) error {

--- a/internal/planetscale/branches.go
+++ b/internal/planetscale/branches.go
@@ -50,6 +50,16 @@ type CreateDatabaseBranchRequest struct {
 	ClusterSize  string `json:"cluster_size,omitempty"`
 }
 
+// UpdateDatabaseBranchRequest encapsulates the request for updating a database
+// branch's settings.
+type UpdateDatabaseBranchRequest struct {
+	Organization      string `json:"-"`
+	Database          string `json:"-"`
+	Branch            string `json:"-"`
+	NewName           string `json:"new_name,omitempty"`
+	DeletionProtected *bool  `json:"deletion_protected,omitempty"`
+}
+
 // ListDatabaseBranchesRequest encapsulates the request for listing the branches
 // of a database.
 type ListDatabaseBranchesRequest struct {
@@ -170,6 +180,7 @@ type DatabaseBranchesService interface {
 	Create(context.Context, *CreateDatabaseBranchRequest) (*DatabaseBranch, error)
 	List(context.Context, *ListDatabaseBranchesRequest, ...ListOption) ([]*DatabaseBranch, error)
 	Get(context.Context, *GetDatabaseBranchRequest) (*DatabaseBranch, error)
+	Update(context.Context, *UpdateDatabaseBranchRequest) (*DatabaseBranch, error)
 	Delete(context.Context, *DeleteDatabaseBranchRequest) error
 	Diff(context.Context, *DiffBranchRequest) ([]*Diff, error)
 	Schema(context.Context, *BranchSchemaRequest) ([]*Diff, error)
@@ -302,6 +313,22 @@ func (d *databaseBranchesService) Get(ctx context.Context, getReq *GetDatabaseBr
 	req, err := d.client.newRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	dbBranch := &DatabaseBranch{}
+	if err := d.client.do(ctx, req, &dbBranch); err != nil {
+		return nil, err
+	}
+
+	return dbBranch, nil
+}
+
+// Update updates a database branch's settings.
+func (d *databaseBranchesService) Update(ctx context.Context, updateReq *UpdateDatabaseBranchRequest) (*DatabaseBranch, error) {
+	path := databaseBranchAPIPath(updateReq.Organization, updateReq.Database, updateReq.Branch)
+	req, err := d.client.newRequest(http.MethodPatch, path, updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for update branch: %w", err)
 	}
 
 	dbBranch := &DatabaseBranch{}

--- a/internal/planetscale/branches_test.go
+++ b/internal/planetscale/branches_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -293,6 +294,42 @@ func TestBranches_RefreshSchema(t *testing.T) {
 		Branch:       testBranch,
 	})
 	c.Assert(err, qt.IsNil)
+}
+
+func TestBranches_Update(t *testing.T) {
+	c := qt.New(t)
+
+	wantURL := "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/planetscale-go-test-db-branch"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.String(), qt.DeepEquals, wantURL)
+
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]any{
+			"new_name":           "trunk",
+			"deletion_protected": true,
+		})
+
+		w.WriteHeader(200)
+		out := `{"id":"planetscale-go-test-db-branch","type":"database_branch","name":"trunk","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	protected := true
+	branch, err := client.DatabaseBranches.Update(context.Background(), &UpdateDatabaseBranchRequest{
+		Organization:      testOrg,
+		Database:          testDatabase,
+		Branch:            testBranch,
+		NewName:           "trunk",
+		DeletionProtected: &protected,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(branch.Name, qt.Equals, "trunk")
 }
 
 func TestBranches_Demote(t *testing.T) {

--- a/internal/planetscale/postgres_branches.go
+++ b/internal/planetscale/postgres_branches.go
@@ -59,6 +59,16 @@ type GetPostgresBranchRequest struct {
 	Branch       string
 }
 
+// UpdatePostgresBranchRequest encapsulates the request for updating a Postgres
+// branch's settings.
+type UpdatePostgresBranchRequest struct {
+	Organization      string `json:"-"`
+	Database          string `json:"-"`
+	Branch            string `json:"-"`
+	NewName           string `json:"new_name,omitempty"`
+	DeletionProtected *bool  `json:"deletion_protected,omitempty"`
+}
+
 // DeletePostgresBranchRequest encapsulates the request to delete a Postgres branch.
 type DeletePostgresBranchRequest struct {
 	Organization      string
@@ -222,6 +232,7 @@ type PostgresBranchesService interface {
 	Create(context.Context, *CreatePostgresBranchRequest) (*PostgresBranch, error)
 	List(context.Context, *ListPostgresBranchesRequest, ...ListOption) ([]*PostgresBranch, error)
 	Get(context.Context, *GetPostgresBranchRequest) (*PostgresBranch, error)
+	Update(context.Context, *UpdatePostgresBranchRequest) (*PostgresBranch, error)
 	Delete(context.Context, *DeletePostgresBranchRequest) error
 	Schema(context.Context, *PostgresBranchSchemaRequest) ([]*PostgresBranchSchema, error)
 	ListClusterSKUs(context.Context, *ListBranchClusterSKUsRequest, ...ListOption) ([]*ClusterSKU, error)
@@ -302,6 +313,22 @@ func (p *postgresBranchesService) Get(ctx context.Context, getReq *GetPostgresBr
 }
 
 // Delete deletes a Postgres branch from the specified organization and database.
+// Update updates a Postgres branch's settings.
+func (p *postgresBranchesService) Update(ctx context.Context, updateReq *UpdatePostgresBranchRequest) (*PostgresBranch, error) {
+	path := postgresBranchAPIPath(updateReq.Organization, updateReq.Database, updateReq.Branch)
+	req, err := p.client.newRequest(http.MethodPatch, path, updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	b := &PostgresBranch{}
+	if err := p.client.do(ctx, req, b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
 func (p *postgresBranchesService) Delete(ctx context.Context, deleteReq *DeletePostgresBranchRequest) error {
 	path := path.Join(postgresBranchesAPIPath(deleteReq.Organization, deleteReq.Database), deleteReq.Branch)
 


### PR DESCRIPTION
Adds `pscale branch update <database> <branch>` to rename a branch and toggle deletion protection. Both settings hit the same `PATCH` branch endpoint, so they are flags on one command rather than separate commands.

```bash
pscale branch update mydb main --new-name trunk
pscale branch update mydb main --deletion-protected
pscale branch update mydb main --deletion-protected=false
```

Only flags that are explicitly passed are sent; the command errors if neither is provided. Works for Vitess and Postgres branches.