### PR TITLE
Add pscale deploy-request unblock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ Vitess only. See https://planetscale.com/docs/vitess/schema-changes/aggressive-c
 
 ## Vitess deploy requests (inspect + throttler)
 
-Core lifecycle is already covered (`list/create/show/diff/review/deploy/apply/edit/cancel/close/revert/skip-revert`). These inspect commands are read-only:
+Core lifecycle is already covered (`list/create/show/diff/review/deploy/apply/unblock/edit/cancel/close/revert/skip-revert`). `unblock` clears the queue after a failed deploy or revert (dashboard “Unblock deploy queue”); it is not `apply`. These inspect commands are read-only:
 
 ```bash
 pscale deploy-request queue <database> --org <org> --format json                         # database deploy queue (first page)
@@ -312,6 +312,12 @@ pscale deploy-request throttler update <database> <number> --org <org> --format 
 ```
 
 Alias: `pscale dr …` works the same. Vitess only. `--ratio` is 0–95 (0 disables throttling; 95 is slowest). Use either `--ratio` or `--configuration keyspace=ratio`, not both.
+
+After a failed deploy or revert (`complete_error` / `complete_revert_error`), unblock the queue. This is not `apply` (gated cutover) and it cannot fix a deploy-check `error`:
+
+```bash
+pscale deploy-request unblock <database> <number> --org <org> --format json
+```
 
 ## Maintenance schedules (Vitess Enterprise)
 

--- a/internal/cmd/deployrequest/dr.go
+++ b/internal/cmd/deployrequest/dr.go
@@ -42,6 +42,7 @@ func DeployRequestCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(SkipRevertCmd(ch))
 	cmd.AddCommand(StorageCheckCmd(ch))
 	cmd.AddCommand(ThrottlerCmd(ch))
+	cmd.AddCommand(UnblockCmd(ch))
 	cmd.AddCommand(RevertCmd(ch))
 
 	return cmd

--- a/internal/cmd/deployrequest/unblock.go
+++ b/internal/cmd/deployrequest/unblock.go
@@ -1,0 +1,114 @@
+package deployrequest
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/spf13/cobra"
+)
+
+// UnblockCmd unblocks the deploy queue after a failed deploy or revert.
+func UnblockCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unblock <database> <number>",
+		Short: "Unblock the deploy queue after a failed deploy or revert",
+		Long: `Unblock the deploy queue after a failed deploy or revert.
+
+When a deployment or revert errors, PlanetScale blocks the queue as a
+precaution. This is the same action as "Unblock deploy queue" in the dashboard.
+It does not apply a gated deploy (use 'deploy-request apply' for that) and it
+does not fix a schema that failed deploy checks.
+
+The API decides whether the failure was a deploy or a revert.`,
+		Args: cmdutil.RequiredArgs("database", "number"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			number := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			n, err := strconv.ParseUint(number, 10, 64)
+			if err != nil {
+				return fmt.Errorf("the argument <number> is invalid: %s", err)
+			}
+
+			dr, err := client.DeployRequests.Get(ctx, &planetscale.GetDeployRequestRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Number:       n,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			if err := checkUnblockState(database, number, dr); err != nil {
+				return err
+			}
+
+			dr, err = client.DeployRequests.UnblockDeploy(ctx, &planetscale.UnblockDeployRequestRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Number:       n,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("deploy request '%s/%s' does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Unblocked the deploy queue for '%s/%s'.\n",
+					printer.BoldBlue(database),
+					printer.BoldBlue(dr.Number))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toDeployRequest(dr))
+		},
+	}
+
+	return cmd
+}
+
+func checkUnblockState(database, number string, dr *planetscale.DeployRequest) error {
+	if dr.Deployment == nil {
+		return fmt.Errorf("deploy request '%s/%s' does not have a failed deploy to unblock",
+			printer.BoldBlue(database), printer.BoldBlue(number))
+	}
+
+	switch dr.Deployment.State {
+	case "complete_error", "complete_revert_error":
+		return nil
+	case "pending_cutover":
+		return fmt.Errorf("deploy request '%s/%s' is waiting to apply changes; use 'pscale deploy-request apply %s %s'",
+			printer.BoldBlue(database), printer.BoldBlue(number), database, number)
+	case "error":
+		msg := fmt.Sprintf("deploy request '%s/%s' failed deploy checks and cannot unblock the queue",
+			printer.BoldBlue(database), printer.BoldBlue(number))
+		if dr.Deployment.DeployCheckErrors != "" {
+			msg += ": " + dr.Deployment.DeployCheckErrors
+		}
+		return fmt.Errorf("%s", msg)
+	default:
+		return fmt.Errorf("deploy request '%s/%s' does not have a failed deploy to unblock (deployment state: %s)",
+			printer.BoldBlue(database), printer.BoldBlue(number), printer.BoldBlue(dr.Deployment.State))
+	}
+}

