### PR TITLE
fix: properly return final state for wait commands

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -162,7 +162,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 						Database:     source,
 						Branch:       branch,
 					}
-					if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+					dbBranch, err = waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq)
+					if err != nil {
 						return err
 					}
 					end()
@@ -226,7 +227,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 						Database:     source,
 						Branch:       branch,
 					}
-					if err := waitUntilPostgresReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+					dbBranch, err = waitUntilPostgresReady(ctx, client, ch.Printer, ch.Debug(), getReq)
+					if err != nil {
 						return err
 					}
 					end()
@@ -272,7 +274,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 // waitUntilReady waits until the given database branch is ready. It times out after 10 minutes.
-func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetDatabaseBranchRequest) error {
+func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
@@ -286,7 +288,7 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("branch creation timed out")
+			return nil, errors.New("branch creation timed out")
 		case <-ticker.C:
 			resp, err := client.DatabaseBranches.Get(ctx, getReq)
 			if err != nil {
@@ -297,7 +299,7 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 			}
 
 			if resp.Ready {
-				return nil
+				return resp, nil
 			}
 
 			elapsed := time.Since(startTime)
@@ -310,7 +312,7 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 	}
 }
 
-func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetPostgresBranchRequest) error {
+func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
@@ -324,7 +326,7 @@ func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *pri
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("branch creation timed out")
+			return nil, errors.New("branch creation timed out")
 		case <-ticker.C:
 			resp, err := client.PostgresBranches.Get(ctx, getReq)
 			if err != nil {
@@ -335,7 +337,7 @@ func waitUntilPostgresReady(ctx context.Context, client *ps.Client, printer *pri
 			}
 
 			if resp.Ready {
-				return nil
+				return resp, nil
 			}
 
 			elapsed := time.Since(startTime)

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -70,6 +70,118 @@ func TestBranch_CreateCmd(t *testing.T) {
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
 
+func TestBranch_CreateCmdWithWaitPrintsReadyBranch(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	pending := &ps.DatabaseBranch{Name: branch, Ready: false}
+	ready := &ps.DatabaseBranch{Name: branch, Ready: true}
+
+	branchSvc := &mock.DatabaseBranchesService{
+		CreateFn: func(_ context.Context, _ *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			return pending, nil
+		},
+		GetFn: func(_ context.Context, req *ps.GetDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			c.Assert(req, qt.DeepEquals, &ps.GetDatabaseBranchRequest{
+				Organization: org,
+				Database:     db,
+				Branch:       branch,
+			})
+			return ready, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(_ context.Context, _ *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: ps.DatabaseEngineMySQL}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:        dbSvc,
+				DatabaseBranches: branchSvc,
+			}, nil
+		},
+	}
+	debug := false
+	ch.SetDebug(&debug)
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(branchSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, ready)
+}
+
+func TestBranch_CreatePostgresCmdWithWaitPrintsReadyBranch(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	pending := &ps.PostgresBranch{Name: branch, Kind: "postgresql", Ready: false}
+	ready := &ps.PostgresBranch{Name: branch, Kind: "postgresql", Ready: true}
+
+	branchSvc := &mock.PostgresBranchesService{
+		CreateFn: func(_ context.Context, _ *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+			return pending, nil
+		},
+		GetFn: func(_ context.Context, req *ps.GetPostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req, qt.DeepEquals, &ps.GetPostgresBranchRequest{
+				Organization: org,
+				Database:     db,
+				Branch:       branch,
+			})
+			return ready, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(_ context.Context, _ *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: ps.DatabaseEnginePostgres}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:        dbSvc,
+				PostgresBranches: branchSvc,
+			}, nil
+		},
+	}
+	debug := false
+	ch.SetDebug(&debug)
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(branchSvc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, ready)
+}
+
 func TestBranch_CreateCmdWithRestore(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/cmd/branch/switch.go
+++ b/internal/cmd/branch/switch.go
@@ -80,7 +80,7 @@ func SwitchCmd(ch *cmdutil.Helper) *cobra.Command {
 						Database:     ch.Config.Database,
 						Branch:       branch,
 					}
-					if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+					if _, err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
 						return err
 					}
 					end()

--- a/internal/cmd/database/create.go
+++ b/internal/cmd/database/create.go
@@ -107,7 +107,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 					Organization: ch.Config.Organization,
 					Database:     database.Name,
 				}
