### PR TITLE
Add switchover list and show commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,13 +417,19 @@ pscale branch switchover <database> <branch> --org <org> --format json
 
 # Promote a specific replica (names from `pscale branch infra`)
 pscale branch switchover <database> <branch> --org <org> --format json --candidate <replica-name>
+
+# List switchovers for a branch (supports --page and --per-page)
+pscale branch switchover list <database> <branch> --org <org> --format json
+
+# Show current status and details for one switchover
+pscale branch switchover show <database> <branch> <id> --org <org> --format json
 ```
 
 - The command returns the created switchover (`id`, `state`, `method`) and exits; it does not wait. A fresh switchover is `pending` and `method` is empty until the operator picks one.
 - `method` is `switchover` (replica promoted) for branches with replicas, or `restart` for single-node branches, which are restarted in place and unreachable while they come back. Warn the user before running this against a single-node branch.
 - Writes are briefly interrupted while the switch completes. A branch accepts one switchover at a time.
 - A switchover that ends in `failed` has an unconfirmed outcome: the primary may still have moved and nothing is rolled back. Check the current primary with `pscale branch infra <database> <branch> --org <org> --format json` before retrying.
-- `--candidate` is rejected for branches without replicas. Poll status with `pscale api organizations/<org>/databases/<database>/branches/<branch>/switchovers/<id>`.
+- `--candidate` is rejected for branches without replicas. Poll status with `pscale branch switchover show <database> <branch> <id> --org <org> --format json`.
 
 ## Postgres branch maintenance
 

--- a/internal/cmd/branch/switchover.go
+++ b/internal/cmd/branch/switchover.go
@@ -1,6 +1,7 @@
 package branch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -76,8 +77,105 @@ comes back. Writes are briefly interrupted while the switch completes.`,
 
 	cmd.Flags().StringVar(&flags.candidate, "candidate", "",
 		"Name of the replica to promote, as returned by 'branch infra'. Omit to select automatically. Only applies to branches with replicas")
+	cmd.AddCommand(SwitchoverListCmd(ch), SwitchoverShowCmd(ch))
 
 	return cmd
+}
+
+func SwitchoverListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list <database> <branch>",
+		Short:   "List switchovers for a Postgres branch",
+		Aliases: []string{"ls"},
+		Args:    cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch := args[0], args[1]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "Switchovers"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching switchovers for %s branch in %s...", printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+			switchovers, err := client.PostgresSwitchovers.List(ctx, &ps.ListPostgresSwitchoversRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				return switchoverReadError(ctx, cmd, ch, err, database, branch, "")
+			}
+			end()
+
+			if len(switchovers) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page > 0 {
+					ch.Printer.Println("No switchovers found on this page.")
+				} else {
+					ch.Printer.Printf("No switchovers exist for %s branch in %s.\n", printer.BoldBlue(branch), printer.BoldBlue(database))
+				}
+				return nil
+			}
+			return ch.Printer.PrintResource(toPostgresSwitchovers(switchovers))
+		},
+	}
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+func SwitchoverShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <database> <branch> <id>",
+		Short: "Show a switchover for a Postgres branch",
+		Args:  cmdutil.RequiredArgs("database", "branch", "id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, id := args[0], args[1], args[2]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			if err := cmdutil.RequirePostgresDatabase(ctx, client, ch.Config.Organization, database, "Switchovers"); err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching switchover %s for %s branch in %s...", printer.BoldBlue(id), printer.BoldBlue(branch), printer.BoldBlue(database)))
+			defer end()
+			switchover, err := client.PostgresSwitchovers.Get(ctx, &ps.GetPostgresSwitchoverRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				ID:           id,
+			})
+			if err != nil {
+				return switchoverReadError(ctx, cmd, ch, err, database, branch, id)
+			}
+			end()
+			return ch.Printer.PrintResource(ToPostgresSwitchover(switchover))
+		},
+	}
+}
+
+func switchoverReadError(ctx context.Context, cmd *cobra.Command, ch *cmdutil.Helper, err error, database, branch, id string) error {
+	if cmdutil.ErrCode(err) != ps.ErrNotFound {
+		return cmdutil.HandleError(err)
+	}
+	if id != "" {
+		return cmdutil.HandleNotFoundWithServiceTokenCheck(ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+			"switchover %s does not exist for branch %s in database %s",
+			printer.BoldBlue(id), printer.BoldBlue(branch), printer.BoldBlue(database))
+	}
+	return cmdutil.HandleNotFoundWithServiceTokenCheck(ctx, cmd, ch.Config, ch.Client, err, "read_branch",
+		"branch %s does not exist in database %s", printer.BoldBlue(branch), printer.BoldBlue(database))
 }
 
 type PostgresSwitchover struct {
@@ -103,4 +201,12 @@ func ToPostgresSwitchover(switchover *ps.PostgresSwitchover) *PostgresSwitchover
 		Method: switchover.Method,
 		orig:   switchover,
 	}
