### PR TITLE
Quote D1 verify identifiers and keep dump files in outdir

### DIFF
--- a/internal/dumper/csv_writer.go
+++ b/internal/dumper/csv_writer.go
@@ -60,8 +60,11 @@ func (w *csvWriter) ShouldFlush() bool {
 }
 
 func (w *csvWriter) Flush(outdir, database, table string, fileNo int) error {
-	file := fmt.Sprintf("%s/%s.%s.%05d.csv", outdir, database, table, fileNo)
-	err := writeFile(file, w.csvBuffer.String())
+	file, err := dumpOutputPath(outdir, database, table, fmt.Sprintf(".%05d.csv", fileNo))
+	if err != nil {
+		return err
+	}
+	err = writeFile(file, w.csvBuffer.String())
 	if err != nil {
 		return err
 	}

--- a/internal/dumper/dumper.go
+++ b/internal/dumper/dumper.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/printer"
@@ -256,10 +258,12 @@ func (d *Dumper) dumpTableSchema(conn *Connection, database string, table string
 
 	schema := qr.Rows[0][1].String() + ";\n"
 
-	file := fmt.Sprintf("%s/%s.%s-schema.sql", d.cfg.Outdir, database, table)
+	file, err := dumpOutputPath(d.cfg.Outdir, database, table, "-schema.sql")
 	if _, ok := views[table]; ok {
-		// https://github.com/mydumper/mydumper/blob/e55612616d17281a45eed0a60a9b054cdd1fe064/src/myloader_common.c#L374
-		file = fmt.Sprintf("%s/%s.%s-schema-view.sql", d.cfg.Outdir, database, table)
+		file, err = dumpOutputPath(d.cfg.Outdir, database, table, "-schema-view.sql")
+	}
+	if err != nil {
+		return err
 	}
 
 	err = writeFile(file, schema)
@@ -513,6 +517,33 @@ func (d *Dumper) dumpableFieldNames(conn *Connection, table string) ([]string, e
 	}
 
 	return fields, nil
+}
+
+func dumpOutputPath(outdir, database, table, suffix string) (string, error) {
+	db, err := sanitizeDumpComponent(database)
+	if err != nil {
+		return "", err
+	}
+	tbl, err := sanitizeDumpComponent(table)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(outdir, db+"."+tbl+suffix), nil
+}
+
+func sanitizeDumpComponent(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("dump path component cannot be empty")
+	}
+	if strings.Contains(name, "..") || strings.ContainsAny(name, `/\:`) || filepath.Base(name) != name {
+		return "", fmt.Errorf("dump path component %q is not a safe file name", name)
+	}
+	for _, r := range name {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("dump path component %q contains a control character", name)
+		}
+	}
+	return name, nil
 }
 
 // writeFile used to write datas to file.