-				if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+				database, err = waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq)
+				if err != nil {
 					return err
 				}
 				end()
@@ -215,7 +216,7 @@ func parseDatabaseEngine(engine string) (ps.DatabaseEngine, error) {
 	}
 }
 
-func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetDatabaseRequest) error {
+func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Printer, debug bool, getReq *ps.GetDatabaseRequest) (*ps.Database, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
@@ -229,7 +230,7 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("database creation timed out")
+			return nil, errors.New("database creation timed out")
 		case <-ticker.C:
 			resp, err := client.Databases.Get(ctx, getReq)
 			if err != nil {
@@ -239,8 +240,8 @@ func waitUntilReady(ctx context.Context, client *ps.Client, printer *printer.Pri
 				continue
 			}
 
-			if resp.State == "ready" {
-				return nil
+			if resp.State == ps.DatabaseReady {
+				return resp, nil
 			}
 
 			elapsed := time.Since(startTime)

--- a/internal/cmd/database/create_test.go
+++ b/internal/cmd/database/create_test.go
@@ -68,6 +68,57 @@ func TestDatabase_CreateCmd(t *testing.T) {
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
 
+func TestDatabase_CreateCmdWithWaitPrintsReadyDatabase(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	pending := &ps.Database{Name: db, State: ps.DatabasePending}
+	ready := &ps.Database{Name: db, State: ps.DatabaseReady}
+
+	svc := &mock.DatabaseService{
+		CreateFn: func(_ context.Context, _ *ps.CreateDatabaseRequest) (*ps.Database, error) {
+			return pending, nil
+		},
+		GetFn: func(_ context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req, qt.DeepEquals, &ps.GetDatabaseRequest{
+				Organization: org,
+				Database:     db,
+			})
+			return ready, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases: svc,
+				Organizations: &mock.OrganizationsService{
+					GetFn: func(_ context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {
+						return &ps.Organization{RemainingFreeDatabases: 1, Name: req.Organization}, nil
+					},
+				},
+			}, nil
+		},
+	}
+	debug := false
+	ch.SetDebug(&debug)
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, "--region", "us-east", "--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, ready)
+}
+
 func TestDatabase_CreateCmdWithReplicasZero(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/cmd/deployrequest/deploy.go
+++ b/internal/cmd/deployrequest/deploy.go
@@ -84,13 +84,13 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 					Database:     database,
 					Number:       number,
 				}
-				state, err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq)
+				dr, err = waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq)
 				if err != nil {
 					return err
 				}
 				end()
 
-				switch state {
+				switch dr.Deployment.State {
 				case "complete_pending_revert":
 					ch.Printer.Printf("Deploy request %s/%s is successfully deployed and revertable. You can skip the revert to unblock the deploy queue.\n\n",
 						printer.BoldBlue(database), printer.BoldBlue(number))
@@ -124,7 +124,7 @@ func DeployCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 // waitUntilReady waits until the given deploy request has been deployed. It times out after 5 minutes.
-func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *printer.Printer, debug bool, getReq *planetscale.GetDeployRequestRequest) (string, error) {
+func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *printer.Printer, debug bool, getReq *planetscale.GetDeployRequestRequest) (*planetscale.DeployRequest, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
@@ -133,7 +133,7 @@ func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *pr
 	for {
 		select {
 		case <-ctx.Done():
-			return "", errors.New("deploy request queueing timed out")
+			return nil, errors.New("deploy request queueing timed out")
 		case <-ticker.C:
 			resp, err := client.DeployRequests.Get(ctx, getReq)
 			if err != nil {
@@ -144,7 +144,7 @@ func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *pr
 			}
 
 			if resp.Deployment.State == "complete" || resp.Deployment.State == "complete_pending_revert" || resp.Deployment.State == "pending_cutover" {
-				return resp.Deployment.State, nil
+				return resp, nil
 			}
 		}
 	}

--- a/internal/cmd/deployrequest/deploy_test.go
+++ b/internal/cmd/deployrequest/deploy_test.go
@@ -60,6 +60,58 @@ func TestDeployRequest_DeployCmd(t *testing.T) {
 	c.Assert(buf.String(), qt.JSONEquals, res)
 }
 
+func TestDeployRequest_DeployCmdWithWaitPrintsFinalDeployRequest(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	number := uint64(10)
+	pending := &ps.DeployRequest{
+		Number:     number,
+		Deployment: &ps.Deployment{State: "pending"},
+	}
+	complete := &ps.DeployRequest{
+		Number:     number,
+		Deployment: &ps.Deployment{State: "complete"},
+	}
+
+	svc := &mock.DeployRequestsService{
+		DeployFn: func(_ context.Context, _ *ps.PerformDeployRequest) (*ps.DeployRequest, error) {
+			return pending, nil
+		},
+		GetFn: func(_ context.Context, req *ps.GetDeployRequestRequest) (*ps.DeployRequest, error) {
+			c.Assert(req, qt.DeepEquals, &ps.GetDeployRequestRequest{
+				Organization: org,
+				Database:     db,
+				Number:       number,
+			})
+			return complete, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{DeployRequests: svc}, nil
+		},
+	}
+	debug := false
+	ch.SetDebug(&debug)
+
+	cmd := DeployCmd(ch)
+	cmd.SetArgs([]string{db, strconv.FormatUint(number, 10), "--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, complete)
+}
+
 func TestDeployRequest_DeployBranchName(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/cmd/keyspace/create.go
+++ b/internal/cmd/keyspace/create.go
@@ -68,7 +68,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 					Branch:       branch,
 					Keyspace:     keyspace,
 				}
-				if err := waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq); err != nil {
+				k, err = waitUntilReady(ctx, client, ch.Printer, ch.Debug(), getReq)
+				if err != nil {
 					return err
 				}
 				end()
@@ -96,7 +97,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	return cmd
 }
 
-func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *printer.Printer, debug bool, getReq *planetscale.GetKeyspaceRequest) error {
+func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *printer.Printer, debug bool, getReq *planetscale.GetKeyspaceRequest) (*planetscale.Keyspace, error) {
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancel()
 
@@ -105,7 +106,7 @@ func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *pr
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.New("keyspace creation timed out")
+			return nil, errors.New("keyspace creation timed out")
 		case <-ticker.C:
 			resp, err := client.Keyspaces.Get(ctx, getReq)
 			if err != nil {
@@ -116,7 +117,7 @@ func waitUntilReady(ctx context.Context, client *planetscale.Client, printer *pr
 			}
 
 			if resp.Ready {
-				return nil
+				return resp, nil
 			}
 		}
 	}

--- a/internal/cmd/keyspace/create_test.go
+++ b/internal/cmd/keyspace/create_test.go
@@ -69,6 +69,54 @@ func TestKeyspace_CreateCmd(t *testing.T) {
 	c.Assert(buf.String(), qt.JSONEquals, ks)
 }
 
+func TestKeyspace_CreateCmdWithWaitPrintsReadyKeyspace(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+	keyspace := "sharded"
+	pending := &ps.Keyspace{Name: keyspace, Ready: false}
+	ready := &ps.Keyspace{Name: keyspace, Ready: true}
+
+	svc := &mock.KeyspacesService{
+		CreateFn: func(_ context.Context, _ *ps.CreateKeyspaceRequest) (*ps.Keyspace, error) {
+			return pending, nil
+		},
+		GetFn: func(_ context.Context, req *ps.GetKeyspaceRequest) (*ps.Keyspace, error) {
+			c.Assert(req, qt.DeepEquals, &ps.GetKeyspaceRequest{
+				Organization: org,
+				Database:     db,
+				Branch:       branch,
+				Keyspace:     keyspace,
+			})
+			return ready, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Keyspaces: svc}, nil
+		},
+	}
+	debug := false
+	ch.SetDebug(&debug)
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, keyspace, "--cluster-size", "PS-20", "--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, ready)
+}
+
 func TestKeyspace_CreateCmdOnlyClusterSize(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
  Behavior changes:

  - branch create --wait now prints the final MySQL or PostgreSQL branch.
  - database create --wait now prints the final ready database.
  - keyspace create --wait now prints the final ready keyspace.
  - deploy-request deploy --wait now prints the final deploy request.
  - branch switch --wait ignores the returned branch because it does not print a resource.
  - Poll intervals and timeouts remain unchanged.

  Tests added:

  - MySQL branch creation
  - PostgreSQL branch creation
  - Database creation
  - Keyspace creation
  - Deploy-request deployment

  Validation:

  - Focused tests passed.
  - go vet passed.
  - All four paths passed live tests in benchmarks.
  - Test resources were deleted.