### PR TITLE
lookup-vindex: default continue-after-copy-with-owner to true, fix swapped keyspace help text

### DIFF
--- a/internal/cmd/branch/vtctld/lookup_vindex.go
+++ b/internal/cmd/branch/vtctld/lookup_vindex.go
@@ -81,9 +81,10 @@ func LookupVindexCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			if cmd.Flags().Changed("tablet-types-in-preference-order") {
 				req.TabletTypesInPreferenceOrder = &flags.tabletTypesInPreferenceOrder
 			}
-			if cmd.Flags().Changed("continue-after-copy-with-owner") {
-				req.ContinueAfterCopyWithOwner = &flags.continueAfterCopyWithOwner
-			}
+			// Always send this field: the server treats an absent value as
+			// false, which stops an owned vindex's backfill after the copy
+			// phase — the opposite of vtctldclient's default of true.
+			req.ContinueAfterCopyWithOwner = &flags.continueAfterCopyWithOwner
 
 			data, err := client.LookupVindex.Create(ctx, req)
 			if err != nil {
@@ -96,8 +97,8 @@ func LookupVindexCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the Lookup Vindex")
-	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace of the table to create the vindex on")
-	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the lookup table")
+	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace where the lookup table and its backfill workflow are created")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace of the owner table, where the lookup vindex is defined")
 	cmd.Flags().StringVar(&flags.vindexType, "type", "", "Type of the vindex")
 	cmd.Flags().StringSliceVar(&flags.cells, "cells", nil, "Cells to replicate from (comma-separated)")
 	cmd.Flags().StringSliceVar(&flags.tabletTypes, "tablet-types", nil, "Tablet types to replicate from (comma-separated)")
@@ -107,7 +108,7 @@ func LookupVindexCreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.tableVindexType, "table-vindex-type", "", "Vindex type on the owner table")
 	cmd.Flags().BoolVar(&flags.ignoreNulls, "ignore-nulls", false, "Ignore null values")
 	cmd.Flags().BoolVar(&flags.tabletTypesInPreferenceOrder, "tablet-types-in-preference-order", false, "Use tablet types in preference order")
-	cmd.Flags().BoolVar(&flags.continueAfterCopyWithOwner, "continue-after-copy-with-owner", false, "Continue after copy with owner")
+	cmd.Flags().BoolVar(&flags.continueAfterCopyWithOwner, "continue-after-copy-with-owner", true, "Keep the backfill workflow running after the copy phase when the vindex has an owner")
 	cmd.MarkFlagRequired("name")           // nolint:errcheck
 	cmd.MarkFlagRequired("table-keyspace") // nolint:errcheck
 
@@ -155,7 +156,7 @@ func LookupVindexShowCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the Lookup Vindex")
-	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace of the table")
+	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace where the lookup table and its workflow live")
 	cmd.MarkFlagRequired("name")           // nolint:errcheck
 	cmd.MarkFlagRequired("table-keyspace") // nolint:errcheck
 
@@ -212,8 +213,8 @@ func LookupVindexExternalizeCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the Lookup Vindex")
-	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace of the table")
-	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the lookup table")
+	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace where the lookup table and its workflow live")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace of the owner table, where the lookup vindex is defined")
 	cmd.Flags().BoolVar(&flags.delete, "delete", false, "Delete the workflow after externalizing")
 	cmd.MarkFlagRequired("name")           // nolint:errcheck
 	cmd.MarkFlagRequired("table-keyspace") // nolint:errcheck
@@ -264,8 +265,8 @@ func LookupVindexInternalizeCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the Lookup Vindex")
-	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace of the table")
-	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the lookup table")
+	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace where the lookup table and its workflow live")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace of the owner table, where the lookup vindex is defined")
 	cmd.MarkFlagRequired("name")           // nolint:errcheck
 	cmd.MarkFlagRequired("table-keyspace") // nolint:errcheck
 
@@ -313,7 +314,7 @@ func LookupVindexCancelCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the Lookup Vindex")
-	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace of the table")
+	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace where the lookup table and its workflow live")
 	cmd.MarkFlagRequired("name")           // nolint:errcheck
 	cmd.MarkFlagRequired("table-keyspace") // nolint:errcheck
 
@@ -363,8 +364,8 @@ func LookupVindexCompleteCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the Lookup Vindex")
-	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace of the table")
-	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the lookup table")
+	cmd.Flags().StringVar(&flags.tableKeyspace, "table-keyspace", "", "Keyspace where the lookup table and its workflow live")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace of the owner table, where the lookup vindex is defined")
 	cmd.MarkFlagRequired("name")           // nolint:errcheck
 	cmd.MarkFlagRequired("table-keyspace") // nolint:errcheck
 

--- a/internal/cmd/branch/vtctld/lookup_vindex_test.go
+++ b/internal/cmd/branch/vtctld/lookup_vindex_test.go
@@ -31,7 +31,11 @@ func TestLookupVindexCreate(t *testing.T) {
 			c.Assert(req.TableKeyspace, qt.Equals, "my-keyspace")
 			c.Assert(req.IgnoreNulls, qt.IsNil)
 			c.Assert(req.TabletTypesInPreferenceOrder, qt.IsNil)
-			c.Assert(req.ContinueAfterCopyWithOwner, qt.IsNil)
+			// Always sent, defaulting to true to match vtctldclient: an
+			// absent value is treated as false by the server, which would
+			// silently stop an owned backfill after the copy phase.
+			c.Assert(req.ContinueAfterCopyWithOwner, qt.IsNotNil)
+			c.Assert(*req.ContinueAfterCopyWithOwner, qt.IsTrue)
 			return json.RawMessage(`{"name":"my-vindex"}`), nil
 		},
 	}


### PR DESCRIPTION
## What

Two fixes to `pscale branch vtctld lookup-vindex`:

1. **Default `--continue-after-copy-with-owner` to `true` and always send the field.** Upstream `vtctldclient` defaults this option to true; the pscale CLI defaulted it to false and only included the field in the request when the flag was explicitly set — and the API treats an absent value as false. The two changes go together: flipping only the flag default would change nothing while the field was gated on `cmd.Flags().Changed(...)`. An explicit `--continue-after-copy-with-owner=false` still flows through as false.

2. **Correct the swapped `--keyspace` / `--table-keyspace` help text** across the lookup-vindex subcommands: `--keyspace` is the owner table's keyspace (where the vindex is defined in the VSchema); `--table-keyspace` is the keyspace where the lookup table and its workflow live. The previous descriptions had them the other way around.

## Why

With the old default, creating an **owned** lookup vindex without the flag stops the backfill workflow as soon as the copy phase finishes. From then on the lookup table is only maintained for writes that flow through vtgate — writes applied directly by VReplication (e.g. during an import into the keyspace) silently never reach it. Nothing errors; the gap only surfaces as wrong routing results after the vindex is externalized. Defaulting to true restores vtctldclient parity and removes the trap.

## Testing

- `TestLookupVindexCreate` now asserts the field is always sent and defaults to true.
- `TestLookupVindexCreateWithExplicitFalseBoolFlags` (unchanged) covers explicit `=false` still reaching the request as false.
- `go test ./internal/cmd/branch/vtctld/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
