### PR TITLE
Add `branch maintenance run` command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,25 @@ pscale branch switchover <database> <branch> --org <org> --format json --candida
 - A switchover that ends in `failed` has an unconfirmed outcome: the primary may still have moved and nothing is rolled back. Check the current primary with `pscale branch infra <database> <branch> --org <org> --format json` before retrying.
 - `--candidate` is rejected for branches without replicas. Poll status with `pscale api organizations/<org>/databases/<database>/branches/<branch>/switchovers/<id>`.
 
+## Postgres branch maintenance
+
+`pscale branch maintenance run` upgrades a Postgres branch to the latest cluster image. This is how regular version bumps, bugfixes, and quality-of-life improvements reach a branch; PlanetScale otherwise upgrades images only in emergencies, such as patching security issues.
+
+```bash
+# Run maintenance now
+pscale branch maintenance run <database> <branch> --org <org> --format json
+
+# Also upgrade to the latest PostgreSQL minor version
+pscale branch maintenance run <database> <branch> --org <org> --format json --update-postgres-minor-version
+```
+
+- The upgrade is applied to the replicas first, followed by a switchover from the old primary to an upgraded replica. That failover leads to a short period of database unavailability (seconds) and terminates all direct connections. A branch running a single instance has no replica to switch over to and is unavailable until it comes back. Warn the user before running this.
+- The command returns `{"result": "maintenance started", "branch": "<branch>"}` and exits; it does not wait. Check progress with `pscale branch infra <database> <branch> --org <org> --format json`.
+- Rejected while a change request from `pscale branch resize` is still in progress — check `pscale branch resize status` first.
+- `--update-postgres-minor-version` is rejected when the branch is already on the latest minor version or the upgrade is unavailable for it.
+- Postgres only; Vitess/MySQL databases are rejected before any API call.
+- See https://planetscale.com/docs/postgres/operations-philosophy
+
 ## Imports (Cloudflare D1)
 
 `pscale import d1` migrates a Cloudflare D1 (SQLite) export into a PlanetScale Postgres branch. Every subcommand supports `--format json` and returns `status`, `issues`, and `next_steps`; stateful steps return a `migration_id` — pass it back with `--migration-id` to resume.

--- a/internal/cmd/branch/branch.go
+++ b/internal/cmd/branch/branch.go
@@ -46,6 +46,7 @@ func BranchCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(vtctld.VtctldCmd(ch))
 	cmd.AddCommand(InfraCmd(ch))
 	cmd.AddCommand(SwitchoverCmd(ch))
+	cmd.AddCommand(MaintenanceCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/branch/maintenance.go
+++ b/internal/cmd/branch/maintenance.go
@@ -1,0 +1,114 @@
+package branch
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+// MaintenanceCmd groups the maintenance commands for a Postgres branch.
+func MaintenanceCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "maintenance <command>",
+		Short: "Run maintenance for a Postgres branch",
+		Long: `Manage maintenance for a Postgres branch.
+
+PlanetScale upgrades a branch's image in emergencies, such as patching security
+issues, or when you initiate the upgrade yourself. 'maintenance run' initiates
+one.
+
+See https://planetscale.com/docs/postgres/operations-philosophy`,
+	}
+
+	cmd.AddCommand(MaintenanceRunCmd(ch))
+
+	return cmd
+}
+
+// MaintenanceRunCmd starts a maintenance run for a Postgres branch.
+func MaintenanceRunCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		updatePostgresMinorVersion bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "run <database> <branch>",
+		Short: "Run maintenance for a Postgres branch now (Postgres only)",
+		Long: `Run maintenance for a Postgres branch, updating it to the latest available
+image. Postgres only.
+
+This is how regular version bumps, bugfixes, and quality-of-life improvements
+reach a branch. PlanetScale otherwise upgrades images only in emergencies, such
+as patching security issues.
+
+The upgrade is applied to the replicas first, followed by a switchover from the
+old primary to an upgraded replica. That failover leads to a short period of
+database unavailability (seconds), and all direct connections are terminated, so
+your application should have retry logic. A branch running a single instance has
+no replica to switch over to and is unavailable until it comes back.
+
+Pass --update-postgres-minor-version to also upgrade the branch to the latest
+PostgreSQL minor version during the run.
+
+Maintenance cannot start while a change request (see 'branch resize') is still
+in progress.
+
+See https://planetscale.com/docs/postgres/operations-philosophy`,
+		Args: cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "Maintenance runs"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Starting maintenance for branch %s in %s...",
+				printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+
+			err = client.BranchMaintenance.Run(ctx, &ps.RunBranchMaintenanceRequest{
+				Organization:               ch.Config.Organization,
+				Database:                   database,
+				Branch:                     branch,
+				UpdatePostgresMinorVersion: flags.updatePostgresMinorVersion,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return cmdutil.HandleNotFoundWithServiceTokenCheck(
+						ctx, cmd, ch.Config, ch.Client, err, "write_database",
+						"branch %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Maintenance for branch %s in %s was started.\n",
+					printer.BoldBlue(branch), printer.BoldBlue(database))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "maintenance started",
+				"branch": branch,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&flags.updatePostgresMinorVersion, "update-postgres-minor-version", false,
+		"Upgrade the branch to the latest PostgreSQL minor version during maintenance")
+
+	return cmd
+}

