### PR TITLE
Add pscale role default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,6 +349,10 @@ pscale branch parameters list <database> <branch> --org <org> --format json --na
 # Extensions available on the cluster image (not CREATE EXTENSION state)
 pscale branch extensions list <database> <branch> --org <org> --format json
 
+# Default postgres role (read-only; reset-default rotates the password)
+pscale role default <database> <branch> --org <org> --format json
+pscale role reset-default <database> <branch> --org <org> --format json --force
+
 # Change parameters (repeat --parameters; keys are namespace.name)
 pscale branch resize <database> <branch> --org <org> --format json --parameters pgconf.max_connections=200
 

--- a/internal/cmd/role/default.go
+++ b/internal/cmd/role/default.go
@@ -1,0 +1,60 @@
+package role
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func DefaultCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "default <database> <branch>",
+		Short: "Show the default postgres role",
+		Long: `Show the default postgres role for a branch.
+
+This does not rotate credentials. Use 'pscale role reset-default' to issue a
+new password for the default role.`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			branch := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching default role for %s/%s...",
+				printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			role, err := client.PostgresRoles.GetDefaultRole(ctx, &ps.GetDefaultPostgresRoleRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err,
+						"read_branch",
+						"database %s or branch %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(branch), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toPostgresRole(role))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/role/default_test.go
+++ b/internal/cmd/role/default_test.go
@@ -1,0 +1,51 @@
+package role
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestRole_DefaultCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.PostgresRolesService{
+		GetDefaultRoleFn: func(ctx context.Context, req *ps.GetDefaultPostgresRoleRequest) (*ps.PostgresRole, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.Branch, qt.Equals, "main")
+			return &ps.PostgresRole{
+				ID:       "role-id",
+				Name:     "postgres",
+				Username: "postgres",
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{PostgresRoles: svc}, nil
+		},
+	}
+
+	cmd := DefaultCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetDefaultRoleFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"username": "postgres"`)
+}

--- a/internal/cmd/role/role.go
+++ b/internal/cmd/role/role.go
@@ -20,6 +20,7 @@ func RoleCmd(ch *cmdutil.Helper) *cobra.Command {
 		CreateCmd(ch),
 		DeleteCmd(ch),
 		GetCmd(ch),
+		DefaultCmd(ch),
 		ListCmd(ch),
 		ReassignCmd(ch),
 		RenewCmd(ch),

--- a/internal/mock/postgres_roles.go
+++ b/internal/mock/postgres_roles.go
@@ -21,6 +21,8 @@ type PostgresRolesService struct {
 	DeleteFnInvoked           bool
 	ResetDefaultRoleFn        func(context.Context, *ps.ResetDefaultRoleRequest) (*ps.PostgresRole, error)
 	ResetDefaultRoleFnInvoked bool
+	GetDefaultRoleFn          func(context.Context, *ps.GetDefaultPostgresRoleRequest) (*ps.PostgresRole, error)
+	GetDefaultRoleFnInvoked   bool
 	ResetPasswordFn           func(context.Context, *ps.ResetPostgresRolePasswordRequest) (*ps.PostgresRole, error)
 	ResetPasswordFnInvoked    bool
 	ReassignObjectsFn         func(context.Context, *ps.ReassignPostgresRoleObjectsRequest) error
@@ -60,6 +62,11 @@ func (s *PostgresRolesService) Delete(ctx context.Context, req *ps.DeletePostgre
 func (s *PostgresRolesService) ResetDefaultRole(ctx context.Context, req *ps.ResetDefaultRoleRequest) (*ps.PostgresRole, error) {
 	s.ResetDefaultRoleFnInvoked = true
 	return s.ResetDefaultRoleFn(ctx, req)
+}
+
+func (s *PostgresRolesService) GetDefaultRole(ctx context.Context, req *ps.GetDefaultPostgresRoleRequest) (*ps.PostgresRole, error) {
+	s.GetDefaultRoleFnInvoked = true
+	return s.GetDefaultRoleFn(ctx, req)
 }
 
 func (s *PostgresRolesService) ResetPassword(ctx context.Context, req *ps.ResetPostgresRolePasswordRequest) (*ps.PostgresRole, error) {

--- a/internal/planetscale/postgres_roles.go
+++ b/internal/planetscale/postgres_roles.go
@@ -84,6 +84,13 @@ type ResetDefaultRoleRequest struct {
 	Branch       string `json:"-"`
 }
 
+// GetDefaultPostgresRoleRequest encapsulates fetching the default postgres role.
+type GetDefaultPostgresRoleRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+}
+
 // ResetPostgresRolePasswordRequest encapsulates the request for resetting a role's password for a database branch.
 type ResetPostgresRolePasswordRequest struct {
 	Organization string `json:"-"`
@@ -110,6 +117,7 @@ type PostgresRolesService interface {
 	Renew(context.Context, *RenewPostgresRoleRequest) (*PostgresRole, error)
 	Delete(context.Context, *DeletePostgresRoleRequest) error
 	ResetDefaultRole(context.Context, *ResetDefaultRoleRequest) (*PostgresRole, error)
+	GetDefaultRole(context.Context, *GetDefaultPostgresRoleRequest) (*PostgresRole, error)
 	ResetPassword(context.Context, *ResetPostgresRolePasswordRequest) (*PostgresRole, error)
 	ReassignObjects(context.Context, *ReassignPostgresRoleObjectsRequest) error
 }
@@ -130,6 +138,22 @@ func NewPostgresRolesService(client *Client) *postgresRolesService {
 func (p *postgresRolesService) ResetDefaultRole(ctx context.Context, resetReq *ResetDefaultRoleRequest) (*PostgresRole, error) {
 	pathStr := path.Join(postgresBranchRolesAPIPath(resetReq.Organization, resetReq.Database, resetReq.Branch), "reset-default")
 	req, err := p.client.newRequest(http.MethodPost, pathStr, resetReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	role := &PostgresRole{}
+	if err := p.client.do(ctx, req, &role); err != nil {
+		return nil, err
+	}
+
+	return role, nil
+}
+
+// GetDefaultRole returns the default postgres role for a branch without rotating credentials.
+func (p *postgresRolesService) GetDefaultRole(ctx context.Context, getReq *GetDefaultPostgresRoleRequest) (*PostgresRole, error) {
+	pathStr := path.Join(postgresBranchRolesAPIPath(getReq.Organization, getReq.Database, getReq.Branch), "default")
+	req, err := p.client.newRequest(http.MethodGet, pathStr, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/internal/planetscale/postgres_roles_test.go
+++ b/internal/planetscale/postgres_roles_test.go
@@ -64,6 +64,39 @@ func TestResetDefaultRole(t *testing.T) {
 	c.Assert(role, qt.DeepEquals, want)
 }
 
+func TestGetDefaultRole(t *testing.T) {
+	c := qt.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, "GET")
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/roles/default")
+		w.WriteHeader(200)
+		out := `{
+			"id": "role-id",
+			"name": "postgres",
+			"access_host_url": "pg.psdb.cloud",
+			"database_name": "postgres",
+			"username": "postgres",
+			"created_at": "2025-07-15T10:19:23.000Z"
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+	t.Cleanup(ts.Close)
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	role, err := client.PostgresRoles.GetDefaultRole(context.Background(), &GetDefaultPostgresRoleRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "my-branch",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(role.ID, qt.Equals, "role-id")
+	c.Assert(role.Username, qt.Equals, "postgres")
+	c.Assert(role.Password, qt.Equals, "")
+}
+
 func TestPostgresRoles_List(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Show the default postgres role without rotating credentials. `reset-default` still issues a new password.

```bash
pscale role default mydb main --org myorg
```