### PR TITLE
Add pscale --skill to print an installable agent skill file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,11 @@
 # PlanetScale CLI — agent guide
 
-> **Developing the CLI?** The API client is vendored at `internal/planetscale/`;
-> this repo **no longer depends on `planetscale-go`**. Read `doc/api-client.md`
-> before touching API-facing code. The rest of this file is about *using* `pscale`.
-
 For **any** automated agent or script using `pscale`. Always pass **`--format json`**. Substitute placeholders from the user's request or from prior command output (`org list`, `database list`, `branch list`).
 
-If you only have the installed `pscale` binary, start here:
+If you only have the installed `pscale` binary and this guide is not already in your context, load it and check auth:
 
 ```bash
-pscale agent-guide --format json
+pscale --skill
 pscale auth check --format json
 ```
 
@@ -17,11 +13,21 @@ Use direct CLI automation for shell commands and scripts. Use the hosted PlanetS
 
 This file documents **how to invoke `pscale`**. For database assessment, safety review, and operational workflows, install the [PlanetScale skills pack](https://github.com/planetscale/skills) (`14-pscale-cli-automation` covers CLI automation; `00-safe-orchestrator` runs the full review). In application repositories, add a separate **project** `AGENTS.md` with org, database, branch, and approval rules (see skill `09-mcp-agent-operating-model` in that repo).
 
-| Placeholder | Meaning |
-|-------------|---------|
-| `<org>` | Organization name |
-| `<database>` | Database name |
-| `<branch>` | Branch name (pick one with `"ready": true` from `branch list`) |
+## Concepts
+
+PlanetScale is a serverless database platform for **MySQL** (via Vitess) and **PostgreSQL**. Resources are namespaced: an **organization** (org) owns **databases**, and each database contains **branches** — isolated copies of schema (and, for Postgres, data) that work like git branches. The default branch is typically `main` (production). Most commands target a database + branch and take `--org` to say which organization they belong to. Throughout this guide, `<org>`, `<database>`, and `<branch>` are placeholders for those names — pick a branch with `"ready": true` from `branch list`.
+
+On Vitess/MySQL, schema changes ship via **deploy requests**: online, non-blocking migrations you review and then deploy.
+
+Many commands are engine-specific, and some operations use different commands per engine. Schema changes: Vitess/MySQL uses `deploy-request`; Postgres branches apply DDL directly. Access: Vitess/MySQL uses `password`; Postgres uses `role`. Resize: Vitess/MySQL uses `keyspace resize`; Postgres uses `branch resize`. Vitess/MySQL-only: `deploy-request`, `keyspace`, `workflow`, `connect`, `password`. Postgres-only: `role`, `traffic-control`, branch `switchover`/`maintenance`/`parameters`, and `import d1`. The rest (`database`, `branch`, `sql`, `shell`, `insights`, `metrics`, `backup`, `org`, `auth`, `api`) work on both.
+
+When a database is "weird" (slow, erroring, locked, bloated):
+
+- **`insights`** — historical analysis computed from production traffic. Start here.
+- **`inspect`** — live, point-in-time state over a direct connection (locks, in-flight queries, sizes).
+- **`metrics`** — time-series for latency, throughput, connections.
+
+See "Diagnostics: insights + inspect" below for the full commands.
 
 ## Flag placement
 
@@ -46,10 +52,10 @@ pscale --org <org> database list --format json
 
 ## Workflow
 
-1. **Guide** — discover machine-readable conventions when you do not have this file:
+1. **Guide** — if this file is not already in your context, load the skill:
 
    ```bash
-   pscale agent-guide --format json
+   pscale --skill
    ```
 
 2. **Auth** — check before anything else:
@@ -353,7 +359,7 @@ pscale maintenance windows <database> <schedule-id> --org <org> --format json
 
 `--org` is required. Schedules include next/last window times, frequency, and any pending Vitess/MySQL version updates. Vitess Enterprise only.
 
-## Postgres branch changes (size, replicas, parameters)
+## Postgres branch changes (size, replicas, parameters) — Postgres only
 
 `pscale branch resize` queues a single asynchronous **change request** for a Postgres branch covering cluster size, replica count, and configuration parameters in any combination. Track it with `resize status`; cancel it with `resize cancel` while queued.
 
@@ -428,7 +434,7 @@ pscale branch maintenance run <database> <branch> --org <org> --format json --up
 - Postgres only; Vitess/MySQL databases are rejected before any API call.
 - See https://planetscale.com/docs/postgres/operations-philosophy
 
-## Imports (Cloudflare D1)
+## Imports (Cloudflare D1) — Postgres only
 
 `pscale import d1` migrates a Cloudflare D1 (SQLite) export into a PlanetScale Postgres branch. Every subcommand supports `--format json` and returns `status`, `issues`, and `next_steps`; stateful steps return a `migration_id` — pass it back with `--migration-id` to resume.
 
@@ -470,4 +476,4 @@ git clone https://github.com/planetscale/skills.git && cd skills && script/setup
 # or: npx skills add planetscale/skills -g -y
 ```
 
-After installing skills, load `14-pscale-cli-automation` for CLI conventions (or re-run `pscale agent-guide --format json` from any `pscale` binary that includes agent onboarding). Use `00-safe-orchestrator` when the user asks for a full PlanetScale assessment.
+After installing skills, load `14-pscale-cli-automation` for CLI conventions (or run `pscale --skill` from any `pscale` binary to print this reference). Use `00-safe-orchestrator` when the user asks for a full PlanetScale assessment.

--- a/README.md
+++ b/README.md
@@ -121,10 +121,15 @@ And then use the `pscale` binary built in `cmd/pscale/` for testing:
 ./cmd/pscale/pscale <command>
 ```
 
+The API client is vendored at `internal/planetscale/`; this repo **no longer depends on
+`planetscale-go`**. Read [`doc/api-client.md`](./doc/api-client.md) before touching
+API-facing code.
+
 ## Documentation
 
 Please checkout our Documentation page: [planetscale.com/docs](https://planetscale.com/docs/reference/planetscale-cli)
 
-For AI agents and automation, run `pscale agent-guide` or see [AGENTS.md](./AGENTS.md).
+For AI agents and automation, run `pscale agent-guide` (or `pscale --skill` for an
+installable skill file) — see [AGENTS.md](./AGENTS.md).
 For operational workflows (inventory, safety review, schema recommendations), install
 [planetscale/skills](https://github.com/planetscale/skills).

--- a/internal/cmd/agentguide/agentguide.go
+++ b/internal/cmd/agentguide/agentguide.go
@@ -1,6 +1,8 @@
 package agentguide
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	clicontent "github.com/planetscale/cli"
@@ -60,7 +62,11 @@ frontmatter plus the guide), suitable for dropping into a skills directory.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if asSkill {
-				ch.Printer.Print(SkillDoc())
+				// --skill dumps a raw skill file (like --version), not a
+				// resource. Write straight to stdout: Printer.Print routes
+				// non-human formats to io.Discard, which would exit 0 with an
+				// empty file when combined with --format json.
+				fmt.Print(SkillDoc())
 				return nil
 			}
 			if ch.Printer.Format() == printer.JSON {

--- a/internal/cmd/agentguide/agentguide.go
+++ b/internal/cmd/agentguide/agentguide.go
@@ -33,17 +33,36 @@ type response struct {
 	NextSteps           []string `json:"next_steps"`
 }
 
+// SkillDoc renders the embedded agent guide as an installable skill file:
+// YAML frontmatter (name/description trigger) followed by the guide body.
+// AGENTS.md stays the single source of truth for the body.
+func SkillDoc() string {
+	return "---\n" +
+		"name: pscale-cli\n" +
+		"description: \"Automate PlanetScale with the pscale CLI. Use when the user asks to run pscale commands or manage PlanetScale databases, branches, deploy requests, or SQL from scripts or agents. Always pass --format json.\"\n" +
+		"---\n\n" +
+		clicontent.AgentGuide
+}
+
 // AgentGuideCmd prints the embedded guide for agents and automation.
 func AgentGuideCmd(ch *cmdutil.Helper) *cobra.Command {
+	var asSkill bool
 	cmd := &cobra.Command{
 		Use:   "agent-guide",
 		Short: "Show guidance for AI agents and automation",
 		Long: `Show guidance for AI agents and automation using pscale.
 
 Use --format json for a machine-readable bootstrap response with first commands,
-supported engines, hosted MCP details, and PlanetScale skills install hints.`,
+supported engines, hosted MCP details, and PlanetScale skills install hints.
+
+Use --skill to print the guide as an installable agent skill file (YAML
+frontmatter plus the guide), suitable for dropping into a skills directory.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if asSkill {
+				ch.Printer.Print(SkillDoc())
+				return nil
+			}
 			if ch.Printer.Format() == printer.JSON {
 				return ch.Printer.PrintJSON(response{
 					Status:              "ok",
@@ -76,6 +95,8 @@ supported engines, hosted MCP details, and PlanetScale skills install hints.`,
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVar(&asSkill, "skill", false, "Print the guide as an installable agent skill file and exit")
 
 	return cmd
 }

--- a/internal/cmd/agentguide/agentguide.go
+++ b/internal/cmd/agentguide/agentguide.go
@@ -1,7 +1,7 @@
 package agentguide
 
 import (
-	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -66,8 +66,8 @@ frontmatter plus the guide), suitable for dropping into a skills directory.`,
 				// resource. Write straight to stdout: Printer.Print routes
 				// non-human formats to io.Discard, which would exit 0 with an
 				// empty file when combined with --format json.
-				fmt.Print(SkillDoc())
-				return nil
+				_, err := io.WriteString(cmd.OutOrStdout(), SkillDoc())
+				return err
 			}
 			if ch.Printer.Format() == printer.JSON {
 				return ch.Printer.PrintJSON(response{

--- a/internal/cmd/agentguide/agentguide_test.go
+++ b/internal/cmd/agentguide/agentguide_test.go
@@ -3,6 +3,8 @@ package agentguide
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -66,22 +68,51 @@ func TestSkillDoc(t *testing.T) {
 	}
 }
 
+// --skill writes to stdout regardless of --format (it is a raw file dump, not a
+// resource), so capture os.Stdout and verify it is not discarded in JSON mode.
 func TestAgentGuideSkillFlag(t *testing.T) {
-	format := printer.Human
-	var out bytes.Buffer
-	ch := &cmdutil.Helper{
-		Printer: printer.NewPrinter(&format),
-	}
-	ch.Printer.SetHumanOutput(&out)
+	for _, format := range []printer.Format{printer.Human, printer.JSON} {
+		t.Run(format.String(), func(t *testing.T) {
+			f := format
+			ch := &cmdutil.Helper{
+				Printer: printer.NewPrinter(&f),
+			}
 
-	cmd := AgentGuideCmd(ch)
-	cmd.SetArgs([]string{"--skill"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
+			got := captureStdout(t, func() {
+				cmd := AgentGuideCmd(ch)
+				cmd.SetArgs([]string{"--skill"})
+				if err := cmd.Execute(); err != nil {
+					t.Fatalf("execute: %v", err)
+				}
+			})
+			if !strings.HasPrefix(got, "---\nname: pscale-cli\n") {
+				t.Fatalf("--skill output missing frontmatter (format=%s), got prefix: %q", format, got[:min(40, len(got))])
+			}
+		})
 	}
-	if got := out.String(); !strings.HasPrefix(got, "---\nname: pscale-cli\n") {
-		t.Fatalf("--skill output missing frontmatter, got prefix: %q", got[:min(40, len(got))])
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
 	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	done := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	return <-done
 }
 
 func min(a, b int) int {

--- a/internal/cmd/agentguide/agentguide_test.go
+++ b/internal/cmd/agentguide/agentguide_test.go
@@ -3,8 +3,6 @@ package agentguide
 import (
 	"bytes"
 	"encoding/json"
-	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -69,7 +67,7 @@ func TestSkillDoc(t *testing.T) {
 }
 
 // --skill writes to stdout regardless of --format (it is a raw file dump, not a
-// resource), so capture os.Stdout and verify it is not discarded in JSON mode.
+// resource), so verify it is not discarded in JSON mode.
 func TestAgentGuideSkillFlag(t *testing.T) {
 	for _, format := range []printer.Format{printer.Human, printer.JSON} {
 		t.Run(format.String(), func(t *testing.T) {
@@ -78,41 +76,20 @@ func TestAgentGuideSkillFlag(t *testing.T) {
 				Printer: printer.NewPrinter(&f),
 			}
 
-			got := captureStdout(t, func() {
-				cmd := AgentGuideCmd(ch)
-				cmd.SetArgs([]string{"--skill"})
-				if err := cmd.Execute(); err != nil {
-					t.Fatalf("execute: %v", err)
-				}
-			})
+			var out bytes.Buffer
+			cmd := AgentGuideCmd(ch)
+			cmd.SetOut(&out)
+			cmd.SetArgs([]string{"--skill"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+
+			got := out.String()
 			if !strings.HasPrefix(got, "---\nname: pscale-cli\n") {
 				t.Fatalf("--skill output missing frontmatter (format=%s), got prefix: %q", format, got[:min(40, len(got))])
 			}
 		})
 	}
-}
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
-	defer func() { os.Stdout = old }()
-
-	done := make(chan string)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = io.Copy(&buf, r)
-		done <- buf.String()
-	}()
-
-	fn()
-	_ = w.Close()
-	os.Stdout = old
-	return <-done
 }
 
 func min(a, b int) int {

--- a/internal/cmd/agentguide/agentguide_test.go
+++ b/internal/cmd/agentguide/agentguide_test.go
@@ -3,6 +3,7 @@ package agentguide
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -50,4 +51,42 @@ func TestAgentGuideJSONBootstrap(t *testing.T) {
 	if resp.Guide == "" {
 		t.Fatal("expected embedded guide")
 	}
+}
+
+func TestSkillDoc(t *testing.T) {
+	doc := SkillDoc()
+	if !strings.HasPrefix(doc, "---\nname: pscale-cli\n") {
+		t.Fatalf("skill doc missing frontmatter, got prefix: %q", doc[:min(40, len(doc))])
+	}
+	if !strings.Contains(doc, "description:") {
+		t.Fatal("skill doc missing description trigger")
+	}
+	if !strings.Contains(doc, "# PlanetScale CLI") {
+		t.Fatal("skill doc missing embedded guide body")
+	}
+}
+
+func TestAgentGuideSkillFlag(t *testing.T) {
+	format := printer.Human
+	var out bytes.Buffer
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+	}
+	ch.Printer.SetHumanOutput(&out)
+
+	cmd := AgentGuideCmd(ch)
+	cmd.SetArgs([]string{"--skill"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got := out.String(); !strings.HasPrefix(got, "---\nname: pscale-cli\n") {
+		t.Fatalf("--skill output missing frontmatter, got prefix: %q", got[:min(40, len(got))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -73,8 +74,9 @@ import (
 )
 
 var (
-	cfgFile  string
-	replacer = strings.NewReplacer("-", "_", ".", "_")
+	cfgFile   string
+	skillFlag bool
+	replacer  = strings.NewReplacer("-", "_", ".", "_")
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -88,6 +90,13 @@ Agents and automation should start with:
   pscale --skill
   pscale auth check --format json`,
 	TraverseChildren: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if skillFlag && len(args) == 0 {
+			_, err := io.WriteString(cmd.OutOrStdout(), agentguide.SkillDoc())
+			return err
+		}
+		return cmd.Help()
+	},
 }
 
 // Execute executes the command and returns the exit status of the finished
@@ -170,18 +179,6 @@ func isRootOrgFlagError(err error) bool {
 func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.Format, debug *bool, sigc chan os.Signal, signals []os.Signal) error {
 	cobra.OnInitialize(initConfig)
 
-	// `pscale --skill` prints the agent guide as an installable skill file,
-	// mirroring `herdr --skill` (an alias for `pscale agent-guide --skill`). It is
-	// handled before cobra runs so that root stays non-runnable: this preserves
-	// the existing behavior for bare `pscale` (help) and unknown subcommands
-	// (non-zero "unknown command"). Matches `--skill` and `--skill=true`.
-	for _, arg := range os.Args[1:] {
-		if arg == "--skill" || arg == "--skill=true" {
-			fmt.Print(agentguide.SkillDoc())
-			return nil
-		}
-	}
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config",
 		"", "Config file (default is $HOME/.config/planetscale/pscale.yml)")
 	rootCmd.SilenceUsage = true
@@ -192,9 +189,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.Version = v
 	rootCmd.Flags().Bool("version", false, "Show pscale version")
 
-	// Register --skill so it shows in root help/usage. The flag is handled before
-	// cobra runs (top of runCmd); this registration is for discoverability only.
-	rootCmd.Flags().Bool("skill", false, "Print the agent skill file and exit")
+	rootCmd.Flags().BoolVar(&skillFlag, "skill", false, "Print the agent skill file and exit")
 
 	cfg, err := config.New()
 	if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -77,6 +77,9 @@ var (
 	replacer = strings.NewReplacer("-", "_", ".", "_")
 )
 
+// skillFlag is set by the root --skill flag (registered in runCmd).
+var skillFlag bool
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "pscale",
@@ -88,6 +91,15 @@ Agents and automation should start with:
   pscale --skill
   pscale auth check --format json`,
 	TraverseChildren: true,
+	// RunE lets the root --skill flag work with no subcommand (cobra only runs
+	// root when it has a Run function). Without --skill, bare `pscale` shows help.
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if skillFlag {
+			fmt.Print(agentguide.SkillDoc())
+			return nil
+		}
+		return cmd.Help()
+	},
 }
 
 // Execute executes the command and returns the exit status of the finished
@@ -180,17 +192,10 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.Version = v
 	rootCmd.Flags().Bool("version", false, "Show pscale version")
 
-	// `pscale --skill` prints the agent guide as an installable skill file and
-	// exits, mirroring `herdr --skill` (an alias for `pscale agent-guide --skill`).
-	// Scan os.Args directly: cobra shows root help instead of running a PreRun when
-	// no subcommand is given, so the flag must short-circuit before Execute.
-	for _, arg := range os.Args[1:] {
-		if arg == "--skill" {
-			fmt.Print(agentguide.SkillDoc())
-			return nil
-		}
-	}
-	rootCmd.Flags().Bool("skill", false, "Print the agent skill file and exit")
+	// `pscale --skill` prints the agent guide as an installable skill file,
+	// mirroring `herdr --skill` (an alias for `pscale agent-guide --skill`). It is
+	// a normal root flag; rootCmd.RunE handles it so it works with no subcommand.
+	rootCmd.Flags().BoolVar(&skillFlag, "skill", false, "Print the agent skill file and exit")
 
 	cfg, err := config.New()
 	if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -85,7 +85,7 @@ var rootCmd = &cobra.Command{
 
 Agents and automation should start with:
 
-  pscale agent-guide --format json
+  pscale --skill
   pscale auth check --format json`,
 	TraverseChildren: true,
 }
@@ -180,6 +180,18 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.Version = v
 	rootCmd.Flags().Bool("version", false, "Show pscale version")
 
+	// `pscale --skill` prints the agent guide as an installable skill file and
+	// exits, mirroring `herdr --skill` (an alias for `pscale agent-guide --skill`).
+	// Scan os.Args directly: cobra shows root help instead of running a PreRun when
+	// no subcommand is given, so the flag must short-circuit before Execute.
+	for _, arg := range os.Args[1:] {
+		if arg == "--skill" {
+			fmt.Print(agentguide.SkillDoc())
+			return nil
+		}
+	}
+	rootCmd.Flags().Bool("skill", false, "Print the agent skill file and exit")
+
 	cfg, err := config.New()
 	if err != nil {
 		return err
@@ -242,7 +254,7 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	// agent guide, so agents that discover pscale via --help (rather than a
 	// repo AGENTS.md) find the machine-readable guidance.
 	rootCmd.SetUsageTemplate(rootCmd.UsageTemplate() +
-		"\nAgents: run \"pscale agent-guide --format json\" for machine-readable guidance, or \"pscale help agents\" to read the full guide.\n")
+		"\nAgents: run \"pscale --skill\" to print the installable agent skill, \"pscale agent-guide --format json\" for machine-readable guidance, or \"pscale help agents\" to read the full guide.\n")
 
 	// Additional help topic (no Run function): `pscale help agents` prints
 	// the embedded agent guide.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -77,9 +77,6 @@ var (
 	replacer = strings.NewReplacer("-", "_", ".", "_")
 )
 
-// skillFlag is set by the root --skill flag (registered in runCmd).
-var skillFlag bool
-
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "pscale",
@@ -91,18 +88,6 @@ Agents and automation should start with:
   pscale --skill
   pscale auth check --format json`,
 	TraverseChildren: true,
-	// NoArgs keeps unknown subcommands/typos (e.g. `pscale databse`) failing with
-	// a non-zero "unknown command" error now that RunE makes root runnable.
-	Args: cobra.NoArgs,
-	// RunE lets the root --skill flag work with no subcommand (cobra only runs
-	// root when it has a Run function). Without --skill, bare `pscale` shows help.
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if skillFlag {
-			fmt.Print(agentguide.SkillDoc())
-			return nil
-		}
-		return cmd.Help()
-	},
 }
 
 // Execute executes the command and returns the exit status of the finished
@@ -185,6 +170,18 @@ func isRootOrgFlagError(err error) bool {
 func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.Format, debug *bool, sigc chan os.Signal, signals []os.Signal) error {
 	cobra.OnInitialize(initConfig)
 
+	// `pscale --skill` prints the agent guide as an installable skill file,
+	// mirroring `herdr --skill` (an alias for `pscale agent-guide --skill`). It is
+	// handled before cobra runs so that root stays non-runnable: this preserves
+	// the existing behavior for bare `pscale` (help) and unknown subcommands
+	// (non-zero "unknown command"). Matches `--skill` and `--skill=true`.
+	for _, arg := range os.Args[1:] {
+		if arg == "--skill" || arg == "--skill=true" {
+			fmt.Print(agentguide.SkillDoc())
+			return nil
+		}
+	}
+
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config",
 		"", "Config file (default is $HOME/.config/planetscale/pscale.yml)")
 	rootCmd.SilenceUsage = true
@@ -195,10 +192,9 @@ func runCmd(ctx context.Context, ver, commit, buildDate string, format *printer.
 	rootCmd.Version = v
 	rootCmd.Flags().Bool("version", false, "Show pscale version")
 
-	// `pscale --skill` prints the agent guide as an installable skill file,
-	// mirroring `herdr --skill` (an alias for `pscale agent-guide --skill`). It is
-	// a normal root flag; rootCmd.RunE handles it so it works with no subcommand.
-	rootCmd.Flags().BoolVar(&skillFlag, "skill", false, "Print the agent skill file and exit")
+	// Register --skill so it shows in root help/usage. The flag is handled before
+	// cobra runs (top of runCmd); this registration is for discoverability only.
+	rootCmd.Flags().Bool("skill", false, "Print the agent skill file and exit")
 
 	cfg, err := config.New()
 	if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -91,6 +91,9 @@ Agents and automation should start with:
   pscale --skill
   pscale auth check --format json`,
 	TraverseChildren: true,
+	// NoArgs keeps unknown subcommands/typos (e.g. `pscale databse`) failing with
+	// a non-zero "unknown command" error now that RunE makes root runnable.
+	Args: cobra.NoArgs,
 	// RunE lets the root --skill flag work with no subcommand (cobra only runs
 	// root when it has a Run function). Without --skill, bare `pscale` shows help.
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmd/agentguide"
+	"github.com/planetscale/cli/internal/cmdutil"
+)
+
+const rootCLIHelperEnv = "PSCALE_ROOT_CLI_HELPER"
+
+func TestRootSkillFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"--skill", "--format", "json"},
+		{"--skill=true", "--format", "json"},
+		{"--skill=TRUE", "--format", "json"},
+		{"--skill=1", "--format", "json"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			result := runRootCLI(t, args...)
+			if result.exitCode != 0 {
+				t.Fatalf("exit code = %d, stderr = %q", result.exitCode, result.stderr)
+			}
+			if result.stdout != agentguide.SkillDoc() {
+				t.Fatalf("skill output differs (prefix=%q)", result.stdout[:min(40, len(result.stdout))])
+			}
+		})
+	}
+}
+
+func TestRootSkillFlagDoesNotInterceptSubcommandValues(t *testing.T) {
+	result := runRootCLI(t,
+		"deploy-request", "review", "db", "1",
+		"--comment", "--skill", "--format", "json",
+	)
+
+	if result.exitCode != cmdutil.ActionRequestedExitCode {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", result.exitCode, result.stdout, result.stderr)
+	}
+	if strings.HasPrefix(result.stdout, "---\nname: pscale-cli\n") {
+		t.Fatal("--skill flag value was intercepted by the root command")
+	}
+	if !strings.Contains(result.stdout, `"code": "NO_AUTH"`) {
+		t.Fatalf("command did not reach authentication, stdout = %q", result.stdout)
+	}
+}
+
+func TestRootSkillFlagDoesNotHideInvalidFlags(t *testing.T) {
+	result := runRootCLI(t, "--format", "json", "--bogus", "--skill")
+
+	if result.exitCode != cmdutil.FatalErrExitCode {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", result.exitCode, result.stdout, result.stderr)
+	}
+	if strings.HasPrefix(result.stdout, "---\nname: pscale-cli\n") {
+		t.Fatal("--skill hid an invalid flag")
+	}
+	if !strings.Contains(result.stdout, `"code": "UNKNOWN_FLAG"`) {
+		t.Fatalf("expected UNKNOWN_FLAG error, stdout = %q", result.stdout)
+	}
+}
+
+func TestRootSkillFlagIsNotInheritedBySubcommands(t *testing.T) {
+	result := runRootCLI(t, "--format", "json", "auth", "check", "--skill")
+
+	if result.exitCode != cmdutil.FatalErrExitCode {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", result.exitCode, result.stdout, result.stderr)
+	}
+	if strings.HasPrefix(result.stdout, "---\nname: pscale-cli\n") {
+		t.Fatal("subcommand --skill flag was intercepted by the root command")
+	}
+	if !strings.Contains(result.stdout, `"code": "UNKNOWN_FLAG"`) {
+		t.Fatalf("expected UNKNOWN_FLAG error, stdout = %q", result.stdout)
+	}
+}
+
+func TestRootCLIHelperProcess(t *testing.T) {
+	if os.Getenv(rootCLIHelperEnv) != "1" {
+		return
+	}
+
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 {
+		t.Fatal("missing argument separator")
+	}
+
+	os.Args = append([]string{"pscale"}, os.Args[separator+1:]...)
+	exitCode := Execute(context.Background(), make(chan os.Signal, 1), []os.Signal{os.Interrupt}, "test", "test", "test")
+	os.Exit(exitCode)
+}
+
+type rootCLIResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+func runRootCLI(t *testing.T, args ...string) rootCLIResult {
+	t.Helper()
+
+	testArgs := append([]string{"-test.run=^TestRootCLIHelperProcess$", "--"}, args...)
+	command := exec.Command(os.Args[0], testArgs...)
+	command.Env = append(os.Environ(),
+		rootCLIHelperEnv+"=1",
+		"PSCALE_DISABLE_DEV_WARNING=true",
+		"PSCALE_NO_UPDATE_NOTIFIER=1",
+		"XDG_CONFIG_HOME="+t.TempDir(),
+	)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	exitCode := 0
+	if err := command.Run(); err != nil {
+		var exitError *exec.ExitError
+		if !errors.As(err, &exitError) {
+			t.Fatalf("run helper process: %v", err)
+		}
+		exitCode = exitError.ExitCode()
+	}
+
+	return rootCLIResult{
+		exitCode: exitCode,
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+	}
+}


### PR DESCRIPTION
## What

Adds `pscale --skill`, mirroring [`herdr --skill`](https://herdr.dev): a cold-start one-liner that prints the agent guide as an **installable skill file** (YAML frontmatter trigger + the embedded guide), so an agent with nothing but the binary can drop it into a skills directory and get trigger-based loading.

`pscale --skill` is an alias for `pscale agent-guide --skill`; both render from the same embedded `AGENTS.md`, so there is no content fork.

## Changes

- **`internal/cmd/root.go`** — new root `--skill` flag. Because cobra prints root help (never a PreRun) when no subcommand is given, it scans `os.Args` before `Execute`, exactly like `herdr --skill`. Root `Long` and the `--help` footer now lead with `pscale --skill`.
- **`internal/cmd/agentguide/agentguide.go`** — `SkillDoc()` prepends `name`/`description` frontmatter to the embedded guide. `agent-guide` (bare) still prints the plain guide for humans; `agent-guide --skill` prints the skill file.
- **`AGENTS.md`** — skill-ified:
  - New **Concepts** section: org → database → branch hierarchy, engine disambiguation (deploy-request / password / keyspace resize = Vitess; role / branch resize / import d1 = Postgres), and a "weird database" triage (insights / inspect / metrics).
  - Removed the repo-dev note (moved to README) — meaningless inside an installed skill.
  - De-circularized self-references: "start here" and Workflow step 1 now point at `pscale --skill`.
- **`README.md`** — the repo-dev pointer (`internal/planetscale/`, `doc/api-client.md`) is preserved under Local Development; Docs section mentions both entry points.
- **Tests** — `TestSkillDoc` (frontmatter + body present), `TestAgentGuideSkillFlag` (`--skill` emits frontmatter).

## Verification

- `pscale --skill` ≡ `pscale agent-guide --skill` (byte-identical, exit 0); `agent-guide` bare stays frontmatter-free; `--help` and other commands unaffected.
- Local CI-equivalent all green: `go fmt`, `go vet`, `staticcheck`, `golangci-lint` (0 issues), full `go test ./...`.

## Note

The `--skill` `os.Args` scan triggers on any bare `--skill` token before cobra runs. No real command defines a `--skill` flag, so this is harmless, but it can be scoped to position 1 if preferred.