+}
+
+func toPostgresSwitchovers(switchovers []*ps.PostgresSwitchover) []*PostgresSwitchover {
+	result := make([]*PostgresSwitchover, 0, len(switchovers))
+	for _, switchover := range switchovers {
+		result = append(result, ToPostgresSwitchover(switchover))
+	}
+	return result
 }

--- a/internal/cmd/branch/switchover_test.go
+++ b/internal/cmd/branch/switchover_test.go
@@ -3,6 +3,7 @@ package branch
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -12,6 +13,21 @@ import (
 	ps "github.com/planetscale/cli/internal/planetscale"
 	"github.com/planetscale/cli/internal/printer"
 )
+
+func switchoverTestHelper(org string, dbSvc *mock.DatabaseService, svc *mock.PostgresSwitchoversService, format printer.Format, buf *bytes.Buffer) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	if format == printer.Human {
+		p.SetHumanOutput(buf)
+	}
+	p.SetResourceOutput(buf)
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Databases: dbSvc, PostgresSwitchovers: svc}, nil
+		},
+	}
+}
 
 func TestBranch_SwitchoverCmd(t *testing.T) {
 	c := qt.New(t)
@@ -106,4 +122,167 @@ func TestBranch_SwitchoverCmd_VitessDatabase(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `(?s).*only available for PostgreSQL.*mysql.*`)
 	c.Assert(svc.CreateFnInvoked, qt.IsFalse)
+}
+
+func TestBranch_SwitchoverListCmd_JSON(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	res := []*ps.PostgresSwitchover{
+		{ID: "switchover-2", State: "running", Method: "switchover"},
+		{ID: "switchover-1", State: "succeeded", Method: "restart"},
+	}
+	dbSvc := postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres)
+	svc := &mock.PostgresSwitchoversService{
+		ListFn: func(_ context.Context, req *ps.ListPostgresSwitchoversRequest, _ ...ps.ListOption) ([]*ps.PostgresSwitchover, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "app")
+			c.Assert(req.Branch, qt.Equals, "main")
+			return res, nil
+		},
+	}
+
+	cmd := SwitchoverCmd(switchoverTestHelper("planetscale", dbSvc, svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"list", "app", "main", "--page", "2", "--per-page", "50"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranch_SwitchoverListCmd_HumanAndEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		data []*ps.PostgresSwitchover
+		want string
+	}{
+		{name: "rows", args: []string{"app", "main"}, data: []*ps.PostgresSwitchover{{ID: "switchover-1", State: "succeeded", Method: "switchover"}}, want: "switchover-1"},
+		{name: "empty", args: []string{"app", "main"}, data: []*ps.PostgresSwitchover{}, want: "No switchovers exist"},
+		{name: "empty page", args: []string{"app", "main", "--page", "2"}, data: []*ps.PostgresSwitchover{}, want: "No switchovers found on this page."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var buf bytes.Buffer
+			svc := &mock.PostgresSwitchoversService{
+				ListFn: func(context.Context, *ps.ListPostgresSwitchoversRequest, ...ps.ListOption) ([]*ps.PostgresSwitchover, error) {
+					return tt.data, nil
+				},
+			}
+			cmd := SwitchoverListCmd(switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres), svc, printer.Human, &buf))
+			cmd.SetArgs(tt.args)
+			c.Assert(cmd.Execute(), qt.IsNil)
+			c.Assert(buf.String(), qt.Contains, tt.want)
+		})
+	}
+}
+
+func TestBranch_SwitchoverListCmd_EmptyJSON(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.PostgresSwitchoversService{
+		ListFn: func(context.Context, *ps.ListPostgresSwitchoversRequest, ...ps.ListOption) ([]*ps.PostgresSwitchover, error) {
+			return []*ps.PostgresSwitchover{}, nil
+		},
+	}
+	cmd := SwitchoverListCmd(switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres), svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"app", "main"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(strings.TrimSpace(buf.String()), qt.Equals, "[]")
+}
+
+func TestBranch_SwitchoverListCmd_NotFound(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.PostgresSwitchoversService{
+		ListFn: func(context.Context, *ps.ListPostgresSwitchoversRequest, ...ps.ListOption) ([]*ps.PostgresSwitchover, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+	cmd := SwitchoverListCmd(switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres), svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"app", "missing"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, `(?s).*branch.*missing.*does not exist.*`)
+}
+
+func TestBranch_SwitchoverShowCmd_JSON(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	res := &ps.PostgresSwitchover{ID: "switchover-1", State: "failed", Method: "restart", Error: "The branch is draining"}
+	svc := &mock.PostgresSwitchoversService{
+		GetFn: func(_ context.Context, req *ps.GetPostgresSwitchoverRequest) (*ps.PostgresSwitchover, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "app")
+			c.Assert(req.Branch, qt.Equals, "main")
+			c.Assert(req.ID, qt.Equals, "switchover-1")
+			return res, nil
+		},
+	}
+	cmd := SwitchoverCmd(switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres), svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"show", "app", "main", "switchover-1"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBranch_SwitchoverShowCmd_Human(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	res := &ps.PostgresSwitchover{ID: "switchover-1", State: "succeeded", Method: "switchover"}
+	svc := &mock.PostgresSwitchoversService{
+		GetFn: func(context.Context, *ps.GetPostgresSwitchoverRequest) (*ps.PostgresSwitchover, error) {
+			return res, nil
+		},
+	}
+	cmd := SwitchoverShowCmd(switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres), svc, printer.Human, &buf))
+	cmd.SetArgs([]string{"app", "main", "switchover-1"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "switchover-1")
+	c.Assert(buf.String(), qt.Contains, "succeeded")
+}
+
+func TestBranch_SwitchoverShowCmd_NotFound(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.PostgresSwitchoversService{
+		GetFn: func(context.Context, *ps.GetPostgresSwitchoverRequest) (*ps.PostgresSwitchover, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+	cmd := SwitchoverShowCmd(switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEnginePostgres), svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"app", "main", "missing"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, `(?s).*switchover.*missing.*does not exist.*`)
+}
+
+func TestBranch_SwitchoverReadCmds_VitessDatabase(t *testing.T) {
+	tests := []struct {
+		name string
+		show bool
+		args []string
+	}{
+		{name: "list", args: []string{"app", "main"}},
+		{name: "show", show: true, args: []string{"app", "main", "switchover-1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var buf bytes.Buffer
+			svc := &mock.PostgresSwitchoversService{}
+			ch := switchoverTestHelper("planetscale", postgresSwitchoverDatabaseService("app", ps.DatabaseEngineMySQL), svc, printer.JSON, &buf)
+			cmd := SwitchoverListCmd(ch)
+			if tt.show {
+				cmd = SwitchoverShowCmd(ch)
+			}
+			cmd.SetArgs(tt.args)
+			c.Assert(cmd.Execute(), qt.ErrorMatches, `(?s).*only available for PostgreSQL.*mysql.*`)
+			c.Assert(svc.ListFnInvoked, qt.IsFalse)
+			c.Assert(svc.GetFnInvoked, qt.IsFalse)
+		})
+	}
+}
+
+func postgresSwitchoverDatabaseService(name string, kind ps.DatabaseEngine) *mock.DatabaseService {
+	return &mock.DatabaseService{
+		GetFn: func(context.Context, *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: name, Kind: kind}, nil
+		},
+	}
 }

