### PR TITLE
Add service token show command

### DIFF
--- a/internal/cmd/token/show.go
+++ b/internal/cmd/token/show.go
@@ -1,0 +1,50 @@
+package token
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <id>",
+		Short: "show a service token in the organization",
+		Args:  cmdutil.RequiredArgs("id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			id := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching service token %s from org %s",
+				printer.BoldBlue(id), printer.BoldBlue(ch.Config.Organization)))
+			defer end()
+
+			token, err := client.ServiceTokens.Get(ctx, &planetscale.GetServiceTokenRequest{
+				Organization: ch.Config.Organization,
+				ID:           id,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case planetscale.ErrNotFound:
+					return fmt.Errorf("service token %s does not exist in organization %s",
+						printer.BoldBlue(id), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toServiceTokenDetails(token))
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/token/show_test.go
+++ b/internal/cmd/token/show_test.go
@@ -1,0 +1,127 @@
+package token
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestServiceToken_ShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	id := "token-id"
+	name := "deploy-token"
+	createdAt := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+	lastUsedAt := time.Date(2025, 1, 20, 14, 45, 0, 0, time.UTC)
+	token := &ps.ServiceToken{
+		ID:         id,
+		Name:       &name,
+		Token:      "must-not-be-printed",
+		CreatedAt:  createdAt,
+		LastUsedAt: &lastUsedAt,
+	}
+
+	svc := &mock.ServiceTokenService{
+		GetFn: func(ctx context.Context, req *ps.GetServiceTokenRequest) (*ps.ServiceToken, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.ID, qt.Equals, id)
+			return token, nil
+		},
+	}
+
+	ch := serviceTokenShowHelper(p, org, svc)
+	cmd := ShowCmd(ch)
+	cmd.SetArgs([]string{id})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, map[string]any{
+		"id":           id,
+		"name":         name,
+		"created_at":   "2025-01-15T10:30:00Z",
+		"last_used_at": "2025-01-20T14:45:00Z",
+		"expires_at":   nil,
+	})
+	c.Assert(buf.String(), qt.Not(qt.Contains), token.Token)
+}
+
+func TestServiceToken_ShowCmdHuman(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetHumanOutput(&buf)
+	p.SetResourceOutput(&buf)
+
+	name := "deploy-token"
+	svc := &mock.ServiceTokenService{
+		GetFn: func(ctx context.Context, req *ps.GetServiceTokenRequest) (*ps.ServiceToken, error) {
+			return &ps.ServiceToken{
+				ID:        "token-id",
+				Name:      &name,
+				Token:     "must-not-be-printed",
+				CreatedAt: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+
+	cmd := ShowCmd(serviceTokenShowHelper(p, "planetscale", svc))
+	cmd.SetArgs([]string{"token-id"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "token-id")
+	c.Assert(buf.String(), qt.Contains, "deploy-token")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "must-not-be-printed")
+}
+
+func TestServiceToken_ShowCmdNotFound(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.ServiceTokenService{
+		GetFn: func(ctx context.Context, req *ps.GetServiceTokenRequest) (*ps.ServiceToken, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	cmd := ShowCmd(serviceTokenShowHelper(p, "planetscale", svc))
+	cmd.SetArgs([]string{"missing-token"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "service token missing-token does not exist in organization planetscale")
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+}
+
+func serviceTokenShowHelper(p *printer.Printer, org string, svc *mock.ServiceTokenService) *cmdutil.Helper {
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: org},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{ServiceTokens: svc}, nil
+		},
+	}
+}

--- a/internal/cmd/token/token.go
+++ b/internal/cmd/token/token.go
@@ -3,6 +3,7 @@ package token
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	ps "github.com/planetscale/cli/internal/planetscale"
@@ -38,6 +39,7 @@ func TokenCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.AddCommand(CreateCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
+	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(ShowAccessCmd(ch))
 	cmd.AddCommand(AddAccessCmd(ch))
 	cmd.AddCommand(DeleteAccessCmd(ch))
@@ -86,6 +88,45 @@ func toServiceToken(st *ps.ServiceToken) *ServiceToken {
 		LastUsedAt: lastUsedAt,
 		ExpiresAt:  expiresAt,
 		CreatedAt:  printer.GetMilliseconds(st.CreatedAt),
+		orig:       st,
+	}
+}
+
+type ServiceTokenDetails struct {
+	ID         string `header:"id"`
+	Name       string `header:"name"`
+	LastUsedAt int64  `header:"last_used_at,timestamp(ms|utc|human)"`
+	ExpiresAt  int64  `header:"expires_at,timestamp(ms|utc|human)"`
+	CreatedAt  int64  `header:"created_at,timestamp(ms|utc|human)"`
+
+	orig *ps.ServiceToken
+}
+
+func (s *ServiceTokenDetails) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(struct {
+		ID         string     `json:"id"`
+		Name       *string    `json:"name"`
+		CreatedAt  time.Time  `json:"created_at"`
+		LastUsedAt *time.Time `json:"last_used_at"`
+		ExpiresAt  *time.Time `json:"expires_at"`
+	}{
+		ID:         s.orig.ID,
+		Name:       s.orig.Name,
+		CreatedAt:  s.orig.CreatedAt,
+		LastUsedAt: s.orig.LastUsedAt,
+		ExpiresAt:  s.orig.ExpiresAt,
+	}, "", "  ")
+}
+
+func toServiceTokenDetails(st *ps.ServiceToken) *ServiceTokenDetails {
+	token := toServiceToken(st)
+
+	return &ServiceTokenDetails{
+		ID:         token.ID,
+		Name:       token.Name,
+		LastUsedAt: token.LastUsedAt,
+		ExpiresAt:  token.ExpiresAt,
+		CreatedAt:  token.CreatedAt,
 		orig:       st,
 	}
 }

--- a/internal/cmd/token/token_test.go
+++ b/internal/cmd/token/token_test.go
@@ -27,3 +27,17 @@ func TestServiceToken_TokenCmd_ServiceTokenAuth(t *testing.T) {
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Equals, " is unavailable when authenticated with a service token")
 }
+
+func TestServiceToken_TokenCmdRegistersShowSeparatelyFromShowAccess(t *testing.T) {
+	c := qt.New(t)
+
+	cmd := TokenCmd(&cmdutil.Helper{Config: &config.Config{}})
+
+	show, _, err := cmd.Find([]string{"show"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(show.Name(), qt.Equals, "show")
+
+	showAccess, _, err := cmd.Find([]string{"show-access"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(showAccess.Name(), qt.Equals, "show-access")
+}

--- a/internal/mock/servicetoken.go
+++ b/internal/mock/servicetoken.go
@@ -10,6 +10,9 @@ type ServiceTokenService struct {
 	CreateFn        func(context.Context, *ps.CreateServiceTokenRequest) (*ps.ServiceToken, error)
 	CreateFnInvoked bool
 
+	GetFn        func(context.Context, *ps.GetServiceTokenRequest) (*ps.ServiceToken, error)
+	GetFnInvoked bool
+
 	ListFn        func(context.Context, *ps.ListServiceTokensRequest) ([]*ps.ServiceToken, error)
 	ListFnInvoked bool
 
@@ -32,6 +35,11 @@ type ServiceTokenService struct {
 func (s *ServiceTokenService) Create(ctx context.Context, req *ps.CreateServiceTokenRequest) (*ps.ServiceToken, error) {
 	s.CreateFnInvoked = true
 	return s.CreateFn(ctx, req)
+}
+
+func (s *ServiceTokenService) Get(ctx context.Context, req *ps.GetServiceTokenRequest) (*ps.ServiceToken, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
 }
 
 func (s *ServiceTokenService) List(ctx context.Context, req *ps.ListServiceTokensRequest) ([]*ps.ServiceToken, error) {

--- a/internal/planetscale/service_tokens.go
+++ b/internal/planetscale/service_tokens.go
@@ -13,6 +13,7 @@ var _ ServiceTokenService = &serviceTokenService{}
 // Service Token API.
 type ServiceTokenService interface {
 	Create(context.Context, *CreateServiceTokenRequest) (*ServiceToken, error)
+	Get(context.Context, *GetServiceTokenRequest) (*ServiceToken, error)
 	List(context.Context, *ListServiceTokensRequest) ([]*ServiceToken, error)
 	ListGrants(context.Context, *ListServiceTokenGrantsRequest) ([]*ServiceTokenGrant, error)
 	Delete(context.Context, *DeleteServiceTokenRequest) error
@@ -33,6 +34,20 @@ func (s *serviceTokenService) Create(ctx context.Context, createReq *CreateServi
 
 	st := &ServiceToken{}
 	if err := s.client.do(ctx, req, &st); err != nil {
+		return nil, err
+	}
+
+	return st, nil
+}
+
+func (s *serviceTokenService) Get(ctx context.Context, getReq *GetServiceTokenRequest) (*ServiceToken, error) {
+	req, err := s.client.newRequest(http.MethodGet, serviceTokenAPIPath(getReq.Organization, getReq.ID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	st := &ServiceToken{}
+	if err := s.client.do(ctx, req, st); err != nil {
 		return nil, err
 	}
 
@@ -116,6 +131,11 @@ type CreateServiceTokenRequest struct {
 	Organization string  `json:"-"`
 	Name         *string `json:"name,omitempty"`
 	TTL          *int    `json:"ttl,omitempty"`
+}
+
+type GetServiceTokenRequest struct {
+	Organization string `json:"-"`
+	ID           string `json:"-"`
 }
 
 type ListServiceTokenGrantsRequest struct {

--- a/internal/planetscale/service_tokens_test.go
+++ b/internal/planetscale/service_tokens_test.go
@@ -95,6 +95,41 @@ func TestServiceTokens_CreateWithTTL(t *testing.T) {
 	c.Assert(snapshot, qt.DeepEquals, want)
 }
 
+func TestServiceTokens_Get(t *testing.T) {
+	c := qt.New(t)
+
+	wantURL := "/v1/organizations/my-org/service-tokens/1234"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.String(), qt.Equals, wantURL)
+
+		out := `{"id":"1234","name":"my-token","token":null,"created_at":"2021-01-14T10:19:23.000Z","last_used_at":"2021-01-15T12:30:00.000Z","service_token_accesses":[{"access":"read_branch"}]}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	token, err := client.ServiceTokens.Get(context.Background(), &GetServiceTokenRequest{
+		Organization: testOrg,
+		ID:           "1234",
+	})
+
+	tokenName := "my-token"
+	lastUsedAt := time.Date(2021, 1, 15, 12, 30, 0, 0, time.UTC)
+	want := &ServiceToken{
+		ID:         "1234",
+		Name:       &tokenName,
+		CreatedAt:  time.Date(2021, 1, 14, 10, 19, 23, 0, time.UTC),
+		LastUsedAt: &lastUsedAt,
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(token, qt.DeepEquals, want)
+}
+
 func TestServiceTokens_ListGrants(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- add `pscale service-token show <id>` backed by the service-token GET endpoint
- render safe human and JSON details without plaintext token fields or duplicated access grants
- keep `show-access` as a separately registered command

## Test plan
- [x] `go test ./internal/cmd/token ./internal/planetscale`
- [x] `go test ./...`
- [x] `go vet ./internal/cmd/token ./internal/mock ./internal/planetscale`
- [x] `staticcheck ./internal/cmd/token ./internal/mock ./internal/planetscale`
- [x] `gofmt -l internal/cmd/token/token.go` (no output)