### PR TITLE
Add Insights query show and summary commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,8 @@ Two complementary read-only surfaces. When diagnosing database health or perform
 ```bash
 pscale insights queries <database> <branch> --org <org> --format json --sort totalTime   # top queries; sorts: totalTime, count, p99Latency, rowsRead, rowsReadPerReturned, errorCount, ...
 pscale insights queries samples <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # recent executions; keyspace from queries list
+pscale insights queries show <database> <branch> <query-id> --org <org> --format json     # one execution; query-id comes from the samples list
+pscale insights queries summary <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # aggregate stats for one query pattern
 pscale insights errors <database> <branch> --org <org> --format json                     # failing queries with error messages
 pscale insights errors show <database> <branch> <fingerprint> --org <org> --format json  # individual queries behind one error fingerprint (use error_fingerprint from the errors list)
 pscale insights anomalies <database> <branch> --org <org> --format json                  # detected resource anomalies (CPU, memory, IOPS, rows)
@@ -274,6 +276,8 @@ pscale branch query-patterns list <database> <branch> --org <org> --format json
 pscale branch query-patterns show <database> <branch> <report-id> --org <org> --format json
 pscale branch query-patterns delete <database> <branch> <report-id> --org <org> --format json --force
 ```
+
+`queries show` takes an individual execution/sample `id`; `queries samples` and `queries summary` take a query `fingerprint`. These identifiers are not interchangeable. `queries summary` requires the keyspace from the queries list and accepts `--period`, or a paired `--from`/`--to` ISO 8601 range.
 
 `branch query-patterns download` generates a new report, waits, and writes CSV. Use list/show/delete for reports that already exist.
 

--- a/internal/cmd/insights/queries.go
+++ b/internal/cmd/insights/queries.go
@@ -120,6 +120,8 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 1d)")
 
 	cmd.AddCommand(QuerySamplesCmd(ch))