--- a/internal/mock/postgres_switchover.go
+++ b/internal/mock/postgres_switchover.go
@@ -7,8 +7,22 @@ import (
 )
 
 type PostgresSwitchoversService struct {
+	ListFn          func(context.Context, *ps.ListPostgresSwitchoversRequest, ...ps.ListOption) ([]*ps.PostgresSwitchover, error)
+	ListFnInvoked   bool
+	GetFn           func(context.Context, *ps.GetPostgresSwitchoverRequest) (*ps.PostgresSwitchover, error)
+	GetFnInvoked    bool
 	CreateFn        func(context.Context, *ps.CreatePostgresSwitchoverRequest) (*ps.PostgresSwitchover, error)
 	CreateFnInvoked bool
+}
+
+func (s *PostgresSwitchoversService) List(ctx context.Context, req *ps.ListPostgresSwitchoversRequest, opts ...ps.ListOption) ([]*ps.PostgresSwitchover, error) {
+	s.ListFnInvoked = true
+	return s.ListFn(ctx, req, opts...)
+}
+
+func (s *PostgresSwitchoversService) Get(ctx context.Context, req *ps.GetPostgresSwitchoverRequest) (*ps.PostgresSwitchover, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
 }
 
 func (s *PostgresSwitchoversService) Create(ctx context.Context, req *ps.CreatePostgresSwitchoverRequest) (*ps.PostgresSwitchover, error) {

--- a/internal/planetscale/postgres_switchovers.go
+++ b/internal/planetscale/postgres_switchovers.go
@@ -31,9 +31,28 @@ type CreatePostgresSwitchoverRequest struct {
 	Candidate    string `json:"candidate,omitempty"`
 }
 
+type postgresSwitchoversResponse struct {
+	Switchovers []*PostgresSwitchover `json:"data"`
+}
+
+type ListPostgresSwitchoversRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+}
+
+type GetPostgresSwitchoverRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	ID           string
+}
+
 // PostgresSwitchoversService is an interface for the PlanetScale Postgres
 // switchover API.
 type PostgresSwitchoversService interface {
+	List(context.Context, *ListPostgresSwitchoversRequest, ...ListOption) ([]*PostgresSwitchover, error)
+	Get(context.Context, *GetPostgresSwitchoverRequest) (*PostgresSwitchover, error)
 	Create(context.Context, *CreatePostgresSwitchoverRequest) (*PostgresSwitchover, error)
 }
 