--- a/internal/cmd/deployrequest/unblock_test.go
+++ b/internal/cmd/deployrequest/unblock_test.go
@@ -1,0 +1,165 @@
+package deployrequest
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+func TestDeployRequest_UnblockCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	var number uint64 = 10
+
+	svc := &mock.DeployRequestsService{
+		GetFn: func(ctx context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Assert(req.Number, qt.Equals, number)
+			return &ps.DeployRequest{
+				Number:     number,
+				Deployment: &ps.Deployment{State: "complete_error"},
+			}, nil
+		},
+		UnblockFn: func(ctx context.Context, req *ps.UnblockDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Assert(req.Number, qt.Equals, number)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.DeployRequest{Number: number}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{DeployRequests: svc}, nil
+		},
+	}
+
+	cmd := UnblockCmd(ch)
+	cmd.SetArgs([]string{db, strconv.FormatUint(number, 10)})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(svc.UnblockFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &ps.DeployRequest{Number: number})
+}
+
+func TestDeployRequest_UnblockCmd_RevertError(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.DeployRequestsService{
+		GetFn: func(ctx context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+			return &ps.DeployRequest{
+				Number:     10,
+				Deployment: &ps.Deployment{State: "complete_revert_error"},
+			}, nil
+		},
+		UnblockFn: func(ctx context.Context, req *ps.UnblockDeployRequestRequest) (*ps.DeployRequest, error) {
+			return &ps.DeployRequest{Number: 10}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{DeployRequests: svc}, nil
+		},
+	}
+
+	cmd := UnblockCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "10"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UnblockFnInvoked, qt.IsTrue)
+}
+
+func TestDeployRequest_UnblockCmd_PendingCutover(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.DeployRequestsService{
+		GetFn: func(ctx context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+			return &ps.DeployRequest{
+				Number:     10,
+				Deployment: &ps.Deployment{State: "pending_cutover"},
+			}, nil
+		},
+		UnblockFn: func(ctx context.Context, req *ps.UnblockDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Fatal("UnblockDeploy should not be called")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{DeployRequests: svc}, nil
+		},
+	}
+
+	cmd := UnblockCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "10"})
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, ".*waiting to apply changes.*deploy-request apply.*")
+	c.Assert(svc.UnblockFnInvoked, qt.IsFalse)
+}
+
+func TestDeployRequest_UnblockCmd_DeployCheckError(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.DeployRequestsService{
+		GetFn: func(ctx context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+			return &ps.DeployRequest{
+				Number: 10,
+				Deployment: &ps.Deployment{
+					State:             "error",
+					DeployCheckErrors: "incompatible unique index",
+				},
+			}, nil
+		},
+		UnblockFn: func(ctx context.Context, req *ps.UnblockDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Fatal("UnblockDeploy should not be called")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{DeployRequests: svc}, nil
+		},
+	}
+
+	cmd := UnblockCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "10"})
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, ".*failed deploy checks.*incompatible unique index")
+	c.Assert(svc.UnblockFnInvoked, qt.IsFalse)
+}