--- a/internal/dumper/json_writer.go
+++ b/internal/dumper/json_writer.go
@@ -55,8 +55,11 @@ func (w *jsonWriter) ShouldFlush() bool {
 }
 
 func (w *jsonWriter) Flush(outdir, database, table string, fileNo int) error {
-	file := fmt.Sprintf("%s/%s.%s.%05d.json", outdir, database, table, fileNo)
-	err := writeFile(file, strings.Join(w.jsonLines, ""))
+	file, err := dumpOutputPath(outdir, database, table, fmt.Sprintf(".%05d.json", fileNo))
+	if err != nil {
+		return err
+	}
+	err = writeFile(file, strings.Join(w.jsonLines, ""))
 	if err != nil {
 		return err
 	}

--- a/internal/dumper/path_test.go
+++ b/internal/dumper/path_test.go
@@ -1,0 +1,28 @@
+package dumper
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDumpOutputPathRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := dumpOutputPath(dir, "db", "../../etc/passwd", "-schema.sql"); err == nil {
+		t.Fatal("expected traversal table name to be rejected")
+	}
+	if _, err := dumpOutputPath(dir, "../db", "t", "-schema.sql"); err == nil {
+		t.Fatal("expected traversal database name to be rejected")
+	}
+
+	got, err := dumpOutputPath(dir, "db", "users", "-schema.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "db.users-schema.sql")
+	if got != want {
+		t.Fatalf("dumpOutputPath = %q, want %q", got, want)
+	}
+	if filepath.Dir(got) != dir {
+		t.Fatalf("path escaped outdir: %q", got)
+	}
+}

--- a/internal/dumper/sql_writer.go
+++ b/internal/dumper/sql_writer.go
@@ -73,8 +73,11 @@ func (w *sqlWriter) ShouldFlush() bool {
 
 func (w *sqlWriter) Flush(outdir, database, table string, fileNo int) error {
 	query := strings.Join(w.inserts, ";\n") + ";\n"
-	file := fmt.Sprintf("%s/%s.%s.%05d.sql", outdir, database, table, fileNo)
-	err := writeFile(file, query)
+	file, err := dumpOutputPath(outdir, database, table, fmt.Sprintf(".%05d.sql", fileNo))
+	if err != nil {
+		return err
+	}
+	err = writeFile(file, query)
 	if err != nil {
 		return err
 	}

--- a/internal/import/d1/verify_checks.go
+++ b/internal/import/d1/verify_checks.go
@@ -227,8 +227,8 @@ func verifyBooleanColumns(ctx context.Context, db *sql.DB, sqlitePath string, ta
 
 func sqliteBooleanDistribution(ctx context.Context, sqlitePath, table, column string) (booleanDistribution, error) {
 	query := fmt.Sprintf(
-		`SELECT SUM(CASE WHEN %q = 1 THEN 1 ELSE 0 END), SUM(CASE WHEN %q = 0 THEN 1 ELSE 0 END), SUM(CASE WHEN %q IS NULL THEN 1 ELSE 0 END) FROM %q;`,
-		column, column, column, table,
+		`SELECT SUM(CASE WHEN %s = 1 THEN 1 ELSE 0 END), SUM(CASE WHEN %s = 0 THEN 1 ELSE 0 END), SUM(CASE WHEN %s IS NULL THEN 1 ELSE 0 END) FROM %s;`,
+		quoteSQLiteIdentifier(column), quoteSQLiteIdentifier(column), quoteSQLiteIdentifier(column), quoteSQLiteIdentifier(table),
 	)
 	return querySQLiteDistribution(ctx, sqlitePath, query)
 }
@@ -684,10 +684,10 @@ func sqliteRowSignature(ctx context.Context, sqlitePath string, table TableSchem
 		cols = append(cols, sqliteSignatureColumnExpr(col, table, all, coerceCtx))
 	}
 	query := fmt.Sprintf(
-		`SELECT %s FROM %q WHERE %q = %s LIMIT 1;`,
+		`SELECT %s FROM %s WHERE %s = %s LIMIT 1;`,
 		strings.Join(cols, " || '|' || "),
-		table.Name,
-		pkCol,
+		quoteSQLiteIdentifier(table.Name),
+		quoteSQLiteIdentifier(pkCol),
 		sqliteLiteral(pkVal),
 	)
 	sqlite3, err := FindSQLite3()

--- a/internal/import/d1/verify_checks_test.go
+++ b/internal/import/d1/verify_checks_test.go
@@ -314,3 +314,11 @@ func TestSummarizeRowSignatureForOutputOmitsBlobPayload(t *testing.T) {
 		t.Fatalf("expected blob byte count in summary, got %q", got)
 	}
 }
+
+func TestQuoteSQLiteIdentifierEscapesEmbeddedQuotes(t *testing.T) {
+	got := quoteSQLiteIdentifier(`id"; ATTACH DATABASE 'x' AS y; SELECT "`)
+	want := `"id""; ATTACH DATABASE 'x' AS y; SELECT """`
+	if got != want {
+		t.Fatalf("quoteSQLiteIdentifier = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Use SQLite identifier quoting in D1 verify queries. Keep database dump output files inside the chosen output directory.