@@ -42,6 +61,39 @@ type postgresSwitchoversService struct {
 }
 
 var _ PostgresSwitchoversService = &postgresSwitchoversService{}
+
+func (s *postgresSwitchoversService) List(ctx context.Context, listReq *ListPostgresSwitchoversRequest, opts ...ListOption) ([]*PostgresSwitchover, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := s.client.newRequest(http.MethodGet, postgresSwitchoversAPIPath(listReq.Organization, listReq.Database, listReq.Branch), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list postgres switchovers: %w", err)
+	}
+
+	resp := &postgresSwitchoversResponse{}
+	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Switchovers, nil
+}
+
+func (s *postgresSwitchoversService) Get(ctx context.Context, getReq *GetPostgresSwitchoverRequest) (*PostgresSwitchover, error) {
+	req, err := s.client.newRequest(http.MethodGet, postgresSwitchoverAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.ID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get postgres switchover: %w", err)
+	}
+
+	switchover := &PostgresSwitchover{}
+	if err := s.client.do(ctx, req, &switchover); err != nil {
+		return nil, err
+	}
+	return switchover, nil
+}
 
 func (s *postgresSwitchoversService) Create(ctx context.Context, createReq *CreatePostgresSwitchoverRequest) (*PostgresSwitchover, error) {
 	req, err := s.client.newRequest(http.MethodPost, postgresSwitchoversAPIPath(createReq.Organization, createReq.Database, createReq.Branch), createReq)
@@ -59,4 +111,8 @@ func (s *postgresSwitchoversService) Create(ctx context.Context, createReq *Crea
 
 func postgresSwitchoversAPIPath(org, db, branch string) string {
 	return path.Join("v1/organizations", org, "databases", db, "branches", branch, "switchovers")
+}
+
+func postgresSwitchoverAPIPath(org, db, branch, id string) string {
+	return path.Join(postgresSwitchoversAPIPath(org, db, branch), id)
 }

--- a/internal/planetscale/postgres_switchovers_test.go
+++ b/internal/planetscale/postgres_switchovers_test.go
@@ -85,3 +85,66 @@ func TestPostgresSwitchovers_CreateWithoutCandidate(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(switchover.ID, qt.Equals, "switchover-2")
 }
+
+func TestPostgresSwitchovers_List(t *testing.T) {
+	c := qt.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/switchovers")
+		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "50")
+		_, err := w.Write([]byte(`{"data":[{"id":"switchover-1","state":"succeeded","method":"switchover","actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},"started_at":"2021-01-14T10:20:00.000Z","completed_at":"2021-01-14T10:21:00.000Z","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:21:00.000Z"}]}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	got, err := client.PostgresSwitchovers.List(context.Background(), &ListPostgresSwitchoversRequest{
+		Organization: testOrg, Database: "my-db", Branch: "main",
+	}, WithPage(2), WithPerPage(50))
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 1)
+	c.Assert(got[0].ID, qt.Equals, "switchover-1")
+	c.Assert(got[0].Actor.Name, qt.Equals, "Alice")
+}
+
+func TestPostgresSwitchovers_ListEmptyUsesDefaultPagination(t *testing.T) {
+	c := qt.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "100")
+		_, err := w.Write([]byte(`{"data":[]}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	got, err := client.PostgresSwitchovers.List(context.Background(), &ListPostgresSwitchoversRequest{
+		Organization: testOrg, Database: "my-db", Branch: "main",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.HasLen, 0)
+}
+
+func TestPostgresSwitchovers_Get(t *testing.T) {
+	c := qt.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/switchovers/switchover-1")
+		_, err := w.Write([]byte(`{"id":"switchover-1","state":"failed","method":"restart","error":"The branch is draining","actor":{"id":"user-1","display_name":"Alice","avatar_url":"https://example.com/a.png"},"started_at":"2021-01-14T10:20:00.000Z","completed_at":"2021-01-14T10:21:00.000Z","created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:21:00.000Z"}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	got, err := client.PostgresSwitchovers.Get(context.Background(), &GetPostgresSwitchoverRequest{
+		Organization: testOrg, Database: "my-db", Branch: "main", ID: "switchover-1",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.ID, qt.Equals, "switchover-1")
+	c.Assert(got.State, qt.Equals, "failed")
+	c.Assert(got.Method, qt.Equals, "restart")
+	c.Assert(got.Error, qt.Equals, "The branch is draining")
+}


### PR DESCRIPTION
## Summary
- add paginated `branch switchover list` and single-resource `branch switchover show` commands
- expose the existing public switchover list/get endpoints with Postgres guards and human/JSON output
- document the commands as the supported replacement for raw API polling

## Test plan
- [x] `go test ./internal/planetscale -run PostgresSwitchovers`
- [x] `go test ./internal/cmd/branch -run Switchover`
- [x] `go test ./...`
- [x] `go vet ./internal/planetscale ./internal/mock ./internal/cmd/branch`
- [x] `staticcheck ./internal/planetscale ./internal/mock ./internal/cmd/branch`