### PR TITLE
Skip SA5011 in test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,13 @@ linters:
       - comments
       - common-false-positives
       - std-error-handling
+    rules:
+      # staticcheck does not always know that t.Fatal ends the test, so nil
+      # guards followed by a dereference are reported as SA5011.
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: SA5011
   disable:
     - errcheck # TODO: reenable after fixing all existing issues
 formatters:


### PR DESCRIPTION
## Summary

- The `lint` job is red on `main`. staticcheck reports SA5011 possible nil dereferences in `internal/import/d1` tests because it does not treat `t.Fatal` as ending the test, so the dereferences after each `if x == nil` guard look reachable. It is intermittent: the same commit range passed one run and failed the next, and the run is clean locally on both Go 1.26.0 and 1.26.5.
- The guard-then-dereference pattern appears in roughly 60 places across 23 test files, so this excludes SA5011 for `_test.go` files instead of restructuring each guard.

## Test plan

- [x] `golangci-lint config verify`
- [x] `golangci-lint run` (clean)
- [x] `lint` job green on this PR