### PR TITLE
Add pscale password show and update

### DIFF
--- a/internal/cmd/password/delete.go
+++ b/internal/cmd/password/delete.go
@@ -29,13 +29,8 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			database := args[0]
 			branch := args[1]
 
-			// Validate that either password-id is provided as arg or --name flag is used
-			var passwordId string
-			if name != "" && len(args) == 3 {
-				return errors.New("cannot specify both password-id argument and --name flag")
-			}
-			if name == "" && len(args) != 3 {
-				return errors.New("must provide either password-id argument or --name flag")
+			if err := passwordSelector(args, name); err != nil {
+				return err
 			}
 
 			client, err := ch.Client()
@@ -43,55 +38,14 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			// If using --name flag, find the password by name
-			if name != "" {
-				end := ch.Printer.PrintProgress(fmt.Sprintf("Finding password %s in %s/%s",
-					printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			var argID string
+			if len(args) == 3 {
+				argID = args[2]
+			}
 
-				var foundPassword *ps.DatabaseBranchPassword
-				page := 1
-				perPage := 100
-
-				for {
-					passwords, err := client.Passwords.List(ctx, &ps.ListDatabaseBranchPasswordRequest{
-						Organization: ch.Config.Organization,
-						Database:     database,
-						Branch:       branch,
-					}, ps.WithPage(page), ps.WithPerPage(perPage))
-					if err != nil {
-						end()
-						switch cmdutil.ErrCode(err) {
-						case ps.ErrNotFound:
-							return fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
-								printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-						default:
-							return cmdutil.HandleError(err)
-						}
-					}
-
-					for _, password := range passwords {
-						if password.Name == name {
-							foundPassword = password
-							break
-						}
-					}
-
-					if foundPassword != nil || len(passwords) < perPage {
-						break
-					}
-					page++
-				}
-
-				end()
-
-				if foundPassword == nil {
-					return fmt.Errorf("password with name %s does not exist in branch %s of %s (organization: %s)",
-						printer.BoldBlue(name), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
-				}
-
-				passwordId = foundPassword.PublicID
-			} else {
-				passwordId = args[2]
+			passwordId, err := resolvePasswordID(ctx, ch, client, database, branch, argID, name)
+			if err != nil {
+				return err
 			}
 
 			if !force {

--- a/internal/cmd/password/password.go
+++ b/internal/cmd/password/password.go
@@ -1,12 +1,16 @@
 package password
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/lensesio/tableprinter"
 	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
 	"github.com/spf13/cobra"
 
 	ps "github.com/planetscale/cli/internal/planetscale"
@@ -16,8 +20,8 @@ import (
 func PasswordCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "password <command>",
-		Short:             "Create, list, and delete branch passwords",
-		Long:              "Create, list, and delete branch passwords.\n\nThis command is only supported for Vitess databases.",
+		Short:             "Create, list, update, and delete branch passwords",
+		Long:              "Create, list, update, and delete branch passwords.\n\nThis command is only supported for Vitess databases.",
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
 
@@ -26,10 +30,65 @@ func PasswordCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.AddCommand(CreateCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
+	cmd.AddCommand(ShowCmd(ch))
+	cmd.AddCommand(UpdateCmd(ch))
 	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(RenewCmd(ch))
 
 	return cmd
+}
+
+// resolvePasswordID resolves the password ID for commands that accept either a
+// password ID argument or a --name flag. Exactly one of id or name must be set.
+func resolvePasswordID(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch, id, name string) (string, error) {
+	if name == "" {
+		return id, nil
+	}
+
+	end := ch.Printer.PrintProgress(fmt.Sprintf("Finding password %s in %s/%s",
+		printer.BoldBlue(name), printer.BoldBlue(database), printer.BoldBlue(branch)))
+	defer end()
+
+	perPage := 100
+	for page := 1; ; page++ {
+		passwords, err := client.Passwords.List(ctx, &ps.ListDatabaseBranchPasswordRequest{
+			Organization: ch.Config.Organization,
+			Database:     database,
+			Branch:       branch,
+		}, ps.WithPage(page), ps.WithPerPage(perPage))
+		if err != nil {
+			switch cmdutil.ErrCode(err) {
+			case ps.ErrNotFound:
+				return "", fmt.Errorf("branch %s does not exist in database %s (organization: %s)",
+					printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+			default:
+				return "", cmdutil.HandleError(err)
+			}
+		}
+
+		for _, password := range passwords {
+			if password.Name == name {
+				return password.PublicID, nil
+			}
+		}
+
+		if len(passwords) < perPage {
+			return "", fmt.Errorf("password with name %s does not exist in branch %s of %s (organization: %s)",
+				printer.BoldBlue(name), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+		}
+	}
+}
+
+// passwordSelector validates the password-id argument and --name flag pair used
+// by show, update, and delete.
+func passwordSelector(args []string, name string) error {
+	if name != "" && len(args) == 3 {
+		return errors.New("cannot specify both password-id argument and --name flag")
+	}
+	if name == "" && len(args) != 3 {
+		return errors.New("must provide either password-id argument or --name flag")
+	}
+	return nil
 }
 
 type Passwords []*Password

--- a/internal/cmd/password/show.go
+++ b/internal/cmd/password/show.go
@@ -1,0 +1,88 @@
+package password
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+
+	"github.com/spf13/cobra"
+)
+
+// ShowCmd shows the metadata for a branch password. The password secret is only
+// available when the password is created or renewed, so it is never shown here.
+func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	var name string
+
+	cmd := &cobra.Command{
+		Use:   "show <database> <branch> [<password-id>]",
+		Short: "Show a branch password",
+		Long: `Show a branch password.
+
+Only metadata is returned. The password itself is shown once, when it is
+created or renewed, and cannot be retrieved afterwards.`,
+		Args: cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+
+			if err := passwordSelector(args, name); err != nil {
+				return err
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			var argID string
+			if len(args) == 3 {
+				argID = args[2]
+			}
+
+			passwordId, err := resolvePasswordID(ctx, ch, client, database, branch, argID, name)
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching password %s from %s/%s",
+				printer.BoldBlue(passwordId), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			password, err := client.Passwords.Get(ctx, &ps.GetDatabaseBranchPasswordRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				PasswordId:   passwordId,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("password %s does not exist in branch %s of %s (organization: %s)",
+						printer.BoldBlue(passwordId), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if err := ch.Printer.PrintResource(toPassword(password)); err != nil {
+				return err
+			}
+
+			if ch.Printer.Format() == printer.Human && len(password.CIDRs) > 0 {
+				ch.Printer.Printf("\nIP restrictions: %s\n", strings.Join(password.CIDRs, ", "))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Show password by name instead of ID")
+	return cmd
+}

--- a/internal/cmd/password/show_test.go
+++ b/internal/cmd/password/show_test.go
@@ -1,0 +1,131 @@
+package password
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPassword_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	passwordID := "pscale_pw_xxx"
+
+	res := &ps.DatabaseBranchPassword{
+		PublicID: passwordID,
+		Name:     "reporting",
+		Role:     "reader",
+		CIDRs:    []string{"10.0.0.0/8"},
+		Branch:   ps.DatabaseBranch{Name: branch},
+	}
+
+	svc := &mock.PasswordsService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.PasswordId, qt.Equals, passwordID)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch, passwordID})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestPassword_ShowCmdByName(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	passwordID := "pscale_pw_xxx"
+
+	res := &ps.DatabaseBranchPassword{
+		PublicID: passwordID,
+		Name:     "reporting",
+		Branch:   ps.DatabaseBranch{Name: branch},
+	}
+
+	svc := &mock.PasswordsService{
+		ListFn: func(ctx context.Context, req *ps.ListDatabaseBranchPasswordRequest, opts ...ps.ListOption) ([]*ps.DatabaseBranchPassword, error) {
+			return []*ps.DatabaseBranchPassword{res}, nil
+		},
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.PasswordId, qt.Equals, passwordID)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--name", "reporting"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+}
+
+func TestPassword_ShowCmdRequiresSelector(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: &mock.PasswordsService{}}, nil
+		},
+	}
+
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "must provide either password-id argument or --name flag")
+}

--- a/internal/cmd/password/update.go
+++ b/internal/cmd/password/update.go
@@ -1,0 +1,135 @@
+package password
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/printer"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+
+	"github.com/spf13/cobra"
+)
+
+// UpdateCmd updates the name or IP restrictions of a branch password. It never
+// changes the password secret; use create and delete, or renew, for that.
+func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		name    string
+		newName string
+		cidrs   []string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <database> <branch> [<password-id>]",
+		Short: "Update a branch password's name or IP restrictions",
+		Long: `Update a branch password's name or IP restrictions.
+
+This does not change the password itself. To rotate a password, create a new
+one and delete the old one.`,
+		Example: `  pscale password update mydb main pscale_pw_xxx --new-name reporting
+  pscale password update mydb main --name reporting --cidrs 10.0.0.0/8,192.168.1.1/32
+  pscale password update mydb main --name reporting --cidrs ""`,
+		Args: cobra.RangeArgs(2, 3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+
+			if err := passwordSelector(args, flags.name); err != nil {
+				return err
+			}
+
+			newNameSet := cmd.Flags().Changed("new-name")
+			cidrsSet := cmd.Flags().Changed("cidrs")
+			if !newNameSet && !cidrsSet {
+				return errors.New("at least one of --new-name or --cidrs must be provided")
+			}
+			if newNameSet && flags.newName == "" {
+				return errors.New("--new-name cannot be empty")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			var argID string
+			if len(args) == 3 {
+				argID = args[2]
+			}
+
+			passwordId, err := resolvePasswordID(ctx, ch, client, database, branch, argID, flags.name)
+			if err != nil {
+				return err
+			}
+
+			updateReq := &ps.UpdateDatabaseBranchPasswordRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				PasswordId:   passwordId,
+			}
+			if newNameSet {
+				updateReq.Name = flags.newName
+			}
+			if cidrsSet {
+				cidrs := normalizeCIDRs(flags.cidrs)
+				updateReq.CIDRs = &cidrs
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating password %s in %s/%s",
+				printer.BoldBlue(passwordId), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			password, err := client.Passwords.Update(ctx, updateReq)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("password %s does not exist in branch %s of %s (organization: %s)",
+						printer.BoldBlue(passwordId), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Password %s was successfully updated in %s.\n",
+					printer.BoldBlue(password.Name), printer.BoldBlue(branch))
+				if cidrsSet {
+					if len(password.CIDRs) == 0 {
+						ch.Printer.Println("IP restrictions: none")
+					} else {
+						ch.Printer.Printf("IP restrictions: %s\n", strings.Join(password.CIDRs, ", "))
+					}
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toPassword(password))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.name, "name", "", "Update password by name instead of ID")
+	cmd.Flags().StringVar(&flags.newName, "new-name", "", "New name for the password")
+	cmd.Flags().StringSliceVar(&flags.cidrs, "cidrs", nil,
+		"Replace the IP addresses and CIDR ranges allowed to use this password. Pass an empty value to remove all restrictions")
+
+	return cmd
+}
+
+// normalizeCIDRs drops the empty entries produced by flags like --cidrs "" so
+// that clearing restrictions sends an empty list instead of a blank CIDR.
+func normalizeCIDRs(cidrs []string) []string {
+	out := make([]string, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		if trimmed := strings.TrimSpace(cidr); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/cmd/password/update_test.go
+++ b/internal/cmd/password/update_test.go
@@ -1,0 +1,185 @@
+package password
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPassword_UpdateCmdRenames(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	passwordID := "pscale_pw_xxx"
+
+	res := &ps.DatabaseBranchPassword{
+		PublicID: passwordID,
+		Name:     "reporting",
+		Branch:   ps.DatabaseBranch{Name: branch},
+	}
+
+	svc := &mock.PasswordsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.PasswordId, qt.Equals, passwordID)
+			c.Assert(req.Name, qt.Equals, "reporting")
+			c.Assert(req.CIDRs, qt.IsNil)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, branch, passwordID, "--new-name", "reporting"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestPassword_UpdateCmdSetsCIDRs(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.PasswordsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.Name, qt.Equals, "")
+			c.Assert(req.CIDRs, qt.IsNotNil)
+			c.Assert(*req.CIDRs, qt.DeepEquals, []string{"10.0.0.0/8", "192.168.1.1/32"})
+			return &ps.DatabaseBranchPassword{PublicID: "pscale_pw_xxx"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "pscale_pw_xxx", "--cidrs", "10.0.0.0/8,192.168.1.1/32"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestPassword_UpdateCmdClearsCIDRs(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.PasswordsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.CIDRs, qt.IsNotNil)
+			c.Assert(*req.CIDRs, qt.HasLen, 0)
+			return &ps.DatabaseBranchPassword{PublicID: "pscale_pw_xxx"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "pscale_pw_xxx", "--cidrs", ""})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestPassword_UpdateCmdByName(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	passwordID := "pscale_pw_xxx"
+
+	svc := &mock.PasswordsService{
+		ListFn: func(ctx context.Context, req *ps.ListDatabaseBranchPasswordRequest, opts ...ps.ListOption) ([]*ps.DatabaseBranchPassword, error) {
+			return []*ps.DatabaseBranchPassword{{PublicID: passwordID, Name: "reporting"}}, nil
+		},
+		UpdateFn: func(ctx context.Context, req *ps.UpdateDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+			c.Assert(req.PasswordId, qt.Equals, passwordID)
+			c.Assert(req.Name, qt.Equals, "analytics")
+			return &ps.DatabaseBranchPassword{PublicID: passwordID, Name: "analytics"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "--name", "reporting", "--new-name", "analytics"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestPassword_UpdateCmdRequiresAFlag(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.PasswordsService{}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Passwords: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "pscale_pw_xxx"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "at least one of --new-name or --cidrs")
+	c.Assert(svc.UpdateFnInvoked, qt.IsFalse)
+}

--- a/internal/mock/password.go
+++ b/internal/mock/password.go
@@ -13,6 +13,8 @@ type PasswordsService struct {
 	ListFnInvoked   bool
 	GetFn           func(context.Context, *ps.GetDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error)
 	GetFnInvoked    bool
+	UpdateFn        func(context.Context, *ps.UpdateDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error)
+	UpdateFnInvoked bool
 	DeleteFn        func(context.Context, *ps.DeleteDatabaseBranchPasswordRequest) error
 	DeleteFnInvoked bool
 	RenewFn         func(context.Context, *ps.RenewDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error)
@@ -27,6 +29,11 @@ func (b *PasswordsService) Create(ctx context.Context, req *ps.DatabaseBranchPas
 func (b *PasswordsService) List(ctx context.Context, req *ps.ListDatabaseBranchPasswordRequest, opts ...ps.ListOption) ([]*ps.DatabaseBranchPassword, error) {
 	b.ListFnInvoked = true
 	return b.ListFn(ctx, req, opts...)
+}
+
+func (b *PasswordsService) Update(ctx context.Context, req *ps.UpdateDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {
+	b.UpdateFnInvoked = true
+	return b.UpdateFn(ctx, req)
 }
 
 func (b *PasswordsService) Get(ctx context.Context, req *ps.GetDatabaseBranchPasswordRequest) (*ps.DatabaseBranchPassword, error) {

--- a/internal/planetscale/passwords.go
+++ b/internal/planetscale/passwords.go
@@ -24,6 +24,7 @@ type DatabaseBranchPassword struct {
 	TTL       int            `json:"ttl_seconds"`
 	Renewable bool           `json:"renewable"`
 	Replica   bool           `json:"replica"`
+	CIDRs     []string       `json:"cidrs"`
 
 	// ReadOnlyRegion is set client-side when the password is known to be scoped to a
 	// Vitess read-only region (the API does not currently return a dedicated flag).
@@ -61,6 +62,21 @@ type GetDatabaseBranchPasswordRequest struct {
 	PasswordId   string
 }
 
+// UpdateDatabaseBranchPasswordRequest encapsulates the request for updating a
+// password's name or IP restrictions.
+type UpdateDatabaseBranchPasswordRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+	PasswordId   string `json:"-"`
+
+	// Name renames the password when set.
+	Name string `json:"name,omitempty"`
+	// CIDRs replaces the IP restrictions when set. A pointer to an empty slice
+	// clears them.
+	CIDRs *[]string `json:"cidrs,omitempty"`
+}
+
 // DeleteDatabaseBranchPasswordRequest encapsulates the request for deleting a password
 // for a given database branch.
 type DeleteDatabaseBranchPasswordRequest struct {
@@ -87,6 +103,7 @@ type PasswordsService interface {
 	// List returns passwords with optional pagination support via ListOption parameters
 	List(context.Context, *ListDatabaseBranchPasswordRequest, ...ListOption) ([]*DatabaseBranchPassword, error)
 	Get(context.Context, *GetDatabaseBranchPasswordRequest) (*DatabaseBranchPassword, error)
+	Update(context.Context, *UpdateDatabaseBranchPasswordRequest) (*DatabaseBranchPassword, error)
 	Delete(context.Context, *DeleteDatabaseBranchPasswordRequest) error
 	Renew(context.Context, *RenewDatabaseBranchPasswordRequest) (*DatabaseBranchPassword, error)
 }
@@ -139,6 +156,22 @@ func (d *passwordsService) Delete(ctx context.Context, deleteReq *DeleteDatabase
 func (d *passwordsService) Get(ctx context.Context, getReq *GetDatabaseBranchPasswordRequest) (*DatabaseBranchPassword, error) {
 	pathStr := passwordBranchAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.PasswordId)
 	req, err := d.client.newRequest(http.MethodGet, pathStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	password := &DatabaseBranchPassword{}
+	if err := d.client.do(ctx, req, &password); err != nil {
+		return nil, err
+	}
+
+	return password, nil
+}
+
+// Update an existing password's name or IP restrictions.
+func (d *passwordsService) Update(ctx context.Context, updateReq *UpdateDatabaseBranchPasswordRequest) (*DatabaseBranchPassword, error) {
+	pathStr := passwordBranchAPIPath(updateReq.Organization, updateReq.Database, updateReq.Branch, updateReq.PasswordId)
+	req, err := d.client.newRequest(http.MethodPatch, pathStr, updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/internal/planetscale/passwords_test.go
+++ b/internal/planetscale/passwords_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -334,6 +335,80 @@ func TestPasswords_Get(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(password, qt.DeepEquals, want)
+}
+
+func TestPasswords_Update(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, fmt.Sprintf("/v1/organizations/my-org/databases/planetscale-go-test-db/branches/my-branch/passwords/%s", testPasswordID))
+
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]any{
+			"name":  "renamed-password",
+			"cidrs": []any{"10.0.0.0/8"},
+		})
+
+		w.WriteHeader(200)
+		out := fmt.Sprintf(`{
+    "id": "%s",
+    "role": "writer",
+    "name": "renamed-password",
+    "cidrs": ["10.0.0.0/8"],
+    "created_at": "2021-01-14T10:19:23.000Z"
+}`, testPasswordID)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	cidrs := []string{"10.0.0.0/8"}
+	password, err := client.Passwords.Update(context.Background(), &UpdateDatabaseBranchPasswordRequest{
+		Organization: "my-org",
+		Database:     "planetscale-go-test-db",
+		Branch:       "my-branch",
+		PasswordId:   testPasswordID,
+		Name:         "renamed-password",
+		CIDRs:        &cidrs,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(password.Name, qt.Equals, "renamed-password")
+	c.Assert(password.CIDRs, qt.DeepEquals, []string{"10.0.0.0/8"})
+}
+
+func TestPasswords_UpdateClearsCIDRs(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]any{"cidrs": []any{}})
+
+		w.WriteHeader(200)
+		out := fmt.Sprintf(`{"id":"%s","name":"planetscale-go-test-password","cidrs":[]}`, testPasswordID)
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	cidrs := []string{}
+	password, err := client.Passwords.Update(context.Background(), &UpdateDatabaseBranchPasswordRequest{
+		Organization: "my-org",
+		Database:     "planetscale-go-test-db",
+		Branch:       "my-branch",
+		PasswordId:   testPasswordID,
+		CIDRs:        &cidrs,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(password.CIDRs, qt.HasLen, 0)
 }
 
 func TestPasswords_Renew(t *testing.T) {


### PR DESCRIPTION
Branch passwords could be created, listed, and deleted, but there was no way to inspect one or change its metadata. Renaming a password or changing its IP allowlist meant deleting and recreating it, which rotates the secret.

```bash
pscale password show mydb main pscale_pw_xxx --org myorg
pscale password show mydb main --name reporting --org myorg

pscale password update mydb main pscale_pw_xxx --new-name reporting --org myorg
pscale password update mydb main --name reporting --cidrs 10.0.0.0/8,192.168.1.1/32 --org myorg
pscale password update mydb main --name reporting --cidrs "" --org myorg
```

Notes:
- `show` returns metadata only. The secret is shown once at create or renew and is not retrievable afterwards.
- `update` never changes the secret. `--name` selects the password (same addressing as `delete`), `--new-name` renames it, `--cidrs` replaces the IP allowlist, and an empty `--cidrs` clears it.
- The lookup-by-name loop that `delete` had is now shared by all three commands.