### PR TITLE
Add pscale insights recommendations show

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,7 @@ pscale insights anomalies show <database> <branch> <id> --org <org> --format jso
 pscale insights tags <database> <branch> --org <org> --format json                       # query tag keys (sqlcommenter / system); use names with summaries
 pscale insights tags summaries <database> <branch> --org <org> --format json --tags username  # stats grouped by tag; names match the Insights UI Key picker
 pscale insights recommendations <database> --org <org> --format json                     # schema recommendations with ready-to-apply DDL
+pscale insights recommendations show <database> <number> --org <org> --format json        # one recommendation plus full DDL (number from list)
 pscale insights recommendations dismiss <database> <number> --org <org> --format json --force  # dismiss a recommendation
 pscale branch query-patterns list <database> <branch> --org <org> --format json
 pscale branch query-patterns show <database> <branch> <report-id> --org <org> --format json

--- a/internal/cmd/insights/recommendation_show.go
+++ b/internal/cmd/insights/recommendation_show.go
@@ -1,0 +1,102 @@
+package insights
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+type RecommendationDetailRow struct {
+	Number   int    `header:"number" json:"number"`
+	State    string `header:"state" json:"state"`
+	Type     string `header:"type" json:"recommendation_type"`
+	Table    string `header:"table" json:"table_name"`
+	Keyspace string `header:"keyspace" json:"keyspace,omitempty"`
+	Title    string `header:"title" json:"title"`
+	DDL      string `header:"ddl" json:"ddl_statement"`
+	URL      string `header:"url" json:"html_url,omitempty"`
+}
+
+func RecommendationShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <database> <number>",
+		Short: "Show a schema recommendation and its DDL",
+		Long: `Show a single schema recommendation, including the full ready-to-apply DDL.
+
+<number> is the recommendation sequence number from
+'pscale insights recommendations <database>', the same value used by
+'pscale insights recommendations dismiss'.`,
+		Example: `  pscale insights recommendations show mydb 1 --org myorg
+  pscale insights recommendations show mydb 1 --org myorg --format json`,
+		Args: cmdutil.RequiredArgs("database", "number"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database := args[0]
+			number := args[1]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching schema recommendation %s for %s...",
+				printer.BoldBlue(number), printer.BoldBlue(database)))
+			defer end()
+
+			recommendation, err := client.SchemaRecommendations.Get(ctx, &ps.GetSchemaRecommendationRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				ID:           number,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("schema recommendation %s does not exist in database %s (organization: %s)",
+						printer.BoldBlue(number), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(recommendation)
+			}
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Number:    %d\n", recommendation.Number)
+				ch.Printer.Printf("State:     %s\n", recommendation.State)
+				ch.Printer.Printf("Type:      %s\n", recommendation.RecommendationType)
+				ch.Printer.Printf("Table:     %s\n", recommendation.Table)
+				if recommendation.Keyspace != "" {
+					ch.Printer.Printf("Keyspace:  %s\n", recommendation.Keyspace)
+				}
+				ch.Printer.Printf("Title:     %s\n", recommendation.Title)
+				if recommendation.HtmlURL != "" {
+					ch.Printer.Printf("URL:       %s\n", recommendation.HtmlURL)
+				}
+				if recommendation.DDLStatement != "" {
+					ch.Printer.Printf("\n%s\n%s\n", printer.Bold("DDL:"), recommendation.DDLStatement)
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource([]*RecommendationDetailRow{{
+				Number:   recommendation.Number,
+				State:    recommendation.State,
+				Type:     recommendation.RecommendationType,
+				Table:    recommendation.Table,
+				Keyspace: recommendation.Keyspace,
+				Title:    recommendation.Title,
+				DDL:      recommendation.DDLStatement,
+				URL:      recommendation.HtmlURL,
+			}})
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/insights/recommendation_show_test.go
+++ b/internal/cmd/insights/recommendation_show_test.go
@@ -1,0 +1,118 @@
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestInsights_RecommendationShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.SchemaRecommendationService{
+		GetFn: func(ctx context.Context, req *ps.GetSchemaRecommendationRequest) (*ps.SchemaRecommendation, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.ID, qt.Equals, "42")
+			return &ps.SchemaRecommendation{
+				ID:                 "rec-42",
+				Number:             42,
+				State:              "open",
+				RecommendationType: "unused_index",
+				Table:              "users",
+				Keyspace:           "main",
+				Title:              "Drop unused index idx_email",
+				DDLStatement:       "ALTER TABLE users DROP INDEX idx_email",
+				HtmlURL:            "https://app.planetscale.com/planetscale/mydb/insights/recommendations/42",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{SchemaRecommendations: svc})
+
+	cmd := RecommendationShowCmd(ch)
+	cmd.SetArgs([]string{"mydb", "42"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+
+	var out map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out["number"], qt.Equals, float64(42))
+	c.Assert(out["ddl_statement"], qt.Equals, "ALTER TABLE users DROP INDEX idx_email")
+	c.Assert(out["title"], qt.Equals, "Drop unused index idx_email")
+}
+
+func TestInsights_RecommendationShowCmd_HumanIncludesFullDDL(t *testing.T) {
+	c := qt.New(t)
+
+	ddl := "ALTER TABLE users DROP INDEX idx_email, DROP INDEX idx_email_dup"
+	svc := &mock.SchemaRecommendationService{
+		GetFn: func(ctx context.Context, req *ps.GetSchemaRecommendationRequest) (*ps.SchemaRecommendation, error) {
+			c.Assert(req.ID, qt.Equals, "1")
+			return &ps.SchemaRecommendation{
+				Number:             1,
+				State:              "open",
+				RecommendationType: "duplicate_index",
+				Table:              "users",
+				Keyspace:           "main",
+				Title:              "Drop duplicate index",
+				DDLStatement:       ddl,
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.Human, &ps.Client{SchemaRecommendations: svc})
+	ch.Printer.SetHumanOutput(&buf)
+
+	cmd := RecommendationShowCmd(ch)
+	cmd.SetArgs([]string{"mydb", "1"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, ddl)
+	c.Assert(buf.String(), qt.Contains, "duplicate_index")
+}
+
+func TestInsights_RecommendationShowCmd_NotFound(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.SchemaRecommendationService{
+		GetFn: func(ctx context.Context, req *ps.GetSchemaRecommendationRequest) (*ps.SchemaRecommendation, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{SchemaRecommendations: svc})
+
+	cmd := RecommendationShowCmd(ch)
+	cmd.SetArgs([]string{"mydb", "99"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "does not exist")
+	c.Assert(err.Error(), qt.Contains, "99")
+}
+
+func TestInsights_RecommendationsCmd_HasShowSubcommand(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{})
+
+	cmd, _, err := RecommendationsCmd(ch).Find([]string{"show"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(cmd.Name(), qt.Equals, "show")
+}

--- a/internal/cmd/insights/recommendations.go
+++ b/internal/cmd/insights/recommendations.go
@@ -30,7 +30,8 @@ indexes, duplicate indexes, bloated tables and indexes, missing indexes
 derived from production query patterns, and sequence overflow risks. Each
 recommendation includes ready-to-apply DDL (shown with --format json).
 
-Use "pscale insights recommendations dismiss" to dismiss a recommendation.`,
+Use "pscale insights recommendations show" to print a recommendation and its
+full DDL. Use "pscale insights recommendations dismiss" to dismiss one.`,
 		Aliases: []string{"recommendation"},
 		Args:    cmdutil.RequiredArgs("database"),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -80,6 +81,7 @@ Use "pscale insights recommendations dismiss" to dismiss a recommendation.`,
 		},
 	}
 
+	cmd.AddCommand(RecommendationShowCmd(ch))
 	cmd.AddCommand(RecommendationDismissCmd(ch))
 
 	return cmd

--- a/internal/planetscale/schema_recommendations_test.go
+++ b/internal/planetscale/schema_recommendations_test.go
@@ -116,7 +116,7 @@ func TestSchemaRecommendations_Get(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		c.Assert(r.Method, qt.Equals, http.MethodGet)
-		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/schema-recommendations/recommendation-123")
+		c.Assert(r.URL.String(), qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/schema-recommendations/1")
 
 		out := `{
 			"id": "recommendation-123",
@@ -143,11 +143,12 @@ func TestSchemaRecommendations_Get(t *testing.T) {
 	recommendation, err := client.SchemaRecommendations.Get(ctx, &GetSchemaRecommendationRequest{
 		Organization: testOrg,
 		Database:     testDatabase,
-		ID:           "recommendation-123",
+		ID:           "1",
 	})
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(recommendation.ID, qt.Equals, "recommendation-123")
+	c.Assert(recommendation.Number, qt.Equals, 1)
 	c.Assert(recommendation.Title, qt.Equals, "Add index on users.email")
 	c.Assert(recommendation.DDLStatement, qt.Equals, "ALTER TABLE users ADD INDEX idx_email (email)")
 	c.Assert(recommendation.State, qt.Equals, "open")


### PR DESCRIPTION
## Summary
- Adds `pscale insights recommendations show <database> <number>` wrapping the existing schema-recommendation Get client method.
- Uses the same sequence-number path parameter as dismiss (and the public API), with JSON dumping the full object and human/CSV output including full DDL.
- Documents the command next to list/dismiss in AGENTS.md and aligns the Get client test with number semantics.

## Test plan
- [x] `go test ./internal/cmd/insights/ ./internal/planetscale/ -run 'TestInsights_Recommendation|TestInsights_Recommendations|TestSchemaRecommendations'`
- [x] `go test ./...`
- [x] `gofmt` on changed files; `staticcheck` and `go vet` on `./internal/cmd/insights/` and `./internal/planetscale/`
- [ ] `pscale insights recommendations show <database> <number> --org <org> --format json` returns the same `number` used by list/dismiss and includes `ddl_statement`