### PR TITLE
Add pscale traffic-control budget list

### DIFF
--- a/internal/cmd/trafficcontrol/budget_list.go
+++ b/internal/cmd/trafficcontrol/budget_list.go
@@ -1,0 +1,73 @@
+package trafficcontrol
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func BudgetListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		fingerprint string
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list <database> <branch>",
+		Short:   "List traffic budgets for a branch",
+		Args:    cmdutil.RequiredArgs("database", "branch"),
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching traffic budgets for %s/%s",
+				printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			budgets, err := client.TrafficBudgets.List(ctx, &ps.ListTrafficBudgetsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Fingerprint:  flags.fingerprint,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if len(budgets) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.fingerprint != "" {
+					ch.Printer.Printf("No traffic budgets in %s/%s match fingerprint %s.\n",
+						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(flags.fingerprint))
+				} else {
+					ch.Printer.Printf("No traffic budgets exist in %s/%s.\n",
+						printer.BoldBlue(database), printer.BoldBlue(branch))
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toTrafficBudgets(budgets))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.fingerprint, "fingerprint", "",
+		"Only list budgets with a rule for this query fingerprint")
+
+	return cmd
+}

--- a/internal/cmd/trafficcontrol/budget_list_test.go
+++ b/internal/cmd/trafficcontrol/budget_list_test.go
@@ -1,0 +1,120 @@
+package trafficcontrol
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestBudgetListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	budgets := []*ps.TrafficBudget{
+		{
+			ID:        budgetID,
+			Name:      "CPU Limiter",
+			Mode:      "enforce",
+			CreatedAt: time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC),
+		},
+	}
+
+	svc := &mock.TrafficBudgetsService{
+		ListFn: func(ctx context.Context, req *ps.ListTrafficBudgetsRequest) ([]*ps.TrafficBudget, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Fingerprint, qt.Equals, "")
+			return budgets, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{TrafficBudgets: svc}, nil
+		},
+	}
+
+	cmd := BudgetListCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, []*TrafficBudget{{orig: budgets[0]}})
+}
+
+func TestBudgetListCmd_FiltersByFingerprint(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.TrafficBudgetsService{
+		ListFn: func(ctx context.Context, req *ps.ListTrafficBudgetsRequest) ([]*ps.TrafficBudget, error) {
+			c.Assert(req.Fingerprint, qt.Equals, "abc123")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{TrafficBudgets: svc}, nil
+		},
+	}
+
+	cmd := BudgetListCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--fingerprint", "abc123"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}
+
+func TestBudgetListCmd_NotFound(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.TrafficBudgetsService{
+		ListFn: func(ctx context.Context, req *ps.ListTrafficBudgetsRequest) ([]*ps.TrafficBudget, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{TrafficBudgets: svc}, nil
+		},
+	}
+
+	cmd := BudgetListCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+}

--- a/internal/cmd/trafficcontrol/traffic_control.go
+++ b/internal/cmd/trafficcontrol/traffic_control.go
@@ -29,6 +29,7 @@ func TrafficCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Manage traffic budgets",
 	}
 	budgetCmd.AddCommand(
+		BudgetListCmd(ch),
 		BudgetShowCmd(ch),
 		BudgetCreateCmd(ch),
 		BudgetUpdateCmd(ch),
@@ -85,6 +86,14 @@ func toTrafficBudget(b *ps.TrafficBudget) *TrafficBudget {
 		UpdatedAt:        printer.GetMilliseconds(b.UpdatedAt),
 		orig:             b,
 	}
+}
+
+func toTrafficBudgets(budgets []*ps.TrafficBudget) []*TrafficBudget {
+	out := make([]*TrafficBudget, 0, len(budgets))
+	for _, b := range budgets {
+		out = append(out, toTrafficBudget(b))
+	}
+	return out
 }
 
 type TrafficRuleDisplay struct {

--- a/internal/planetscale/traffic_budgets.go
+++ b/internal/planetscale/traffic_budgets.go
@@ -3,6 +3,7 @@ package planetscale
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"path"
 	"time"
 )
@@ -71,6 +72,9 @@ type ListTrafficBudgetsRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
 	Branch       string `json:"-"`
+	// Fingerprint, when set, returns only budgets with a rule for that query
+	// fingerprint.
+	Fingerprint string `json:"-"`
 }
 
 // GetTrafficBudgetRequest is the request for getting a traffic budget.
@@ -144,7 +148,14 @@ func NewTrafficBudgetsService(client *Client) *trafficBudgetsService {
 }
 
 func (s *trafficBudgetsService) List(ctx context.Context, listReq *ListTrafficBudgetsRequest) ([]*TrafficBudget, error) {
-	req, err := s.client.newRequest(http.MethodGet, trafficBudgetsAPIPath(listReq.Organization, listReq.Database, listReq.Branch), nil)
+	var opts []RequestOption
+	if listReq.Fingerprint != "" {
+		v := url.Values{}
+		v.Add("fingerprint", listReq.Fingerprint)
+		opts = append(opts, WithQueryParams(v))
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, trafficBudgetsAPIPath(listReq.Organization, listReq.Database, listReq.Branch), nil, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/planetscale/traffic_budgets_test.go
+++ b/internal/planetscale/traffic_budgets_test.go
@@ -10,6 +10,33 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
+func TestTrafficBudgets_ListWithFingerprint(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/planetscale-go-test-db-branch/traffic/budgets")
+		c.Assert(r.URL.Query().Get("fingerprint"), qt.Equals, "abc123")
+
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"data":[]}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	budgets, err := client.TrafficBudgets.List(context.Background(), &ListTrafficBudgetsRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       testBranch,
+		Fingerprint:  "abc123",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(budgets, qt.HasLen, 0)
+}
+
 func TestTrafficBudgets_List(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Traffic budgets could only be fetched one at a time by ID, so there was no way to discover budget IDs from the CLI. Adds the missing list command.

```bash
pscale traffic-control budget list mydb main --org myorg
pscale traffic-control budget list mydb main --org myorg --fingerprint abc123
```

`--fingerprint` is passed through to the API's existing filter and returns only budgets with a rule for that query fingerprint.