+	cmd.AddCommand(QueryShowCmd(ch))
+	cmd.AddCommand(QuerySummaryCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/insights/queries_test.go
+++ b/internal/cmd/insights/queries_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net/url"
 	"testing"
 	"time"
 
@@ -76,6 +77,19 @@ func TestInsights_QueriesCmd_InvalidSort(t *testing.T) {
 
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, `invalid --sort "bogus"`)
+}
+
+func TestInsights_QueriesCmd_RegistersShowAndSummary(t *testing.T) {
+	c := qt.New(t)
+	cmd := QueriesCmd(testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{}))
+
+	show, _, err := cmd.Find([]string{"show"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(show.Name(), qt.Equals, "show")
+
+	summary, _, err := cmd.Find([]string{"summary"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(summary.Name(), qt.Equals, "summary")
 }
 
 func TestInsights_ErrorsCmd(t *testing.T) {
@@ -269,6 +283,195 @@ func TestInsights_QuerySamplesCmd_RequiresKeyspace(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "keyspace")
 	c.Assert(svc.ListQuerySamplesFnInvoked, qt.IsFalse)
+}
+
+func TestInsights_QueryShowCmd(t *testing.T) {
+	c := qt.New(t)
+	startedAt := time.Date(2026, 8, 25, 18, 0, 0, 0, time.UTC)
+
+	svc := &mock.QueryInsightsService{
+		GetQueryFn: func(ctx context.Context, req *ps.GetQueryRequest) (*ps.Query, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.Branch, qt.Equals, "main")
+			c.Assert(req.QueryID, qt.Equals, "exec-1")
+			return &ps.Query{
+				ID:                  "exec-1",
+				Fingerprint:         "b129e8fa",
+				StartedAt:           &startedAt,
+				StatementType:       "SELECT",
+				Keyspace:            "mydb",
+				Username:            "app",
+				RowsRead:            2,
+				RowsReturned:        1,
+				TotalDurationMillis: 2.5,
+				NormalizedSQL:       "select * from users where id = ?",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := QueryShowCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "exec-1"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetQueryFnInvoked, qt.IsTrue)
+
+	var out map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out["id"], qt.Equals, "exec-1")
+	c.Assert(out["fingerprint"], qt.Equals, "b129e8fa")
+}
+
+func TestInsights_QueryShowCmd_Human(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{
+		GetQueryFn: func(ctx context.Context, req *ps.GetQueryRequest) (*ps.Query, error) {
+			return &ps.Query{
+				ID:            "exec-1",
+				Fingerprint:   "b129e8fa",
+				StatementType: "SELECT",
+				Keyspace:      "mydb",
+				NormalizedSQL: "select 1",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.Human, &ps.Client{QueryInsights: svc})
+
+	cmd := QueryShowCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "exec-1"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "exec-1")
+	c.Assert(buf.String(), qt.Contains, "b129e8fa")
+	c.Assert(buf.String(), qt.Contains, "select 1")
+}
+
+func TestInsights_QuerySummaryCmd(t *testing.T) {
+	c := qt.New(t)
+	lastRunAt := time.Date(2026, 8, 25, 18, 0, 0, 0, time.UTC)
+
+	svc := &mock.QueryInsightsService{
+		GetQuerySummaryFn: func(ctx context.Context, req *ps.GetQuerySummaryRequest, opts ...ps.ListOption) (*ps.QuerySummary, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.Branch, qt.Equals, "main")
+			c.Assert(req.Fingerprint, qt.Equals, "b129e8fa")
+
+			values := url.Values{}
+			listOpts := &ps.ListOptions{URLValues: &values}
+			for _, opt := range opts {
+				c.Assert(opt(listOpts), qt.IsNil)
+			}
+			c.Assert(values.Get("keyspace"), qt.Equals, "mydb")
+			c.Assert(values.Get("period"), qt.Equals, "1h")
+
+			return &ps.QuerySummary{
+				ID:                     "summary-1",
+				Fingerprint:            "b129e8fa",
+				Keyspace:               "mydb",
+				StatementType:          "SELECT",
+				QueryCount:             20,
+				SumRowsRead:            40,
+				SumRowsReturned:        20,
+				SumTotalDurationMillis: 50.5,
+				LastRunAt:              &lastRunAt,
+				NormalizedSQL:          "select * from users where id = ?",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := QuerySummaryCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--keyspace", "mydb", "--period", "1h"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetQuerySummaryFnInvoked, qt.IsTrue)
+
+	var out map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out["fingerprint"], qt.Equals, "b129e8fa")
+	c.Assert(out["query_count"], qt.Equals, float64(20))
+}
+
+func TestInsights_QuerySummaryCmd_Human(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{
+		GetQuerySummaryFn: func(ctx context.Context, req *ps.GetQuerySummaryRequest, opts ...ps.ListOption) (*ps.QuerySummary, error) {
+			return &ps.QuerySummary{
+				Fingerprint:   "b129e8fa",
+				Keyspace:      "mydb",
+				StatementType: "SELECT",
+				QueryCount:    20,
+				NormalizedSQL: "select 1",
+			}, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.Human, &ps.Client{QueryInsights: svc})
+
+	cmd := QuerySummaryCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--keyspace", "mydb"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "b129e8fa")
+	c.Assert(buf.String(), qt.Contains, "20")
+	c.Assert(buf.String(), qt.Contains, "select 1")
+}
+
+func TestInsights_QuerySummaryCmd_RequiresKeyspace(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{}
+	ch := testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := QuerySummaryCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "keyspace")
+	c.Assert(svc.GetQuerySummaryFnInvoked, qt.IsFalse)
+}
+
+func TestInsights_QuerySummaryCmd_ValidatesTimeRange(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "from requires to",
+			args: []string{"mydb", "main", "b129e8fa", "--keyspace", "mydb", "--from", "2026-08-25T17:00:00Z"},
+			want: "--from and --to must be used together",
+		},
+		{
+			name: "period conflicts with range",
+			args: []string{"mydb", "main", "b129e8fa", "--keyspace", "mydb", "--period", "1h", "--from", "2026-08-25T17:00:00Z", "--to", "2026-08-25T18:00:00Z"},
+			want: "--period cannot be combined with --from and --to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			svc := &mock.QueryInsightsService{}
+			ch := testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{QueryInsights: svc})
+
+			cmd := QuerySummaryCmd(ch)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, tt.want)
+			c.Assert(svc.GetQuerySummaryFnInvoked, qt.IsFalse)
+		})
+	}
 }
 
 func TestInsights_TagsCmd(t *testing.T) {

--- a/internal/cmd/insights/query_show.go
+++ b/internal/cmd/insights/query_show.go
@@ -1,0 +1,94 @@
+package insights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+type QueryShowRow struct {
+	ID           string  `header:"id" json:"id"`
+	Fingerprint  string  `header:"fingerprint" json:"fingerprint"`
+	StartedAt    string  `header:"started" json:"started_at"`
+	Statement    string  `header:"statement" json:"statement_type"`
+	Keyspace     string  `header:"keyspace" json:"keyspace"`
+	Tables       string  `header:"tables" json:"tables"`
+	Username     string  `header:"user" json:"username"`
+	Remote       string  `header:"remote address" json:"remote_address"`
+	ShardQueries int64   `header:"shard queries" json:"shard_queries"`
+	RowsRead     int64   `header:"rows read" json:"rows_read"`
+	RowsAffected int64   `header:"rows affected" json:"rows_affected"`
+	RowsReturned int64   `header:"rows returned" json:"rows_returned"`
+	DurationMs   float64 `header:"duration (ms)" json:"total_duration_millis"`
+	Error        string  `header:"error" json:"error_message"`
+	Query        string  `header:"query" json:"normalized_sql"`
+}
+
+func QueryShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <database> <branch> <query-id>",
+		Short: "Show an individual query execution",
+		Long: `Show one query execution using an ID returned by
+'pscale insights queries samples'. The query ID is an execution/sample ID,
+not the fingerprint used by the samples and summary commands.`,
+		Example: `  pscale insights queries show mydb main exec-1 --org myorg`,
+		Args:    cmdutil.RequiredArgs("database", "branch", "query-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			database, branch, queryID := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching query execution %s on %s/%s...",
+				printer.BoldBlue(queryID), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			query, err := client.QueryInsights.GetQuery(cmd.Context(), &ps.GetQueryRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				QueryID:      queryID,
+			})
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(query)
+			}
+
+			startedAt := ""
+			if query.StartedAt != nil {
+				startedAt = query.StartedAt.Format("2006-01-02 15:04:05")
+			}
+
+			return ch.Printer.PrintResource([]*QueryShowRow{{
+				ID:           query.ID,
+				Fingerprint:  query.Fingerprint,
+				StartedAt:    startedAt,
+				Statement:    query.StatementType,
+				Keyspace:     query.Keyspace,
+				Tables:       strings.Join(query.Tables, ", "),
+				Username:     query.Username,
+				Remote:       query.RemoteAddress,
+				ShardQueries: query.ShardQueries,
+				RowsRead:     query.RowsRead,
+				RowsAffected: query.RowsAffected,
+				RowsReturned: query.RowsReturned,
+				DurationMs:   round2(query.TotalDurationMillis),
+				Error:        query.ErrorMessage,
+				Query:        query.NormalizedSQL,
+			}})
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/insights/query_summary.go
+++ b/internal/cmd/insights/query_summary.go
@@ -1,0 +1,128 @@
+package insights
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+type QuerySummaryRow struct {
+	Fingerprint   string  `header:"fingerprint" json:"fingerprint"`
+	Keyspace      string  `header:"keyspace" json:"keyspace"`
+	Statement     string  `header:"statement" json:"statement_type"`
+	Count         int64   `header:"count" json:"query_count"`
+	Errors        int64   `header:"errors" json:"error_count"`
+	TotalTimeMs   float64 `header:"total time (ms)" json:"sum_total_duration_millis"`
+	TimePerQryMs  float64 `header:"per query (ms)" json:"time_per_query"`
+	P50Ms         float64 `header:"p50 (ms)" json:"p50_latency"`
+	P99Ms         float64 `header:"p99 (ms)" json:"p99_latency"`
+	MaxMs         float64 `header:"max (ms)" json:"max_latency"`
+	RowsRead      int64   `header:"rows read" json:"sum_rows_read"`
+	RowsReturned  int64   `header:"rows returned" json:"sum_rows_returned"`
+	ReadPerReturn float64 `header:"read/returned" json:"rows_read_per_returned"`
+	LastRunAt     string  `header:"last run" json:"last_run_at"`
+	Tables        string  `header:"tables" json:"tables"`
+	Multishard    bool    `header:"multishard" json:"multishard"`
+	Query         string  `header:"query" json:"normalized_sql"`
+}
+
+func QuerySummaryCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		keyspace string
+		period   string
+		from     string
+		to       string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "summary <database> <branch> <fingerprint>",
+		Short: "Show aggregate statistics for a query fingerprint",
+		Long: `Show aggregate statistics for a fingerprint from
+'pscale insights queries <database> <branch>'.
+
+--keyspace is required (use the keyspace column from the queries list).
+The fingerprint identifies a query pattern; it is not an execution/sample ID.`,
+		Example: `  pscale insights queries summary mydb main b129e8fa --org myorg --keyspace mydb
+  pscale insights queries summary mydb main b129e8fa --org myorg --keyspace mydb --period 1h
+  pscale insights queries summary mydb main b129e8fa --org myorg --keyspace mydb --from 2026-08-25T14:00:00Z --to 2026-08-25T15:00:00Z`,
+		Args: cmdutil.RequiredArgs("database", "branch", "fingerprint"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateQuerySummaryRangeFlags(cmd, flags.from, flags.to); err != nil {
+				return err
+			}
+
+			database, branch, fingerprint := args[0], args[1], args[2]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching query summary for fingerprint %s on %s/%s...",
+				printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			summary, err := client.QueryInsights.GetQuerySummary(cmd.Context(), &ps.GetQuerySummaryRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Fingerprint:  fingerprint,
+			}, ps.WithKeyspace(flags.keyspace), ps.WithPeriod(flags.period), ps.WithTimeRange(flags.from, flags.to))
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(summary)
+			}
+
+			lastRunAt := ""
+			if summary.LastRunAt != nil {
+				lastRunAt = summary.LastRunAt.Format("2006-01-02 15:04:05")
+			}
+
+			return ch.Printer.PrintResource([]*QuerySummaryRow{{
+				Fingerprint:   summary.Fingerprint,
+				Keyspace:      summary.Keyspace,
+				Statement:     summary.StatementType,
+				Count:         summary.QueryCount,
+				Errors:        summary.ErrorCount,
+				TotalTimeMs:   round2(summary.SumTotalDurationMillis),
+				TimePerQryMs:  round2(summary.TimePerQuery),
+				P50Ms:         round2(summary.P50Latency),
+				P99Ms:         round2(summary.P99Latency),
+				MaxMs:         round2(summary.MaxLatency),
+				RowsRead:      summary.SumRowsRead,
+				RowsReturned:  summary.SumRowsReturned,
+				ReadPerReturn: round2(summary.RowsReadPerReturned),
+				LastRunAt:     lastRunAt,
+				Tables:        strings.Join(summary.Tables, ", "),
+				Multishard:    summary.Multishard,
+				Query:         summary.NormalizedSQL,
+			}})
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the fingerprint (required; from insights queries)")
+	cmd.Flags().StringVar(&flags.period, "period", "", "Named time period to summarize (for example 1h, 12h, or 1d)")
+	cmd.Flags().StringVar(&flags.from, "from", "", "Start of a custom time range as an ISO 8601 timestamp")
+	cmd.Flags().StringVar(&flags.to, "to", "", "End of a custom time range as an ISO 8601 timestamp")
+	cmd.MarkFlagRequired("keyspace") // nolint:errcheck
+
+	return cmd
+}
+
+func validateQuerySummaryRangeFlags(cmd *cobra.Command, from, to string) error {
+	if (from == "") != (to == "") {
+		return fmt.Errorf("--from and --to must be used together")
+	}
+	if from != "" && cmd.Flags().Changed("period") {
+		return fmt.Errorf("--period cannot be combined with --from and --to")
+	}
+	return nil
+}