--- a/internal/cmd/branch/maintenance_test.go
+++ b/internal/cmd/branch/maintenance_test.go
@@ -1,0 +1,148 @@
+package branch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestBranch_MaintenanceRunCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "main"
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: db, Kind: ps.DatabaseEnginePostgres}, nil
+		},
+	}
+	svc := &mock.BranchMaintenanceService{
+		RunFn: func(ctx context.Context, req *ps.RunBranchMaintenanceRequest) error {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.UpdatePostgresMinorVersion, qt.IsFalse)
+
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:         dbSvc,
+				BranchMaintenance: svc,
+			}, nil
+		},
+	}
+
+	cmd := MaintenanceRunCmd(ch)
+	cmd.SetArgs([]string{db, branch})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.RunFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]string{
+		"result": "maintenance started",
+		"branch": branch,
+	})
+}
+
+func TestBranch_MaintenanceRunCmd_UpdateMinorVersion(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: req.Database, Kind: ps.DatabaseEnginePostgres}, nil
+		},
+	}
+	svc := &mock.BranchMaintenanceService{
+		RunFn: func(ctx context.Context, req *ps.RunBranchMaintenanceRequest) error {
+			c.Assert(req.UpdatePostgresMinorVersion, qt.IsTrue)
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: "planetscale",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:         dbSvc,
+				BranchMaintenance: svc,
+			}, nil
+		},
+	}
+
+	cmd := MaintenanceRunCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "main", "--update-postgres-minor-version"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.RunFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_MaintenanceRunCmd_VitessDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: req.Database, Kind: ps.DatabaseEngineMySQL}, nil
+		},
+	}
+	svc := &mock.BranchMaintenanceService{
+		RunFn: func(ctx context.Context, req *ps.RunBranchMaintenanceRequest) error {
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: "planetscale",
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:         dbSvc,
+				BranchMaintenance: svc,
+			}, nil
+		},
+	}
+
+	cmd := MaintenanceRunCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "main"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*only available for PostgreSQL.*mysql.*`)
+	c.Assert(svc.RunFnInvoked, qt.IsFalse)
+}

--- a/internal/mock/branch_maintenance.go
+++ b/internal/mock/branch_maintenance.go
@@ -1,0 +1,17 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+type BranchMaintenanceService struct {
+	RunFn        func(context.Context, *ps.RunBranchMaintenanceRequest) error
+	RunFnInvoked bool
+}
+
+func (s *BranchMaintenanceService) Run(ctx context.Context, req *ps.RunBranchMaintenanceRequest) error {
+	s.RunFnInvoked = true
+	return s.RunFn(ctx, req)
+}

--- a/internal/planetscale/branch_maintenance.go
+++ b/internal/planetscale/branch_maintenance.go
@@ -1,0 +1,47 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+)
+
+// RunBranchMaintenanceRequest encapsulates the request for running maintenance
+// on a branch.
+type RunBranchMaintenanceRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+
+	// UpdatePostgresMinorVersion upgrades the branch to the latest PostgreSQL
+	// minor version as part of the maintenance run.
+	UpdatePostgresMinorVersion bool `json:"update_postgres_minor_version,omitempty"`
+}
+
+// BranchMaintenanceService is an interface for communicating with the
+// PlanetScale branch maintenance API endpoint.
+type BranchMaintenanceService interface {
+	Run(context.Context, *RunBranchMaintenanceRequest) error
+}
+
+type branchMaintenanceService struct {
+	client *Client
+}
+
+var _ BranchMaintenanceService = &branchMaintenanceService{}
+
+// Run starts a maintenance run for the given branch.
+func (s *branchMaintenanceService) Run(ctx context.Context, runReq *RunBranchMaintenanceRequest) error {
+	req, err := s.client.newRequest(http.MethodPost,
+		branchMaintenanceAPIPath(runReq.Organization, runReq.Database, runReq.Branch), runReq)
+	if err != nil {
+		return fmt.Errorf("error creating request for run branch maintenance: %w", err)
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+func branchMaintenanceAPIPath(org, db, branch string) string {
+	return path.Join(databasesAPIPath(org), db, "branches", branch, "maintenance")
+}

--- a/internal/planetscale/branch_maintenance_test.go
+++ b/internal/planetscale/branch_maintenance_test.go
@@ -1,0 +1,92 @@
+package planetscale
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBranchMaintenance_Run(t *testing.T) {
+	c := qt.New(t)
+
+	wantURL := "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/planetscale-go-test-db-branch/maintenance"
+
+	var gotBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.String(), qt.DeepEquals, wantURL)
+
+		body, err := io.ReadAll(r.Body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(json.Unmarshal(body, &gotBody), qt.IsNil)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	err = client.BranchMaintenance.Run(ctx, &RunBranchMaintenanceRequest{
+		Organization:               testOrg,
+		Database:                   testDatabase,
+		Branch:                     testBranch,
+		UpdatePostgresMinorVersion: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotBody, qt.DeepEquals, map[string]interface{}{"update_postgres_minor_version": true})
+}
+
+func TestBranchMaintenance_Run_OmitsMinorVersionByDefault(t *testing.T) {
+	c := qt.New(t)
+
+	var gotBody map[string]interface{}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(json.Unmarshal(body, &gotBody), qt.IsNil)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.BranchMaintenance.Run(context.Background(), &RunBranchMaintenanceRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       testBranch,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotBody, qt.HasLen, 0)
+}
+
+func TestBranchMaintenance_Run_Unprocessable(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		out := `{"code":"unprocessable","message":"Maintenance cannot run while a resize is in progress."}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.BranchMaintenance.Run(context.Background(), &RunBranchMaintenanceRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       testBranch,
+	})
+	c.Assert(err, qt.ErrorMatches, ".*Maintenance cannot run while a resize is in progress.*")
+}

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -54,6 +54,7 @@ type Client struct {
 	BackupPolicies        BackupPoliciesService
 	Backups               BackupsService
 	BranchInfrastructure  BranchInfrastructureService
+	BranchMaintenance     BranchMaintenanceService
 	D1ImportNotifications D1ImportNotificationsService
 	DatabaseBranches      DatabaseBranchesService
 	Databases             DatabasesService
@@ -330,6 +331,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.BackupPolicies = &backupPoliciesService{client: c}
 	c.Backups = &backupsService{client: c}
 	c.BranchInfrastructure = &branchInfrastructureService{client: c}
+	c.BranchMaintenance = &branchMaintenanceService{client: c}
 	c.D1ImportNotifications = &d1ImportNotificationsService{client: c}
 	c.DatabaseBranches = &databaseBranchesService{client: c}
 	c.Databases = &databasesService{client: c}


### PR DESCRIPTION
`branch maintenance run` allows triggering maintenance for a Postgres branch, optionally upgrading to the latest available Postgres minor image for that branch.

https://planetscale.com/docs/postgres/operations-philosophy documents how this works.