--- a/internal/mock/dr.go
+++ b/internal/mock/dr.go
@@ -13,6 +13,9 @@ type DeployRequestsService struct {
 	ForceCutoverFn        func(context.Context, *ps.ForceCutoverDeployRequestRequest) (*ps.DeployRequest, error)
 	ForceCutoverFnInvoked bool
 
+	UnblockFn        func(context.Context, *ps.UnblockDeployRequestRequest) (*ps.DeployRequest, error)
+	UnblockFnInvoked bool
+
 	AutoApplyFn        func(context.Context, *ps.AutoApplyDeployRequestRequest) (*ps.DeployRequest, error)
 	AutoApplyFnInvoked bool
 
@@ -79,6 +82,11 @@ func (d *DeployRequestsService) ApplyDeploy(ctx context.Context, req *ps.ApplyDe
 func (d *DeployRequestsService) ForceCutover(ctx context.Context, req *ps.ForceCutoverDeployRequestRequest) (*ps.DeployRequest, error) {
 	d.ForceCutoverFnInvoked = true
 	return d.ForceCutoverFn(ctx, req)
+}
+
+func (d *DeployRequestsService) UnblockDeploy(ctx context.Context, req *ps.UnblockDeployRequestRequest) (*ps.DeployRequest, error) {
+	d.UnblockFnInvoked = true
+	return d.UnblockFn(ctx, req)
 }
 
 func (d *DeployRequestsService) AutoApplyDeploy(ctx context.Context, req *ps.AutoApplyDeployRequestRequest) (*ps.DeployRequest, error) {

--- a/internal/planetscale/deploy_requests.go
+++ b/internal/planetscale/deploy_requests.go
@@ -38,6 +38,7 @@ type DeployRequestsService interface {
 	UpdateThrottler(context.Context, *UpdateDeployRequestThrottlerRequest) (*DeployRequestThrottler, error)
 	SkipRevertDeploy(context.Context, *SkipRevertDeployRequestRequest) (*DeployRequest, error)
 	RevertDeploy(context.Context, *RevertDeployRequestRequest) (*DeployRequest, error)
+	UnblockDeploy(context.Context, *UnblockDeployRequestRequest) (*DeployRequest, error)
 }
 
 // DeployRequestReview posts a review to a deploy request.
@@ -290,6 +291,14 @@ type ForceCutoverDeployRequestRequest struct {
 	Number       uint64 `json:"-"`
 }
 
+// UnblockDeployRequestRequest unblocks the deploy queue after a failed deploy
+// or revert (complete_error / complete_revert_error).
+type UnblockDeployRequestRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Number       uint64 `json:"-"`
+}
+
 type AutoApplyDeployRequestRequest struct {
 	Organization string `json:"-"`
 	Database     string `json:"-"`
@@ -478,6 +487,22 @@ func (d *deployRequestsService) ApplyDeploy(ctx context.Context, applyReq *Apply
 func (d *deployRequestsService) ForceCutover(ctx context.Context, forceReq *ForceCutoverDeployRequestRequest) (*DeployRequest, error) {
 	path := deployRequestActionAPIPath(forceReq.Organization, forceReq.Database, forceReq.Number, "force-cutover")
 	req, err := d.client.newRequest(http.MethodPost, path, forceReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	drr := &DeployRequest{}
+	if err := d.client.do(ctx, req, &drr); err != nil {
+		return nil, err
+	}
+
+	return drr, nil
+}
+
+// UnblockDeploy marks a failed deploy or revert complete so the queue can proceed.
+func (d *deployRequestsService) UnblockDeploy(ctx context.Context, unblockReq *UnblockDeployRequestRequest) (*DeployRequest, error) {
+	path := deployRequestActionAPIPath(unblockReq.Organization, unblockReq.Database, unblockReq.Number, "complete-deploy")
+	req, err := d.client.newRequest(http.MethodPost, path, unblockReq)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/internal/planetscale/deploy_requests_test.go
+++ b/internal/planetscale/deploy_requests_test.go
@@ -240,6 +240,45 @@ func TestDeployRequests_CancelDeploy(t *testing.T) {
 	c.Assert(dr, qt.DeepEquals, want)
 }
 
+func TestDeployRequests_UnblockDeploy(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/test-organization/databases/test-database/deploy-requests/1337/complete-deploy")
+		w.WriteHeader(200)
+		out := `{"id": "test-deploy-request-id", "branch": "development", "into_branch": "some-branch", "notes": "", "created_at": "2021-01-14T10:19:23.000Z", "updated_at": "2021-01-14T10:19:23.000Z", "closed_at": null, "deployment": { "state": "complete" }, "number": 1337}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	dr, err := client.DeployRequests.UnblockDeploy(context.Background(), &UnblockDeployRequestRequest{
+		Organization: "test-organization",
+		Database:     "test-database",
+		Number:       1337,
+	})
+
+	testTime := time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC)
+	want := &DeployRequest{
+		ID:     "test-deploy-request-id",
+		Branch: "development",
+		Deployment: &Deployment{
+			State: "complete",
+		},
+		IntoBranch: "some-branch",
+		Number:     1337,
+		Notes:      "",
+		CreatedAt:  testTime,
+		UpdatedAt:  testTime,
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dr, qt.DeepEquals, want)
+}
+
 func TestDeployRequests_ForceCutover(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
When a Vitess deploy or revert fails, PlanetScale blocks the queue as a precaution. The dashboard button is “Unblock deploy queue”; this adds the same action to the CLI.

```bash
pscale deploy-request unblock mydb 12 --org myorg
```

Notes:
- Calls `POST …/complete-deploy` only when the deployment is in `complete_error` or `complete_revert_error`.
- Gated cutover (`pending_cutover`) is pointed at `deploy-request apply`. Deploy-check failures (`error`) are rejected — they are not an unblockable queue.