--- a/internal/mock/insights.go
+++ b/internal/mock/insights.go
@@ -13,6 +13,12 @@ type QueryInsightsService struct {
 	ListQuerySamplesFn        func(context.Context, *ps.ListQuerySamplesRequest, ...ps.ListOption) ([]*ps.QuerySample, error)
 	ListQuerySamplesFnInvoked bool
 
+	GetQueryFn        func(context.Context, *ps.GetQueryRequest) (*ps.Query, error)
+	GetQueryFnInvoked bool
+
+	GetQuerySummaryFn        func(context.Context, *ps.GetQuerySummaryRequest, ...ps.ListOption) (*ps.QuerySummary, error)
+	GetQuerySummaryFnInvoked bool
+
 	ListErrorsFn        func(context.Context, *ps.ListQueryInsightsErrorsRequest, ...ps.ListOption) ([]*ps.QueryInsightError, error)
 	ListErrorsFnInvoked bool
 
@@ -53,6 +59,16 @@ func (s *QueryInsightsService) GetAnomaly(ctx context.Context, req *ps.GetAnomal
 func (s *QueryInsightsService) ListQuerySamples(ctx context.Context, req *ps.ListQuerySamplesRequest, opts ...ps.ListOption) ([]*ps.QuerySample, error) {
 	s.ListQuerySamplesFnInvoked = true
 	return s.ListQuerySamplesFn(ctx, req, opts...)
+}
+
+func (s *QueryInsightsService) GetQuery(ctx context.Context, req *ps.GetQueryRequest) (*ps.Query, error) {
+	s.GetQueryFnInvoked = true
+	return s.GetQueryFn(ctx, req)
+}
+
+func (s *QueryInsightsService) GetQuerySummary(ctx context.Context, req *ps.GetQuerySummaryRequest, opts ...ps.ListOption) (*ps.QuerySummary, error) {
+	s.GetQuerySummaryFnInvoked = true
+	return s.GetQuerySummaryFn(ctx, req, opts...)
 }
 
 func (s *QueryInsightsService) ListErrors(ctx context.Context, req *ps.ListQueryInsightsErrorsRequest, opts ...ps.ListOption) ([]*ps.QueryInsightError, error) {

--- a/internal/planetscale/insights.go
+++ b/internal/planetscale/insights.go
@@ -15,6 +15,8 @@ var _ QueryInsightsService = &queryInsightsService{}
 type QueryInsightsService interface {
 	ListQueries(context.Context, *ListQueryInsightsRequest, ...ListOption) ([]*QueryInsight, error)
 	ListQuerySamples(context.Context, *ListQuerySamplesRequest, ...ListOption) ([]*QuerySample, error)
+	GetQuery(context.Context, *GetQueryRequest) (*Query, error)
+	GetQuerySummary(context.Context, *GetQuerySummaryRequest, ...ListOption) (*QuerySummary, error)
 	ListErrors(context.Context, *ListQueryInsightsErrorsRequest, ...ListOption) ([]*QueryInsightError, error)
 	ListErrorQueries(context.Context, *ListErrorQueriesRequest, ...ListOption) ([]*QuerySample, error)
 	ListAnomalies(context.Context, *ListAnomaliesRequest, ...ListOption) ([]*Anomaly, error)
@@ -159,8 +161,100 @@ type QuerySample struct {
 	Tags                []QuerySampleTag `json:"tags"`
 }
 
+type Query struct {
+	ID                   string           `json:"id"`
+	Password             map[string]any   `json:"password"`
+	Tags                 []map[string]any `json:"tags"`
+	Fingerprint          string           `json:"fingerprint"`
+	StartedAt            *time.Time       `json:"started_at"`
+	StatementType        string           `json:"statement_type"`
+	Keyspace             string           `json:"keyspace"`
+	Tables               []string         `json:"tables"`
+	Username             string           `json:"username"`
+	RemoteAddress        string           `json:"remote_address"`
+	ShardQueries         int64            `json:"shard_queries"`
+	RowsRead             int64            `json:"rows_read"`
+	RowsAffected         int64            `json:"rows_affected"`
+	RowsReturned         int64            `json:"rows_returned"`
+	TotalDurationMillis  float64          `json:"total_duration_millis"`
+	ErrorMessage         string           `json:"error_message"`
+	NormalizedSQL        string           `json:"normalized_sql"`
+	SyntaxHighlightedSQL string           `json:"syntax_highlighted_sql"`
+	CreatedAt            time.Time        `json:"created_at"`
+	UpdatedAt            time.Time        `json:"updated_at"`
+	Explainable          bool             `json:"explainable"`
+	Truncated            bool             `json:"truncated"`
+}
+
+type QuerySummary struct {
+	ID                      string           `json:"id"`
+	Fingerprint             string           `json:"fingerprint"`
+	StatementType           string           `json:"statement_type"`
+	Keyspace                string           `json:"keyspace"`
+	NormalizedSQL           string           `json:"normalized_sql"`
+	SyntaxHighlightedSQL    string           `json:"syntax_highlighted_sql"`
+	Multishard              bool             `json:"multishard"`
+	QueryCount              int64            `json:"query_count"`
+	ErrorCount              int64            `json:"error_count"`
+	Tables                  []string         `json:"tables"`
+	QualifiedTables         []string         `json:"qualified_tables"`
+	TableKeyspaces          []map[string]any `json:"table_keyspaces"`
+	IndexUsages             []map[string]any `json:"index_usages"`
+	RoutingIndexUsages      []map[string]any `json:"routing_index_usages"`
+	SumShardQueries         int64            `json:"sum_shard_queries"`
+	MaxShardQueries         int64            `json:"max_shard_queries"`
+	AvgShardQueries         float64          `json:"avg_shard_queries"`
+	AvgParallelWorkers      float64          `json:"avg_parallel_workers"`
+	SumRowsRead             int64            `json:"sum_rows_read"`
+	SumRowsAffected         int64            `json:"sum_rows_affected"`
+	SumRowsReturned         int64            `json:"sum_rows_returned"`
+	RowsReadPerReturned     float64          `json:"rows_read_per_returned"`
+	RowsReadPerQuery        float64          `json:"rows_read_per_query"`
+	RowsReturnedPerQuery    float64          `json:"rows_returned_per_query"`
+	RowsAffectedPerQuery    float64          `json:"rows_affected_per_query"`
+	SumTotalDurationMillis  float64          `json:"sum_total_duration_millis"`
+	SumTotalDurationPercent float64          `json:"sum_total_duration_percent"`
+	SumCPUDurationMillis    float64          `json:"sum_cpu_duration_millis"`
+	SumCPUDurationPercent   float64          `json:"sum_cpu_duration_percent"`
+	SumIODurationMillis     float64          `json:"sum_io_duration_millis"`
+	SumIODurationPercent    float64          `json:"sum_io_duration_percent"`
+	LastRunAt               *time.Time       `json:"last_run_at"`
+	TimePerQuery            float64          `json:"time_per_query"`
+	P50Latency              float64          `json:"p50_latency"`
+	P99Latency              float64          `json:"p99_latency"`
+	MaxLatency              float64          `json:"max_latency"`
+	EgressBytes             int64            `json:"egress_bytes"`
+	EgressBytesPerQuery     float64          `json:"egress_bytes_per_query"`
+	MaxEgressBytes          int64            `json:"max_egress_bytes"`
+	IngressBytes            int64            `json:"ingress_bytes"`
+	IngressBytesPerQuery    float64          `json:"ingress_bytes_per_query"`
+	MaxIngressBytes         int64            `json:"max_ingress_bytes"`
+	BlocksRead              int64            `json:"blocks_read"`
+	BlocksHit               int64            `json:"blocks_hit"`
+	BlockCacheHitRatio      float64          `json:"block_cache_hit_ratio"`
+	BlocksDirtied           int64            `json:"blocks_dirtied"`
+	BlocksWritten           int64            `json:"blocks_written"`
+	TrafficControlWarnings  int64            `json:"traffic_control_warnings"`
+	TrafficControlThrottled int64            `json:"traffic_control_throttled"`
+	TrafficControlChecked   int64            `json:"traffic_control_checked"`
+}
+
 // ListQuerySamplesRequest lists individual executions for a query fingerprint.
 type ListQuerySamplesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Fingerprint  string
+}
+
+type GetQueryRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	QueryID      string
+}
+
+type GetQuerySummaryRequest struct {
 	Organization string
 	Database     string
 	Branch       string
@@ -186,6 +280,18 @@ func WithPeriod(period string) ListOption {
 	return func(opt *ListOptions) error {
 		if period != "" {
 			opt.URLValues.Set("period", period)
+		}
+		return nil
+	}
+}
+
+func WithTimeRange(from, to string) ListOption {
+	return func(opt *ListOptions) error {
+		if from != "" {
+			opt.URLValues.Set("from", from)
+		}
+		if to != "" {
+			opt.URLValues.Set("to", to)
 		}
 		return nil
 	}
@@ -305,6 +411,38 @@ func (s *queryInsightsService) ListQuerySamples(ctx context.Context, request *Li
 	}
 
 	return resp.Data, nil
+}
+
+func (s *queryInsightsService) GetQuery(ctx context.Context, request *GetQueryRequest) (*Query, error) {
+	pathStr := path.Join(insightsAPIPath(request.Organization, request.Database, request.Branch), "queries", request.QueryID)
+	req, err := s.client.newRequest(http.MethodGet, pathStr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	query := &Query{}
+	if err := s.client.do(ctx, req, query); err != nil {
+		return nil, err
+	}
+
+	return query, nil
+}
+
+func (s *queryInsightsService) GetQuerySummary(ctx context.Context, request *GetQuerySummaryRequest, opts ...ListOption) (*QuerySummary, error) {
+	listOpts := defaultListOptions(opts...)
+
+	pathStr := path.Join(insightsFingerprintAPIPath(request.Organization, request.Database, request.Branch, request.Fingerprint), "summary")
+	req, err := s.client.newRequest(http.MethodGet, pathStr, nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, err
+	}
+
+	summary := &QuerySummary{}
+	if err := s.client.do(ctx, req, summary); err != nil {
+		return nil, err
+	}
+
+	return summary, nil
 }
 
 func insightsAPIPath(org, db, branch string) string {

--- a/internal/planetscale/insights_test.go
+++ b/internal/planetscale/insights_test.go
@@ -307,6 +307,117 @@ func TestQueryInsights_ListQuerySamples(t *testing.T) {
 	})
 }
 
+func TestQueryInsights_GetQuery(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/queries/exec-1")
+
+		w.WriteHeader(200)
+		out := `{
+			"id": "exec-1",
+			"password": {"id": "password-1"},
+			"tags": [{"name": "Sapp", "value": "web"}],
+			"fingerprint": "b129e8fa",
+			"started_at": "2026-08-25T18:00:00.000Z",
+			"statement_type": "SELECT",
+			"keyspace": "main",
+			"tables": ["users"],
+			"username": "app",
+			"remote_address": "192.0.2.10",
+			"shard_queries": 1,
+			"rows_read": 2,
+			"rows_affected": 0,
+			"rows_returned": 1,
+			"total_duration_millis": 2.5,
+			"error_message": "",
+			"normalized_sql": "select * from users where id = ?",
+			"syntax_highlighted_sql": "select * from users where id = ?",
+			"created_at": "2026-08-25T18:00:01.000Z",
+			"updated_at": "2026-08-25T18:00:01.000Z",
+			"explainable": true,
+			"truncated": false
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	query, err := client.QueryInsights.GetQuery(context.Background(), &GetQueryRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+		QueryID:      "exec-1",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(query.ID, qt.Equals, "exec-1")
+	c.Assert(query.Fingerprint, qt.Equals, "b129e8fa")
+	c.Assert(query.TotalDurationMillis, qt.Equals, 2.5)
+	c.Assert(query.StartedAt.IsZero(), qt.IsFalse)
+	c.Assert(query.Password["id"], qt.Equals, "password-1")
+	c.Assert(query.Tags[0]["value"], qt.Equals, "web")
+}
+
+func TestQueryInsights_GetQuerySummary(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/b129e8fa/summary")
+		c.Assert(r.URL.Query().Get("keyspace"), qt.Equals, "main")
+		c.Assert(r.URL.Query().Get("from"), qt.Equals, "2026-08-25T17:00:00Z")
+		c.Assert(r.URL.Query().Get("to"), qt.Equals, "2026-08-25T18:00:00Z")
+
+		w.WriteHeader(200)
+		out := `{
+			"id": "summary-1",
+			"fingerprint": "b129e8fa",
+			"statement_type": "SELECT",
+			"keyspace": "main",
+			"normalized_sql": "select * from users where id = ?",
+			"query_count": 20,
+			"error_count": 1,
+			"tables": ["users"],
+			"index_usages": [{"name": "PRIMARY", "count": 20}],
+			"sum_rows_read": 40,
+			"sum_rows_returned": 20,
+			"rows_read_per_returned": 2,
+			"sum_total_duration_millis": 50.5,
+			"last_run_at": "2026-08-25T18:00:00.000Z",
+			"time_per_query": 2.525,
+			"p50_latency": 2.1,
+			"p99_latency": 4.8,
+			"max_latency": 5.2
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	summary, err := client.QueryInsights.GetQuerySummary(context.Background(), &GetQuerySummaryRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+		Fingerprint:  "b129e8fa",
+	}, WithKeyspace("main"), WithTimeRange("2026-08-25T17:00:00Z", "2026-08-25T18:00:00Z"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(summary.ID, qt.Equals, "summary-1")
+	c.Assert(summary.Fingerprint, qt.Equals, "b129e8fa")
+	c.Assert(summary.QueryCount, qt.Equals, int64(20))
+	c.Assert(summary.SumTotalDurationMillis, qt.Equals, 50.5)
+	c.Assert(summary.IndexUsages[0]["name"], qt.Equals, "PRIMARY")
+	c.Assert(summary.LastRunAt.IsZero(), qt.IsFalse)
+}
+
 func TestQueryInsights_ListTags(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- add `insights queries show` for retrieving one execution by sample ID
- add `insights queries summary` for fingerprint-level aggregate statistics with required keyspace and validated time filters
- add typed clients, human/JSON output, mocks, tests, and agent-guide documentation

## Test plan
- [x] `go test ./internal/planetscale ./internal/cmd/insights`
- [x] `go test ./...`
- [x] `go vet ./internal/planetscale ./internal/mock ./internal/cmd/insights`
- [x] `staticcheck ./internal/planetscale ./internal/mock ./internal/cmd/insights`