### PR TITLE
Show replica and PgBouncer connection details for Postgres roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,11 @@ pscale branch extensions list <database> <branch> --org <org> --format json
 pscale role default <database> <branch> --org <org> --format json
 pscale role reset-default <database> <branch> --org <org> --format json --force
 
+# Role connection details for a branch replica, regional read-only replica, or PgBouncer
+pscale role get <database> <branch> <role-id> --org <org> --format json --replica
+pscale role get <database> <branch> <role-id> --org <org> --format json --read-only-replica <region-slug>
+pscale role get <database> <branch> <role-id> --org <org> --format json --bouncer <bouncer-name>
+
 # Change parameters (repeat --parameters; keys are namespace.name)
 pscale branch resize <database> <branch> --org <org> --format json --parameters pgconf.max_connections=200
 
@@ -391,6 +396,7 @@ pscale branch resize cancel <database> <branch> --org <org> --format json
 ```
 
 - At least one of `--cluster-size`, `--replicas`, or `--parameters` is required.
+- The `role get` connection target flags are mutually exclusive. Targeted role responses keep the same shape while changing `username`, `access_host_url`, and `database_url` as needed.
 - `--parameters` values are validated against the catalog before submission; unknown or immutable parameters fail fast. Parameters with `"restart": true` in the catalog restart the database when applied — surface this to the user before changing them.
 - Change request `state` is one of `queued`, `pending`, `resizing`, `completed`, `canceled`. Only `completed` and `canceled` are terminal. Without `--wait`, poll `resize status` instead of assuming completion.
 - A no-op (branch already matches the requested configuration) prints `{"result": "no_change", "branch": "<branch>"}` in JSON mode instead of a change request.

--- a/internal/cmd/role/get.go
+++ b/internal/cmd/role/get.go
@@ -85,7 +85,12 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			return ch.Printer.PrintResource(toPostgresRole(role))
+			output := toPostgresRole(role)
+			if flags.bouncer != "" {
+				output.DatabaseURL = buildPostgresConnectionURLWithDefaultPort(role.Username, role.Password, role.AccessHostURL, "6432")
+			}
+
+			return ch.Printer.PrintResource(output)
 		},
 	}
 

--- a/internal/cmd/role/get.go
+++ b/internal/cmd/role/get.go
@@ -47,11 +47,38 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
+					notFoundFormat := "role %s does not exist in branch %s of database %s (organization: %s)"
+					notFoundArgs := []any{
+						printer.BoldBlue(roleID),
+						printer.BoldBlue(branch),
+						printer.BoldBlue(database),
+						printer.BoldBlue(ch.Config.Organization),
+					}
+					if flags.readOnlyReplica != "" {
+						notFoundFormat = "role %s or a read-only replica in region %s was not found in branch %s of database %s (organization: %s)"
+						notFoundArgs = []any{
+							printer.BoldBlue(roleID),
+							printer.BoldBlue(flags.readOnlyReplica),
+							printer.BoldBlue(branch),
+							printer.BoldBlue(database),
+							printer.BoldBlue(ch.Config.Organization),
+						}
+					} else if flags.bouncer != "" {
+						notFoundFormat = "role %s or PgBouncer %s was not found in branch %s of database %s (organization: %s)"
+						notFoundArgs = []any{
+							printer.BoldBlue(roleID),
+							printer.BoldBlue(flags.bouncer),
+							printer.BoldBlue(branch),
+							printer.BoldBlue(database),
+							printer.BoldBlue(ch.Config.Organization),
+						}
+					}
+
 					return cmdutil.HandleNotFoundWithServiceTokenCheck(
 						ctx, cmd, ch.Config, ch.Client, err,
 						"read_branch",
-						"role %s does not exist in branch %s of database %s (organization: %s)",
-						printer.BoldBlue(roleID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+						notFoundFormat,
+						notFoundArgs...)
 				default:
 					return cmdutil.HandleError(err)
 				}

--- a/internal/cmd/role/get.go
+++ b/internal/cmd/role/get.go
@@ -11,6 +11,12 @@ import (
 )
 
 func GetCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		replica         bool
+		readOnlyReplica string
+		bouncer         string
+	}
+
 	cmd := &cobra.Command{
 		Use:   "get <database> <branch> <role-id>",
 		Short: "Retrieve information about a specific role",
@@ -30,10 +36,13 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 			defer end()
 
 			role, err := client.PostgresRoles.Get(ctx, &ps.GetPostgresRoleRequest{
-				Organization: ch.Config.Organization,
-				Database:     database,
-				Branch:       branch,
-				RoleId:       roleID,
+				Organization:    ch.Config.Organization,
+				Database:        database,
+				Branch:          branch,
+				RoleId:          roleID,
+				Replica:         flags.replica,
+				ReadOnlyReplica: flags.readOnlyReplica,
+				Bouncer:         flags.bouncer,
 			})
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
@@ -52,6 +61,11 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 			return ch.Printer.PrintResource(toPostgresRole(role))
 		},
 	}
+
+	cmd.Flags().BoolVar(&flags.replica, "replica", false, "Return connection details for a branch replica.")
+	cmd.Flags().StringVar(&flags.readOnlyReplica, "read-only-replica", "", "Return connection details for a regional read-only replica (region slug).")
+	cmd.Flags().StringVar(&flags.bouncer, "bouncer", "", "Return connection details for a PgBouncer (name).")
+	cmd.MarkFlagsMutuallyExclusive("replica", "read-only-replica", "bouncer")
 
 	return cmd
 }

--- a/internal/cmd/role/get_test.go
+++ b/internal/cmd/role/get_test.go
@@ -65,3 +65,103 @@ func TestRole_GetCmdIncludesStatusAndExpiration(t *testing.T) {
 		"with_replication": false,
 	})
 }
+
+func TestRole_GetCmdConnectionTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		request ps.GetPostgresRoleRequest
+	}{
+		{
+			name: "replica",
+			args: []string{"mydb", "main", "role-id", "--replica"},
+			request: ps.GetPostgresRoleRequest{
+				Replica: true,
+			},
+		},
+		{
+			name: "read-only replica",
+			args: []string{"mydb", "main", "role-id", "--read-only-replica", "us-west"},
+			request: ps.GetPostgresRoleRequest{
+				ReadOnlyReplica: "us-west",
+			},
+		},
+		{
+			name: "bouncer",
+			args: []string{"mydb", "main", "role-id", "--bouncer", "pool"},
+			request: ps.GetPostgresRoleRequest{
+				Bouncer: "pool",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			var buf bytes.Buffer
+			format := printer.JSON
+			p := printer.NewPrinter(&format)
+			p.SetResourceOutput(&buf)
+
+			svc := &mock.PostgresRolesService{
+				GetFn: func(ctx context.Context, req *ps.GetPostgresRoleRequest) (*ps.PostgresRole, error) {
+					test.request.Organization = "planetscale"
+					test.request.Database = "mydb"
+					test.request.Branch = "main"
+					test.request.RoleId = "role-id"
+					c.Assert(req, qt.DeepEquals, &test.request)
+
+					return &ps.PostgresRole{
+						ID:            "role-id",
+						Name:          "app",
+						Username:      "app.branch|replica",
+						AccessHostURL: "us-west.pg.psdb.cloud",
+					}, nil
+				},
+			}
+
+			ch := &cmdutil.Helper{
+				Printer: p,
+				Config:  &config.Config{Organization: "planetscale"},
+				Client: func() (*ps.Client, error) {
+					return &ps.Client{PostgresRoles: svc}, nil
+				},
+			}
+
+			cmd := GetCmd(ch)
+			cmd.SetArgs(test.args)
+			c.Assert(cmd.Execute(), qt.IsNil)
+
+			c.Assert(buf.String(), qt.JSONEquals, map[string]any{
+				"id":               "role-id",
+				"name":             "app",
+				"username":         "app.branch|replica",
+				"status":           "active",
+				"expires_at":       nil,
+				"password":         "",
+				"access_host_url":  "us-west.pg.psdb.cloud",
+				"database_url":     "postgresql://app.branch%7Creplica:@us-west.pg.psdb.cloud:5432/postgres?sslmode=verify-full",
+				"with_replication": false,
+			})
+		})
+	}
+}
+
+func TestRole_GetCmdRejectsMultipleConnectionTargets(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.PostgresRolesService{}
+	ch := &cmdutil.Helper{
+		Config: &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{PostgresRoles: svc}, nil
+		},
+	}
+
+	cmd := GetCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "role-id", "--replica", "--bouncer", "pool"})
+
+	c.Assert(cmd.Execute(), qt.IsNotNil)
+	c.Assert(svc.GetFnInvoked, qt.IsFalse)
+}

--- a/internal/cmd/role/get_test.go
+++ b/internal/cmd/role/get_test.go
@@ -3,6 +3,7 @@ package role
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -164,4 +165,57 @@ func TestRole_GetCmdRejectsMultipleConnectionTargets(t *testing.T) {
 
 	c.Assert(cmd.Execute(), qt.IsNotNil)
 	c.Assert(svc.GetFnInvoked, qt.IsFalse)
+}
+
+func TestRole_GetCmdConnectionTargetNotFound(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		targetType string
+		target     string
+	}{
+		{
+			name:       "read-only replica",
+			args:       []string{"mydb", "main", "role-id", "--read-only-replica", "missing-region"},
+			targetType: "read-only replica in region",
+			target:     "missing-region",
+		},
+		{
+			name:       "bouncer",
+			args:       []string{"mydb", "main", "role-id", "--bouncer", "missing-bouncer"},
+			targetType: "PgBouncer",
+			target:     "missing-bouncer",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			format := printer.Human
+			p := printer.NewPrinter(&format)
+			svc := &mock.PostgresRolesService{
+				GetFn: func(ctx context.Context, req *ps.GetPostgresRoleRequest) (*ps.PostgresRole, error) {
+					return nil, &ps.Error{Code: ps.ErrNotFound}
+				},
+			}
+			ch := &cmdutil.Helper{
+				Printer: p,
+				Config:  &config.Config{Organization: "planetscale"},
+				Client: func() (*ps.Client, error) {
+					return &ps.Client{PostgresRoles: svc}, nil
+				},
+			}
+
+			cmd := GetCmd(ch)
+			cmd.SetArgs(test.args)
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(strings.Contains(err.Error(), "role"), qt.IsTrue)
+			c.Assert(strings.Contains(err.Error(), "role-id"), qt.IsTrue)
+			c.Assert(strings.Contains(err.Error(), test.targetType), qt.IsTrue)
+			c.Assert(strings.Contains(err.Error(), test.target), qt.IsTrue)
+		})
+	}
 }

--- a/internal/cmd/role/get_test.go
+++ b/internal/cmd/role/get_test.go
@@ -69,9 +69,12 @@ func TestRole_GetCmdIncludesStatusAndExpiration(t *testing.T) {
 
 func TestRole_GetCmdConnectionTargets(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    []string
-		request ps.GetPostgresRoleRequest
+		name          string
+		args          []string
+		request       ps.GetPostgresRoleRequest
+		username      string
+		accessHostURL string
+		databaseURL   string
 	}{
 		{
 			name: "replica",
@@ -79,6 +82,9 @@ func TestRole_GetCmdConnectionTargets(t *testing.T) {
 			request: ps.GetPostgresRoleRequest{
 				Replica: true,
 			},
+			username:      "app.branch|replica",
+			accessHostURL: "primary.pg.psdb.cloud",
+			databaseURL:   "postgresql://app.branch%7Creplica:@primary.pg.psdb.cloud:5432/postgres?sslmode=verify-full",
 		},
 		{
 			name: "read-only replica",
@@ -86,6 +92,9 @@ func TestRole_GetCmdConnectionTargets(t *testing.T) {
 			request: ps.GetPostgresRoleRequest{
 				ReadOnlyReplica: "us-west",
 			},
+			username:      "app.read-only|replica",
+			accessHostURL: "us-west.pg.psdb.cloud",
+			databaseURL:   "postgresql://app.read-only%7Creplica:@us-west.pg.psdb.cloud:5432/postgres?sslmode=verify-full",
 		},
 		{
 			name: "bouncer",
@@ -93,6 +102,9 @@ func TestRole_GetCmdConnectionTargets(t *testing.T) {
 			request: ps.GetPostgresRoleRequest{
 				Bouncer: "pool",
 			},
+			username:      "app.branch|pool",
+			accessHostURL: "primary.pg.psdb.cloud",
+			databaseURL:   "postgresql://app.branch%7Cpool:@primary.pg.psdb.cloud:6432/postgres?sslmode=verify-full",
 		},
 	}
 
@@ -116,8 +128,8 @@ func TestRole_GetCmdConnectionTargets(t *testing.T) {
 					return &ps.PostgresRole{
 						ID:            "role-id",
 						Name:          "app",
-						Username:      "app.branch|replica",
-						AccessHostURL: "us-west.pg.psdb.cloud",
+						Username:      test.username,
+						AccessHostURL: test.accessHostURL,
 					}, nil
 				},
 			}
@@ -137,12 +149,12 @@ func TestRole_GetCmdConnectionTargets(t *testing.T) {
 			c.Assert(buf.String(), qt.JSONEquals, map[string]any{
 				"id":               "role-id",
 				"name":             "app",
-				"username":         "app.branch|replica",
+				"username":         test.username,
 				"status":           "active",
 				"expires_at":       nil,
 				"password":         "",
-				"access_host_url":  "us-west.pg.psdb.cloud",
-				"database_url":     "postgresql://app.branch%7Creplica:@us-west.pg.psdb.cloud:5432/postgres?sslmode=verify-full",
+				"access_host_url":  test.accessHostURL,
+				"database_url":     test.databaseURL,
 				"with_replication": false,
 			})
 		})

--- a/internal/cmd/role/reset_default.go
+++ b/internal/cmd/role/reset_default.go
@@ -178,11 +178,14 @@ func roleAttributes(role *PostgresRole) string {
 
 // buildPostgresConnectionURL constructs a PostgreSQL connection URL from role credentials.
 func buildPostgresConnectionURL(username, password, accessHostURL string) string {
+	return buildPostgresConnectionURLWithDefaultPort(username, password, accessHostURL, "5432")
+}
+
+func buildPostgresConnectionURLWithDefaultPort(username, password, accessHostURL, defaultPort string) string {
 	host, port, err := net.SplitHostPort(accessHostURL)
 	if err != nil {
-		// If no port specified, use the host as-is and default to 5432
 		host = accessHostURL
-		port = "5432"
+		port = defaultPort
 	}
 
 	return fmt.Sprintf("postgresql://%s:%s@%s:%s/postgres?sslmode=verify-full",

--- a/internal/planetscale/postgres_roles.go
+++ b/internal/planetscale/postgres_roles.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 	"time"
 )
@@ -37,10 +38,13 @@ type ListPostgresRolesRequest struct {
 
 // GetPostgresRoleRequest encapsulates the request for getting a specific role for a given database branch.
 type GetPostgresRoleRequest struct {
-	Organization string `json:"-"`
-	Database     string `json:"-"`
-	Branch       string `json:"-"`
-	RoleId       string
+	Organization    string
+	Database        string
+	Branch          string
+	RoleId          string
+	Replica         bool
+	ReadOnlyReplica string
+	Bouncer         string
 }
 
 // CreatePostgresRoleRequest encapsulates the request for creating role credentials for a database branch.
@@ -197,7 +201,18 @@ func (p *postgresRolesService) List(ctx context.Context, listReq *ListPostgresRo
 // Get an existing role for a database branch.
 func (p *postgresRolesService) Get(ctx context.Context, getReq *GetPostgresRoleRequest) (*PostgresRole, error) {
 	pathStr := postgresBranchRoleAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.RoleId)
-	req, err := p.client.newRequest(http.MethodGet, pathStr, nil)
+	query := url.Values{}
+	if getReq.Replica {
+		query.Set("replica", "true")
+	}
+	if getReq.ReadOnlyReplica != "" {
+		query.Set("read_only_replica", getReq.ReadOnlyReplica)
+	}
+	if getReq.Bouncer != "" {
+		query.Set("bouncer", getReq.Bouncer)
+	}
+
+	req, err := p.client.newRequest(http.MethodGet, pathStr, nil, WithQueryParams(query))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/internal/planetscale/postgres_roles_test.go
+++ b/internal/planetscale/postgres_roles_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -319,6 +320,74 @@ func TestPostgresRoles_Get(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(role, qt.DeepEquals, want)
+}
+
+func TestPostgresRoles_GetConnectionTargets(t *testing.T) {
+	tests := []struct {
+		name       string
+		request    GetPostgresRoleRequest
+		query      url.Values
+		username   string
+		accessHost string
+	}{
+		{
+			name:       "replica",
+			request:    GetPostgresRoleRequest{Replica: true},
+			query:      url.Values{"replica": []string{"true"}},
+			username:   "test-user.branch-id|replica",
+			accessHost: "primary.planetscale.com",
+		},
+		{
+			name:       "read-only replica",
+			request:    GetPostgresRoleRequest{ReadOnlyReplica: "us-west"},
+			query:      url.Values{"read_only_replica": []string{"us-west"}},
+			username:   "test-user.replica-id|replica",
+			accessHost: "us-west.planetscale.com",
+		},
+		{
+			name:       "bouncer",
+			request:    GetPostgresRoleRequest{Bouncer: "pool"},
+			query:      url.Values{"bouncer": []string{"pool"}},
+			username:   "test-user.branch-id|pool",
+			accessHost: "primary.planetscale.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c.Assert(r.Method, qt.Equals, http.MethodGet)
+				c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/my-branch/roles/AbC123xYz")
+				c.Assert(r.URL.Query(), qt.DeepEquals, test.query)
+
+				_, err := fmt.Fprintf(w, `{
+					"id": "%s",
+					"name": "test-role",
+					"access_host_url": "%s",
+					"database_name": "postgres",
+					"username": "%s"
+				}`, testRoleID, test.accessHost, test.username)
+				c.Assert(err, qt.IsNil)
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := NewClient(WithBaseURL(ts.URL))
+			c.Assert(err, qt.IsNil)
+
+			test.request.Organization = "my-org"
+			test.request.Database = "my-db"
+			test.request.Branch = "my-branch"
+			test.request.RoleId = testRoleID
+
+			role, err := client.PostgresRoles.Get(context.Background(), &test.request)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(role.Username, qt.Equals, test.username)
+			c.Assert(role.AccessHostURL, qt.Equals, test.accessHost)
+		})
+	}
 }
 
 func TestPostgresRoles_Create(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Customers can use `pscale role get` to retrieve connection details for a branch replica, a regional read-only replica, or a PgBouncer. The command returns the target-specific username, host, and database URL.

```console
pscale role get <database> <branch> <role-id> --replica
pscale role get <database> <branch> <role-id> --read-only-replica <region-slug>
pscale role get <database> <branch> <role-id> --bouncer <bouncer-name>
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dd29b1a-a526-44bf-9c71-734d894b6a8b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dd29b1a-a526-44bf-9c71-734d894b6a8b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

