### PR TITLE
Re-push sync commit so the approval agent runs

### DIFF
--- a/.github/workflows/sync-planetscale-go.yml
+++ b/.github/workflows/sync-planetscale-go.yml
@@ -91,14 +91,16 @@ jobs:
           source_sha=$(git -C ../cli rev-parse --short HEAD)
           branch="sync-cli-${source_sha}"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          # Set before the early exit: the re-push step amends a commit and so
+          # needs an identity on re-runs where the branch already exists.
+          git config user.name "planetscale-cli[bot]"
+          git config user.email "272331943+planetscale-cli[bot]@users.noreply.github.com"
           if git ls-remote --exit-code origin "refs/heads/$branch" > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "Branch $branch already exists, nothing to do"
             exit 0
           fi
           echo "exists=false" >> "$GITHUB_OUTPUT"
-          git config user.name "planetscale-cli[bot]"
-          git config user.email "272331943+planetscale-cli[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add -A
           git commit -m "Sync API client from planetscale/cli@${source_sha}"
@@ -149,14 +151,33 @@ jobs:
       # Cursor Approval Agent has never started from the "PR opened" event in
       # planetscale-go; every run there began within seconds of a push to an
       # already-open PR. Amending republishes the same tree under a new SHA so
-      # the push trigger fires. The amend can land in the same second as the
-      # original commit and produce an identical SHA, so retry until it differs.
+      # the push trigger fires. This works from the remote branch tip rather
+      # than the local HEAD, so re-runs where the branch already exists (and the
+      # commit step exited early) still emit a push.
       - name: Re-push sync commit to trigger review automation
-        if: steps.changes.outputs.changed == 'true' && steps.commit.outputs.exists == 'false'
+        if: steps.changes.outputs.changed == 'true'
         working-directory: planetscale-go
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           branch="${{ steps.commit.outputs.branch }}"
-          before=$(git rev-parse HEAD)
+          pr_json=$(gh pr view --repo planetscale/planetscale-go "$branch" \
+            --json state,reviews 2>/dev/null || echo '{}')
+          state=$(printf '%s' "$pr_json" | jq -r '.state // "NONE"')
+          if [ "$state" != "OPEN" ]; then
+            echo "PR for $branch is $state; nothing to re-push"
+            exit 0
+          fi
+          approvals=$(printf '%s' "$pr_json" | jq '[(.reviews // [])[] | select(.state == "APPROVED")] | length')
+          if [ "$approvals" -gt 0 ]; then
+            echo "PR for $branch is already approved; nothing to re-push"
+            exit 0
+          fi
+          git fetch origin "$branch"
+          before=$(git rev-parse FETCH_HEAD)
+          git checkout -f -B "$branch" "$before"
+          # An amend landing in the same second as the original commit yields an
+          # identical SHA, which would make the push a no-op.
           for _ in 1 2 3; do
             git commit --amend --no-edit --date=now
             if [ "$(git rev-parse HEAD)" != "$before" ]; then

--- a/.github/workflows/sync-planetscale-go.yml
+++ b/.github/workflows/sync-planetscale-go.yml
@@ -146,12 +146,11 @@ jobs:
             --title "Sync API client from cli@${source_sha}" \
             --body-file /tmp/pr-body.md
 
-      # Cursor Approval Agent never runs on the "PR opened" event here: the
-      # author is planetscale-cli[bot] and the dashboard's user filter does not
-      # match bot accounts. Its "PR pushed" trigger does match, so amend the
-      # commit to republish the same tree under a new SHA. The amend can land in
-      # the same second as the original commit and produce an identical SHA, so
-      # retry until it differs.
+      # Cursor Approval Agent has never started from the "PR opened" event in
+      # planetscale-go; every run there began within seconds of a push to an
+      # already-open PR. Amending republishes the same tree under a new SHA so
+      # the push trigger fires. The amend can land in the same second as the
+      # original commit and produce an identical SHA, so retry until it differs.
       - name: Re-push sync commit to trigger review automation
         if: steps.changes.outputs.changed == 'true' && steps.commit.outputs.exists == 'false'
         working-directory: planetscale-go

--- a/.github/workflows/sync-planetscale-go.yml
+++ b/.github/workflows/sync-planetscale-go.yml
@@ -146,6 +146,31 @@ jobs:
             --title "Sync API client from cli@${source_sha}" \
             --body-file /tmp/pr-body.md
 
+      # Cursor Approval Agent never runs on the "PR opened" event here: the
+      # author is planetscale-cli[bot] and the dashboard's user filter does not
+      # match bot accounts. Its "PR pushed" trigger does match, so amend the
+      # commit to republish the same tree under a new SHA. The amend can land in
+      # the same second as the original commit and produce an identical SHA, so
+      # retry until it differs.
+      - name: Re-push sync commit to trigger review automation
+        if: steps.changes.outputs.changed == 'true' && steps.commit.outputs.exists == 'false'
+        working-directory: planetscale-go
+        run: |
+          branch="${{ steps.commit.outputs.branch }}"
+          before=$(git rev-parse HEAD)
+          for _ in 1 2 3; do
+            git commit --amend --no-edit --date=now
+            if [ "$(git rev-parse HEAD)" != "$before" ]; then
+              break
+            fi
+            sleep 1
+          done
+          if [ "$(git rev-parse HEAD)" = "$before" ]; then
+            echo "Could not produce a new commit SHA; the approval agent may not run"
+            exit 0
+          fi
+          git push --force-with-lease="$branch:$before" origin "$branch"
+
       # Runs for both newly created sync PRs and re-runs where the branch
       # already exists (e.g. create succeeded but enabling auto-merge failed).
       - name: Enable auto-merge


### PR DESCRIPTION
Sync PRs in planetscale-go sit unapproved because Cursor Approval Agent never starts from the "PR opened" event there. Every run it has ever done in that repo started 4-6 seconds after a push to an already-open PR (#338, #339, #347, #348); the seven bot-authored PRs with no post-open push (#340-#346) got no run at all. Amending the sync commit after creating the PR republishes the same tree under a new SHA, which fires the push trigger.

Verified on planetscale/planetscale-go#348, open and unapproved since 14:06. A push at 16:38:43 started the agent at 16:38:47, it approved at 16:39:55, and auto-merge merged it at 16:40:21.

Why the opened event does not fire is still unknown — it did not fire for a human-authored PR either (#339), and Cursor's docs do not document a per-author trigger filter. This works around it rather than fixing it.