### PR TITLE
Add Postgres PITR restore-point support to branch create

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -20,6 +20,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		parentBranch  string
 		clusterSize   string
 		backupID      string
+		restorePoint  string
 		majorVersion  string
 		minStorage    int64
 		maxStorage    int64
@@ -105,7 +106,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			clusterSize := flags.clusterSize
 			if clusterSize == "" {
-				if flags.backupID != "" || flags.dataBranching {
+				if flags.backupID != "" || flags.restorePoint != "" || flags.dataBranching {
 					clusterSize = "PS-10"
 				} else {
 					clusterSize = "PS_DEV"
@@ -115,6 +116,9 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if db.Kind == "mysql" {
 				if cmd.Flags().Changed("min-storage") || cmd.Flags().Changed("max-storage") {
 					return fmt.Errorf("--min-storage and --max-storage are only supported for PostgreSQL databases")
+				}
+				if flags.restorePoint != "" {
+					return fmt.Errorf("--restore-point is only supported for PostgreSQL databases")
 				}
 
 				createReq := &ps.CreateDatabaseBranchRequest{
@@ -183,6 +187,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 					ClusterName:  clusterSize,
 					ParentBranch: flags.parentBranch,
 					BackupID:     flags.backupID,
+					RestorePoint: flags.restorePoint,
 					MajorVersion: flags.majorVersion,
 				}
 
@@ -246,6 +251,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
 	cmd.Flags().StringVar(&flags.region, "region", "", "Region for the branch to be created in.")
 	cmd.Flags().StringVar(&flags.backupID, "restore", "", "ID of Backup to restore into branch.")
+	cmd.Flags().StringVar(&flags.restorePoint, "restore-point", "", "For PostgreSQL databases, restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z).")
 	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "", "Cluster size for the branch. Defaults to PS_DEV for regular branches, or PS-10 for branches created from a backup or with seed-data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
@@ -255,6 +261,8 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.MarkFlagsMutuallyExclusive("from", "restore")
 	cmd.MarkFlagsMutuallyExclusive("restore", "seed-data")
+	cmd.MarkFlagsMutuallyExclusive("restore", "restore-point")
+	cmd.MarkFlagsMutuallyExclusive("restore-point", "seed-data")
 
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return cmdutil.RegionsCompletionFunc(ch, cmd, args, toComplete)

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -734,3 +734,109 @@ func TestBranch_CreateCmd_SourceDatabaseNotFound(t *testing.T) {
 	c.Assert(err.Error(), qt.Not(qt.Contains), branch)
 	c.Assert(orgSvc.GetFnInvoked, qt.IsTrue)
 }
+
+func TestBranch_CreateCmdWithRestorePoint(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	restorePoint := "2023-01-01T00:00:00Z"
+
+	res := &ps.PostgresBranch{Name: branch}
+
+	svc := &mock.PostgresBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req.Name, qt.Equals, branch)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Region, qt.Equals, "us-east")
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.RestorePoint, qt.Equals, restorePoint)
+			c.Assert(req.ParentBranch, qt.Equals, "main")
+			c.Assert(req.ClusterName, qt.Equals, "PS-10")
+
+			return res, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Organization, qt.Equals, org)
+			return &ps.Database{Kind: "postgresql"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--region", "us-east", "--from", "main", "--restore-point", restorePoint})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranch_CreateCmdWithRestorePointMySQLError(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "mysql"}, nil
+		},
+	}
+
+	svc := &mock.DatabaseBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreateDatabaseBranchRequest) (*ps.DatabaseBranch, error) {
+			c.Fatal("CreateFn should not be called for MySQL with --restore-point")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				DatabaseBranches: svc,
+				Databases:        dbSvc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--region", "us-east", "--restore-point", "2023-01-01T00:00:00Z"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, ".*only supported for PostgreSQL.*")
+	c.Assert(svc.CreateFnInvoked, qt.IsFalse)
+}

--- a/internal/planetscale/postgres_branches.go
+++ b/internal/planetscale/postgres_branches.go
@@ -41,6 +41,7 @@ type CreatePostgresBranchRequest struct {
 	Name         string         `json:"name"`
 	ParentBranch string         `json:"parent_branch"`
 	BackupID     string         `json:"backup_id,omitempty"`
+	RestorePoint string         `json:"restore_point,omitempty"`
 	ClusterName  string         `json:"cluster_name,omitempty"`
 	MajorVersion string         `json:"major_version,omitempty"`
 	Storage      *StorageConfig `json:"storage,omitempty"`

--- a/internal/planetscale/postgres_branches_test.go
+++ b/internal/planetscale/postgres_branches_test.go
@@ -695,3 +695,49 @@ func TestPostgresBranches_CreateWithStorage(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(branch, qt.DeepEquals, want)
 }
+
+func TestPostgresBranches_CreateWithRestorePoint(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		c.Assert(err, qt.IsNil)
+		c.Assert(body["restore_point"], qt.Equals, "2023-01-01T00:00:00Z")
+		c.Assert(body["parent_branch"], qt.Equals, "main")
+
+		out := `{"id":"postgres-test-branch","name":"postgres-test-branch","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z", "region": {"slug": "us-west", "display_name": "US West"}}`
+		_, err = w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+
+	branch, err := client.PostgresBranches.Create(ctx, &CreatePostgresBranchRequest{
+		Organization: "my-org",
+		Database:     "postgres-test-db",
+		Region:       "us-west",
+		Name:         testPostgresBranch,
+		ParentBranch: "main",
+		RestorePoint: "2023-01-01T00:00:00Z",
+	})
+
+	want := &PostgresBranch{
+		ID:   "postgres-test-branch",
+		Name: testPostgresBranch,
+		Region: Region{
+			Slug: "us-west",
+			Name: "US West",
+		},
+		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(branch, qt.DeepEquals, want)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds support for point-in-time recovery (PITR) when creating PostgreSQL branches.

The PlanetScale API accepts a `restore_point` timestamp on `create_branch`, but the CLI and vendored API client did not expose it. This change wires that field through both layers.

## Changes

- Add `RestorePoint` to `CreatePostgresBranchRequest` in the vendored API client (`internal/planetscale`)
- Add `--restore-point` flag to `pscale branch create` for PostgreSQL databases
- Default cluster size to `PS-10` when `--restore-point` is set (same behavior as backup restore)
- Reject `--restore-point` for MySQL databases
- Mark `--restore-point` as mutually exclusive with `--restore` and `--seed-data`
- Add unit tests for the CLI and API client

## Usage

```bash
pscale branch create <database> <branch> --from main --restore-point 2023-01-01T00:00:00Z
```

The `restore_point` field will be available in `planetscale-go` after the usual sync from this repository.

## Test plan

- [x] `go test ./internal/cmd/branch/... ./internal/planetscale/... -run 'Create.*RestorePoint|CreateCmdWithRestorePoint'`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://planetscale.slack.com/archives/C08EXKYAB96/p1787501044842779?thread_ts=1787501044.842779&cid=C08EXKYAB96)

<div><a href="https://cursor.com/agents/bc-bc2f905e-3a25-58b3-bb55-c381cc97cab6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc2f905e-3a25-58b3-bb55-c381cc97cab6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

