### PR TITLE
Resolve backup for Postgres PITR restore-point in branch create

### DIFF
--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -72,6 +72,10 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 			source := args[0]
 			branch := args[1]
 
+			if flags.backupID != "" && flags.parentBranch != "" && flags.restorePoint == "" {
+				return fmt.Errorf("--from and --restore cannot be used together")
+			}
+
 			client, err := ch.Client()
 			if err != nil {
 				return err
@@ -179,6 +183,20 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				return ch.Printer.PrintResource(ToDatabaseBranch(dbBranch))
 			} else {
+				if flags.restorePoint != "" {
+					if flags.parentBranch == "" {
+						return fmt.Errorf("--from is required when using --restore-point")
+					}
+
+					if flags.backupID == "" {
+						backupID, err := cmdutil.BackupIDForRestorePoint(ctx, client, ch.Config.Organization, source, flags.parentBranch, flags.restorePoint)
+						if err != nil {
+							return err
+						}
+						flags.backupID = backupID
+					}
+				}
+
 				createReq := &ps.CreatePostgresBranchRequest{
 					Organization: ch.Config.Organization,
 					Database:     source,
@@ -248,10 +266,10 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore")
+	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Required with --restore-point. Cannot be used with --restore unless --restore-point is also set.")
 	cmd.Flags().StringVar(&flags.region, "region", "", "Region for the branch to be created in.")
 	cmd.Flags().StringVar(&flags.backupID, "restore", "", "ID of Backup to restore into branch.")
-	cmd.Flags().StringVar(&flags.restorePoint, "restore-point", "", "For PostgreSQL databases, restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z).")
+	cmd.Flags().StringVar(&flags.restorePoint, "restore-point", "", "For PostgreSQL databases, restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z). Requires --from. The CLI selects a backup at or before the restore point and sends it with the restore point to the API.")
 	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "", "Cluster size for the branch. Defaults to PS_DEV for regular branches, or PS-10 for branches created from a backup or with seed-data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")
@@ -259,9 +277,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().Int64Var(&flags.minStorage, "min-storage", 0, "Minimum storage size in bytes")
 	cmd.Flags().Int64Var(&flags.maxStorage, "max-storage", 0, "Maximum storage size in bytes for autoscaling")
 
-	cmd.MarkFlagsMutuallyExclusive("from", "restore")
 	cmd.MarkFlagsMutuallyExclusive("restore", "seed-data")
-	cmd.MarkFlagsMutuallyExclusive("restore", "restore-point")
 	cmd.MarkFlagsMutuallyExclusive("restore-point", "seed-data")
 
 	cmd.RegisterFlagCompletionFunc("region", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/branch/create.go
+++ b/internal/cmd/branch/create.go
@@ -184,11 +184,11 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 				return ch.Printer.PrintResource(ToDatabaseBranch(dbBranch))
 			} else {
 				if flags.restorePoint != "" {
-					if flags.parentBranch == "" {
-						return fmt.Errorf("--from is required when using --restore-point")
-					}
-
 					if flags.backupID == "" {
+						if flags.parentBranch == "" {
+							return fmt.Errorf("--from is required when using --restore-point without --restore")
+						}
+
 						backupID, err := cmdutil.BackupIDForRestorePoint(ctx, client, ch.Config.Organization, source, flags.parentBranch, flags.restorePoint)
 						if err != nil {
 							return err
@@ -266,10 +266,10 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Required with --restore-point. Cannot be used with --restore unless --restore-point is also set.")
+	cmd.Flags().StringVar(&flags.parentBranch, "from", "", "Parent branch to create the new branch from. Cannot be used with --restore unless --restore-point is set.")
 	cmd.Flags().StringVar(&flags.region, "region", "", "Region for the branch to be created in.")
 	cmd.Flags().StringVar(&flags.backupID, "restore", "", "ID of Backup to restore into branch.")
-	cmd.Flags().StringVar(&flags.restorePoint, "restore-point", "", "For PostgreSQL databases, restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z). Requires --from. The CLI selects a backup at or before the restore point and sends it with the restore point to the API.")
+	cmd.Flags().StringVar(&flags.restorePoint, "restore-point", "", "For PostgreSQL databases, restore from a point-in-time recovery timestamp (e.g. 2023-01-01T00:00:00Z). Requires --restore or --from.")
 	cmd.Flags().StringVar(&flags.clusterSize, "cluster-size", "", "Cluster size for the branch. Defaults to PS_DEV for regular branches, or PS-10 for branches created from a backup or with seed-data. Use 'pscale size cluster list' to see the valid sizes.")
 	cmd.Flags().BoolVar(&flags.dataBranching, "seed-data", false, "Add seed data using the Data Branching™ feature. This branch will be created with the same resources as the base branch.")
 	cmd.Flags().BoolVar(&flags.wait, "wait", false, "Wait until the branch is ready")

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
@@ -746,9 +747,27 @@ func TestBranch_CreateCmdWithRestorePoint(t *testing.T) {
 	org := "planetscale"
 	db := "planetscale"
 	branch := "development"
+	parentBranch := "main"
 	restorePoint := "2023-01-01T00:00:00Z"
+	backupID := "backup-id"
 
 	res := &ps.PostgresBranch{Name: branch}
+
+	backupSvc := &mock.BackupsService{
+		ListFn: func(ctx context.Context, req *ps.ListBackupsRequest) ([]*ps.Backup, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, parentBranch)
+			c.Assert(req.State, qt.Equals, "success")
+			c.Assert(req.To, qt.Equals, "2023-01-01T00:00:59.999Z")
+
+			return []*ps.Backup{{
+				PublicID:    backupID,
+				State:       "success",
+				CompletedAt: time.Date(2022, time.December, 31, 23, 0, 0, 0, time.UTC),
+			}}, nil
+		},
+	}
 
 	svc := &mock.PostgresBranchesService{
 		CreateFn: func(ctx context.Context, req *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
@@ -757,7 +776,8 @@ func TestBranch_CreateCmdWithRestorePoint(t *testing.T) {
 			c.Assert(req.Region, qt.Equals, "us-east")
 			c.Assert(req.Organization, qt.Equals, org)
 			c.Assert(req.RestorePoint, qt.Equals, restorePoint)
-			c.Assert(req.ParentBranch, qt.Equals, "main")
+			c.Assert(req.ParentBranch, qt.Equals, parentBranch)
+			c.Assert(req.BackupID, qt.Equals, backupID)
 			c.Assert(req.ClusterName, qt.Equals, "PS-10")
 
 			return res, nil
@@ -781,17 +801,103 @@ func TestBranch_CreateCmdWithRestorePoint(t *testing.T) {
 			return &ps.Client{
 				PostgresBranches: svc,
 				Databases:        dbSvc,
+				Backups:          backupSvc,
 			}, nil
 		},
 	}
 
 	cmd := CreateCmd(ch)
-	cmd.SetArgs([]string{db, branch, "--region", "us-east", "--from", "main", "--restore-point", restorePoint})
+	cmd.SetArgs([]string{db, branch, "--region", "us-east", "--from", parentBranch, "--restore-point", restorePoint})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
+	c.Assert(backupSvc.ListFnInvoked, qt.IsTrue)
 	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranch_CreateCmdWithRestorePointRequiresFrom(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "postgresql"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: dbSvc}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "development", "--restore-point", "2023-01-01T00:00:00Z"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, ".*--from is required.*")
+}
+
+func TestBranch_CreateCmdWithRestoreAndRestorePoint(t *testing.T) {
+	c := qt.New(t)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	parentBranch := "main"
+	restorePoint := "2023-01-01T00:00:00Z"
+	backupID := "explicit-backup"
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.PostgresBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req.RestorePoint, qt.Equals, restorePoint)
+			c.Assert(req.ParentBranch, qt.Equals, parentBranch)
+			c.Assert(req.BackupID, qt.Equals, backupID)
+
+			return &ps.PostgresBranch{Name: branch}, nil
+		},
+	}
+
+	backupSvc := &mock.BackupsService{
+		ListFn: func(ctx context.Context, req *ps.ListBackupsRequest) ([]*ps.Backup, error) {
+			c.Fatal("List should not be called when --restore is provided with --restore-point")
+			return nil, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "postgresql"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
+				Backups:          backupSvc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--from", parentBranch, "--restore", backupID, "--restore-point", restorePoint})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(backupSvc.ListFnInvoked, qt.IsFalse)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
 }
 
 func TestBranch_CreateCmdWithRestorePointMySQLError(t *testing.T) {

--- a/internal/cmd/branch/create_test.go
+++ b/internal/cmd/branch/create_test.go
@@ -840,7 +840,7 @@ func TestBranch_CreateCmdWithRestorePointRequiresFrom(t *testing.T) {
 	cmd.SetArgs([]string{"planetscale", "development", "--restore-point", "2023-01-01T00:00:00Z"})
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, ".*--from is required.*")
+	c.Assert(err, qt.ErrorMatches, ".*--from is required when using --restore-point without --restore.*")
 }
 
 func TestBranch_CreateCmdWithRestoreAndRestorePoint(t *testing.T) {
@@ -893,6 +893,62 @@ func TestBranch_CreateCmdWithRestoreAndRestorePoint(t *testing.T) {
 
 	cmd := CreateCmd(ch)
 	cmd.SetArgs([]string{db, branch, "--from", parentBranch, "--restore", backupID, "--restore-point", restorePoint})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(backupSvc.ListFnInvoked, qt.IsFalse)
+	c.Assert(svc.CreateFnInvoked, qt.IsTrue)
+}
+
+func TestBranch_CreateCmdWithRestoreAndRestorePointWithoutFrom(t *testing.T) {
+	c := qt.New(t)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	restorePoint := "2023-01-01T00:00:00Z"
+	backupID := "explicit-backup"
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.PostgresBranchesService{
+		CreateFn: func(ctx context.Context, req *ps.CreatePostgresBranchRequest) (*ps.PostgresBranch, error) {
+			c.Assert(req.RestorePoint, qt.Equals, restorePoint)
+			c.Assert(req.ParentBranch, qt.Equals, "")
+			c.Assert(req.BackupID, qt.Equals, backupID)
+
+			return &ps.PostgresBranch{Name: branch}, nil
+		},
+	}
+
+	backupSvc := &mock.BackupsService{
+		ListFn: func(ctx context.Context, req *ps.ListBackupsRequest) ([]*ps.Backup, error) {
+			c.Fatal("List should not be called when --restore is provided with --restore-point")
+			return nil, nil
+		},
+	}
+
+	dbSvc := &mock.DatabaseService{
+		GetFn: func(ctx context.Context, req *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Kind: "postgresql"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				PostgresBranches: svc,
+				Databases:        dbSvc,
+				Backups:          backupSvc,
+			}, nil
+		},
+	}
+
+	cmd := CreateCmd(ch)
+	cmd.SetArgs([]string{db, branch, "--restore", backupID, "--restore-point", restorePoint})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)

--- a/internal/cmdutil/backups.go
+++ b/internal/cmdutil/backups.go
@@ -1,0 +1,60 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+func BackupForRestorePoint(backups []*ps.Backup, restorePoint time.Time) *ps.Backup {
+	target := restorePoint.UnixMilli()
+	var selected *ps.Backup
+
+	for _, backup := range backups {
+		if backup.State != "success" || backup.CompletedAt.IsZero() {
+			continue
+		}
+
+		completed := backup.CompletedAt.UnixMilli()
+		if completed > target {
+			continue
+		}
+
+		if selected != nil && !selected.CompletedAt.IsZero() && selected.CompletedAt.UnixMilli() >= completed {
+			continue
+		}
+
+		selected = backup
+	}
+
+	return selected
+}
+
+func BackupIDForRestorePoint(ctx context.Context, client *ps.Client, org, database, branch, restorePoint string) (string, error) {
+	restoreTime, err := time.Parse(time.RFC3339, restorePoint)
+	if err != nil {
+		return "", fmt.Errorf("invalid --restore-point timestamp %q: use RFC3339 format (e.g. 2023-01-01T00:00:00Z)", restorePoint)
+	}
+
+	restoreUTC := restoreTime.UTC()
+	to := time.Date(restoreUTC.Year(), restoreUTC.Month(), restoreUTC.Day(), restoreUTC.Hour(), restoreUTC.Minute(), 59, 999000000, time.UTC)
+	backups, err := client.Backups.List(ctx, &ps.ListBackupsRequest{
+		Organization: org,
+		Database:     database,
+		Branch:       branch,
+		To:           to.Format("2006-01-02T15:04:05.999Z"),
+		State:        "success",
+	})
+	if err != nil {
+		return "", HandleError(err)
+	}
+
+	backup := BackupForRestorePoint(backups, restoreTime)
+	if backup == nil {
+		return "", fmt.Errorf("no successful backup found for restore point %s on branch %s", restorePoint, branch)
+	}
+
+	return backup.PublicID, nil
+}

--- a/internal/cmdutil/backups_test.go
+++ b/internal/cmdutil/backups_test.go
@@ -1,0 +1,57 @@
+package cmdutil
+
+import (
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+func TestBackupForRestorePoint(t *testing.T) {
+	c := qt.New(t)
+
+	restorePoint := time.Date(2026, 8, 24, 12, 14, 49, 0, time.UTC)
+	backups := []*ps.Backup{
+		{
+			PublicID:    "too-new",
+			State:       "success",
+			CompletedAt: time.Date(2026, 8, 24, 12, 15, 0, 0, time.UTC),
+		},
+		{
+			PublicID:    "selected",
+			State:       "success",
+			CompletedAt: time.Date(2026, 8, 24, 12, 10, 0, 0, time.UTC),
+		},
+		{
+			PublicID:    "older",
+			State:       "success",
+			CompletedAt: time.Date(2026, 8, 24, 11, 0, 0, 0, time.UTC),
+		},
+		{
+			PublicID:    "pending",
+			State:       "pending",
+			CompletedAt: time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	backup := BackupForRestorePoint(backups, restorePoint)
+	c.Assert(backup, qt.IsNotNil)
+	c.Assert(backup.PublicID, qt.Equals, "selected")
+}
+
+func TestBackupForRestorePoint_NoMatch(t *testing.T) {
+	c := qt.New(t)
+
+	restorePoint := time.Date(2026, 8, 24, 12, 14, 49, 0, time.UTC)
+	backups := []*ps.Backup{
+		{
+			PublicID:    "too-new",
+			State:       "success",
+			CompletedAt: time.Date(2026, 8, 24, 12, 15, 0, 0, time.UTC),
+		},
+	}
+
+	backup := BackupForRestorePoint(backups, restorePoint)
+	c.Assert(backup, qt.IsNil)
+}

--- a/internal/planetscale/backups.go
+++ b/internal/planetscale/backups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 	"time"
 )
@@ -40,6 +41,8 @@ type ListBackupsRequest struct {
 	Organization string
 	Database     string
 	Branch       string
+	To           string
+	State        string
 }
 
 type GetBackupRequest struct {
@@ -111,7 +114,20 @@ func (d *backupsService) Get(ctx context.Context, getReq *GetBackupRequest) (*Ba
 
 // Returns all of the backups for a branch.
 func (d *backupsService) List(ctx context.Context, listReq *ListBackupsRequest) ([]*Backup, error) {
-	req, err := d.client.newRequest(http.MethodGet, backupsAPIPath(listReq.Organization, listReq.Database, listReq.Branch), nil)
+	query := url.Values{}
+	if listReq.To != "" {
+		query.Set("to", listReq.To)
+	}
+	if listReq.State != "" {
+		query.Set("state", listReq.State)
+	}
+
+	var opts []RequestOption
+	if len(query) > 0 {
+		opts = append(opts, WithQueryParams(query))
+	}
+
+	req, err := d.client.newRequest(http.MethodGet, backupsAPIPath(listReq.Organization, listReq.Database, listReq.Branch), nil, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/internal/planetscale/backups_test.go
+++ b/internal/planetscale/backups_test.go
@@ -51,6 +51,8 @@ func TestBackups_List(t *testing.T) {
 	c := qt.New(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Query().Get("to"), qt.Equals, "2023-01-01T00:00:59.999Z")
+		c.Assert(r.URL.Query().Get("state"), qt.Equals, "success")
 		w.WriteHeader(200)
 		out := `{"data":[{"id":"planetscale-go-test-backup","type":"backup","name":"planetscale-go-test-backup","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}]}`
 		_, err := w.Write([]byte(out))
@@ -69,6 +71,8 @@ func TestBackups_List(t *testing.T) {
 		Organization: org,
 		Database:     db,
 		Branch:       branch,
+		To:           "2023-01-01T00:00:59.999Z",
+		State:        "success",
 	})
 
 	want := []*Backup{{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Postgres point-in-time recovery via `pscale branch create --restore-point` now matches the dashboard behavior: the CLI resolves a successful backup on the parent branch at or before the requested timestamp and sends both `backup_id` and `restore_point` to the API.

## Changes

- When `--restore-point` is used with `--from`, list successful backups up to the restore timestamp and pick the latest completed backup at or before that time.
- Require `--from` with `--restore-point`.
- Allow `--from` together with `--restore` when `--restore-point` is also set (for explicit backup + PITR).
- Extend backup list API client support with `to` and `state` query parameters.

## Test plan

- [x] `go test ./internal/cmdutil/... ./internal/planetscale/... ./internal/cmd/branch/... -run 'RestorePoint|BackupFor'`
- [x] `go test ./internal/cmdutil/... ./internal/planetscale/... ./internal/cmd/branch/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcfce7d2-f315-54fd-a197-af33f0044229?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcfce7d2-f315-54fd-a197-af33f0044229&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

