### PR TITLE
Add database region discovery commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,8 +101,14 @@ pscale --org <org> database list --format json
 
    ```bash
    pscale database list --org <org> --format json
+   pscale database regions list <database> --org <org> --format json
+   pscale database read-only-regions list <database> --org <org> --format json
    pscale branch list <database> --org <org> --format json
    ```
+
+   `database regions list` returns the regions available to that database for
+   its engine. `database read-only-regions list` returns configured Vitess
+   read-only regions for the database's default branch.
 
 6. **Query** (read-only default):
 

--- a/internal/cmd/database/database.go
+++ b/internal/cmd/database/database.go
@@ -33,6 +33,8 @@ func DatabaseCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ThrottlerCmd(ch))
 	cmd.AddCommand(AggressiveCutoverCmd(ch))
 	cmd.AddCommand(IPRestrictionCmd(ch))
+	cmd.AddCommand(RegionsCmd(ch))
+	cmd.AddCommand(ReadOnlyRegionsCmd(ch))
 	cmd.AddCommand(DumpCmd(ch))
 	cmd.AddCommand(RestoreCmd(ch))
 

--- a/internal/cmd/database/dump.go
+++ b/internal/cmd/database/dump.go
@@ -63,7 +63,7 @@ func DumpCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&f.replica, "replica", false, "Dump from a replica tablet in the primary region (if available; will fail if not).")
 	cmd.PersistentFlags().BoolVar(&f.rdonly, "rdonly", false, "Dump from a rdonly tablet in the primary region (if available; will fail if not). Not for separate read-only regions — use --read-only-region instead.")
 	cmd.PersistentFlags().StringVar(&f.readOnlyRegion, "read-only-region", "",
-		"Dump from a Vitess read-only region (region slug, display name, or id). List regions with: pscale keyspace read-only-regions <database> <branch> <keyspace>.")
+		"Dump from a Vitess read-only region (region slug, display name, or id). List regions with: pscale database read-only-regions list <database>.")
 	cmd.PersistentFlags().StringVar(&f.tables, "tables", "",
 		"Comma separated string of tables to dump. By default all tables are dumped.")
 	cmd.PersistentFlags().StringVar(&f.wheres, "wheres", "",

--- a/internal/cmd/database/read_only_regions.go
+++ b/internal/cmd/database/read_only_regions.go
@@ -1,0 +1,109 @@
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func ReadOnlyRegionsCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "read-only-regions <command>",
+		Short: "List read-only regions for a database",
+		Long: "List read-only regions for a database's default branch.\n\n" +
+			"This command is only supported for Vitess databases.",
+	}
+
+	cmd.AddCommand(ReadOnlyRegionsListCmd(ch))
+	return cmd
+}
+
+func ReadOnlyRegionsListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list <database>",
+		Short:   "List read-only regions for a database",
+		Aliases: []string{"ls"},
+		Args:    cmdutil.RequiredArgs("database"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			database := args[0]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching read-only regions for database %s...", printer.BoldBlue(database)))
+			defer end()
+
+			regions, err := client.ReadOnlyRegions.List(cmd.Context(), &ps.ListReadOnlyRegionsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(regions) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page == 0 {
+					ch.Printer.Println("No read-only regions have been configured for this database.")
+				} else {
+					ch.Printer.Println("No read-only regions found on this page.")
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toDatabaseReadOnlyRegions(regions))
+		},
+	}
+
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+type databaseReadOnlyRegion struct {
+	ID       string `header:"id" json:"id"`
+	Name     string `header:"name" json:"display_name"`
+	Region   string `header:"region" json:"region"`
+	Provider string `header:"provider" json:"provider"`
+	Ready    bool   `header:"ready" json:"ready"`
+	orig     *ps.ReadOnlyRegion
+}
+
+func toDatabaseReadOnlyRegions(regions []*ps.ReadOnlyRegion) []*databaseReadOnlyRegion {
+	out := make([]*databaseReadOnlyRegion, 0, len(regions))
+	for _, region := range regions {
+		out = append(out, &databaseReadOnlyRegion{
+			ID:       region.ID,
+			Name:     region.DisplayName,
+			Region:   region.Region.Slug,
+			Provider: region.Region.Provider,
+			Ready:    region.Ready,
+			orig:     region,
+		})
+	}
+	return out
+}
+
+func (r *databaseReadOnlyRegion) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(r.orig, "", "  ")
+}
+
+func (r *databaseReadOnlyRegion) MarshalCSVValue() interface{} {
+	return []*databaseReadOnlyRegion{r}
+}

--- a/internal/cmd/database/regions.go
+++ b/internal/cmd/database/regions.go
@@ -1,0 +1,111 @@
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func RegionsCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "regions <command>",
+		Short: "List regions available to a database",
+	}
+
+	cmd.AddCommand(RegionsListCmd(ch))
+	return cmd
+}
+
+func RegionsListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list <database>",
+		Short:   "List regions available to a database",
+		Aliases: []string{"ls"},
+		Args:    cmdutil.RequiredArgs("database"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			database := args[0]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching regions for database %s...", printer.BoldBlue(database)))
+			defer end()
+
+			regions, err := client.Databases.ListRegions(cmd.Context(), &ps.ListDatabaseRegionsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("database %s does not exist in organization %s",
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(regions) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page == 0 {
+					ch.Printer.Println("No regions are available for this database.")
+				} else {
+					ch.Printer.Println("No regions found on this page.")
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toDatabaseRegions(regions))
+		},
+	}
+
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+type databaseRegion struct {
+	Name                string `header:"name" json:"display_name"`
+	Slug                string `header:"slug" json:"slug"`
+	Location            string `header:"location" json:"location"`
+	Provider            string `header:"provider" json:"provider"`
+	Enabled             bool   `header:"enabled" json:"enabled"`
+	MySQLSupported      bool   `header:"mysql_supported" json:"mysql_supported"`
+	PostgreSQLSupported bool   `header:"postgresql_supported" json:"postgresql_supported"`
+	orig                *ps.Region
+}
+
+func toDatabaseRegions(regions []*ps.Region) []*databaseRegion {
+	out := make([]*databaseRegion, 0, len(regions))
+	for _, region := range regions {
+		out = append(out, &databaseRegion{
+			Name:                region.Name,
+			Slug:                region.Slug,
+			Location:            region.Location,
+			Provider:            region.Provider,
+			Enabled:             region.Enabled,
+			MySQLSupported:      region.MySQLSupported,
+			PostgreSQLSupported: region.PostgreSQLSupported,
+			orig:                region,
+		})
+	}
+	return out
+}
+
+func (r *databaseRegion) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(r.orig, "", "  ")
+}
+
+func (r *databaseRegion) MarshalCSVValue() interface{} {
+	return []*databaseRegion{r}
+}

--- a/internal/cmd/database/regions_test.go
+++ b/internal/cmd/database/regions_test.go
@@ -1,0 +1,168 @@
+package database
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestDatabase_RegionsListCmd(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+	regions := []*ps.Region{{
+		ID:                  "reg123",
+		Name:                "US East",
+		Slug:                "us-east",
+		Location:            "Northern Virginia",
+		Provider:            "AWS",
+		Enabled:             true,
+		MySQLSupported:      true,
+		PostgreSQLSupported: true,
+	}}
+
+	svc := &mock.DatabaseService{
+		ListRegionsFn: func(_ context.Context, req *ps.ListDatabaseRegionsRequest, opts ...ps.ListOption) ([]*ps.Region, error) {
+			c.Assert(req.Organization, qt.Equals, "acme")
+			c.Assert(req.Database, qt.Equals, "app")
+			values := url.Values{}
+			listOpts := &ps.ListOptions{URLValues: &values}
+			for _, opt := range opts {
+				c.Assert(opt(listOpts), qt.IsNil)
+			}
+			c.Assert(values.Get("page"), qt.Equals, "2")
+			c.Assert(values.Get("per_page"), qt.Equals, "25")
+			return regions, nil
+		},
+	}
+
+	cmd := RegionsListCmd(databaseRegionsTestHelper(printer.JSON, &out, svc, nil))
+	cmd.SetArgs([]string{"app", "--page", "2", "--per-page", "25"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.ListRegionsFnInvoked, qt.IsTrue)
+	c.Assert(out.String(), qt.JSONEquals, regions)
+	c.Assert(cmd.Aliases, qt.Contains, "ls")
+}
+
+func TestDatabase_RegionsListCmdHuman(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+	svc := &mock.DatabaseService{
+		ListRegionsFn: func(context.Context, *ps.ListDatabaseRegionsRequest, ...ps.ListOption) ([]*ps.Region, error) {
+			return []*ps.Region{{
+				Name:                "US East",
+				Slug:                "us-east",
+				Location:            "Northern Virginia",
+				Provider:            "AWS",
+				Enabled:             true,
+				MySQLSupported:      true,
+				PostgreSQLSupported: false,
+			}}, nil
+		},
+	}
+
+	cmd := RegionsListCmd(databaseRegionsTestHelper(printer.Human, &out, svc, nil))
+	cmd.SetArgs([]string{"app"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "US East")
+	c.Assert(out.String(), qt.Contains, "us-east")
+	c.Assert(out.String(), qt.Contains, "MYSQL SUPPORTED")
+}
+
+func TestDatabase_ReadOnlyRegionsListCmd(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+	regions := []*ps.ReadOnlyRegion{{
+		ID:          "ror123",
+		DisplayName: "Europe West",
+		Ready:       true,
+		Region: ps.Region{
+			Slug:     "eu-west",
+			Provider: "AWS",
+		},
+	}}
+
+	svc := &mock.ReadOnlyRegionsService{
+		ListFn: func(_ context.Context, req *ps.ListReadOnlyRegionsRequest, opts ...ps.ListOption) ([]*ps.ReadOnlyRegion, error) {
+			c.Assert(req.Organization, qt.Equals, "acme")
+			c.Assert(req.Database, qt.Equals, "app")
+			values := url.Values{}
+			listOpts := &ps.ListOptions{URLValues: &values}
+			for _, opt := range opts {
+				c.Assert(opt(listOpts), qt.IsNil)
+			}
+			c.Assert(values.Get("page"), qt.Equals, "3")
+			c.Assert(values.Get("per_page"), qt.Equals, "10")
+			return regions, nil
+		},
+	}
+
+	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.JSON, &out, nil, svc))
+	cmd.SetArgs([]string{"app", "--page", "3", "--per-page", "10"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.ListFnInvoked, qt.IsTrue)
+	c.Assert(out.String(), qt.JSONEquals, regions)
+	c.Assert(cmd.Aliases, qt.Contains, "ls")
+}
+
+func TestDatabase_ReadOnlyRegionsListCmdHuman(t *testing.T) {
+	c := qt.New(t)
+	var out bytes.Buffer
+	svc := &mock.ReadOnlyRegionsService{
+		ListFn: func(context.Context, *ps.ListReadOnlyRegionsRequest, ...ps.ListOption) ([]*ps.ReadOnlyRegion, error) {
+			return []*ps.ReadOnlyRegion{{
+				ID:          "ror123",
+				DisplayName: "Europe West",
+				Ready:       true,
+				Region: ps.Region{
+					Slug:     "eu-west",
+					Provider: "AWS",
+				},
+			}}, nil
+		},
+	}
+
+	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.Human, &out, nil, svc))
+	cmd.SetArgs([]string{"app"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "ror123")
+	c.Assert(out.String(), qt.Contains, "eu-west")
+	c.Assert(out.String(), qt.Contains, "Europe West")
+}
+
+func TestDatabase_RegionCommandsRegistered(t *testing.T) {
+	c := qt.New(t)
+	ch := databaseRegionsTestHelper(printer.JSON, &bytes.Buffer{}, &mock.DatabaseService{}, &mock.ReadOnlyRegionsService{})
+	cmd := DatabaseCmd(ch)
+
+	found, _, err := cmd.Find([]string{"regions", "list"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(found.Use, qt.Equals, "list <database>")
+
+	found, _, err = cmd.Find([]string{"read-only-regions", "ls"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(found.Use, qt.Equals, "list <database>")
+}
+
+func databaseRegionsTestHelper(format printer.Format, out *bytes.Buffer, databases ps.DatabasesService, readOnlyRegions ps.ReadOnlyRegionsService) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(out)
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "acme"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Databases:       databases,
+				ReadOnlyRegions: readOnlyRegions,
+			}, nil
+		},
+	}
+}

--- a/internal/cmd/password/create.go
+++ b/internal/cmd/password/create.go
@@ -120,7 +120,7 @@ func CreateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.PersistentFlags().Var(&flags.ttl, "ttl", `TTL defines the time to live for the password. Durations such as "30m", "24h", or bare integers such as "3600" (seconds) are accepted. The default TTL is 0s, which means the password will never expire.`)
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
 	cmd.Flags().StringVar(&flags.readOnlyRegion, "read-only-region", "",
-		"Create a password scoped to a Vitess read-only region (region slug, display name, or id). List regions with: pscale keyspace read-only-regions <database> <branch> <keyspace>.")
+		"Create a password scoped to a Vitess read-only region (region slug, display name, or id). List regions with: pscale database read-only-regions list <database>.")
 
 	return cmd
 }

--- a/internal/mock/database.go
+++ b/internal/mock/database.go
@@ -16,6 +16,9 @@ type DatabaseService struct {
 	ListFn        func(context.Context, *ps.ListDatabasesRequest, ...ps.ListOption) ([]*ps.Database, error)
 	ListFnInvoked bool
 
+	ListRegionsFn        func(context.Context, *ps.ListDatabaseRegionsRequest, ...ps.ListOption) ([]*ps.Region, error)
+	ListRegionsFnInvoked bool
+
 	DeleteFn        func(context.Context, *ps.DeleteDatabaseRequest) (*ps.DatabaseDeletionRequest, error)
 	DeleteFnInvoked bool
 
@@ -51,6 +54,11 @@ func (d *DatabaseService) Get(ctx context.Context, req *ps.GetDatabaseRequest) (
 func (d *DatabaseService) List(ctx context.Context, req *ps.ListDatabasesRequest, opts ...ps.ListOption) ([]*ps.Database, error) {
 	d.ListFnInvoked = true
 	return d.ListFn(ctx, req, opts...)
+}
+
+func (d *DatabaseService) ListRegions(ctx context.Context, req *ps.ListDatabaseRegionsRequest, opts ...ps.ListOption) ([]*ps.Region, error) {
+	d.ListRegionsFnInvoked = true
+	return d.ListRegionsFn(ctx, req, opts...)
 }
 
 func (d *DatabaseService) Delete(ctx context.Context, req *ps.DeleteDatabaseRequest) (*ps.DatabaseDeletionRequest, error) {

--- a/internal/planetscale/database_regions_test.go
+++ b/internal/planetscale/database_regions_test.go
@@ -1,0 +1,59 @@
+package planetscale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestDatabases_ListRegions(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/regions")
+		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "50")
+
+		_, err := w.Write([]byte(`{
+			"data": [{
+				"id": "reg123",
+				"slug": "us-east",
+				"provider": "AWS",
+				"display_name": "US East",
+				"location": "Northern Virginia",
+				"enabled": true,
+				"current_default": true,
+				"public_ip_addresses": ["192.0.2.1"],
+				"mysql_supported": true,
+				"postgresql_supported": true
+			}]
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	regions, err := client.Databases.ListRegions(context.Background(), &ListDatabaseRegionsRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+	}, WithPage(2), WithPerPage(50))
+	c.Assert(err, qt.IsNil)
+	c.Assert(regions, qt.DeepEquals, []*Region{{
+		ID:                  "reg123",
+		Slug:                "us-east",
+		Provider:            "AWS",
+		Name:                "US East",
+		Location:            "Northern Virginia",
+		Enabled:             true,
+		IsDefault:           true,
+		PublicIPAddresses:   []string{"192.0.2.1"},
+		MySQLSupported:      true,
+		PostgreSQLSupported: true,
+	}})
+}

--- a/internal/planetscale/databases.go
+++ b/internal/planetscale/databases.go
@@ -49,6 +49,11 @@ type ListDatabasesRequest struct {
 	Organization string
 }
 
+type ListDatabaseRegionsRequest struct {
+	Organization string
+	Database     string
+}
+
 // DeleteDatabaseRequest encapsulates the request for deleting a database from
 // an organization.
 type DeleteDatabaseRequest struct {
@@ -116,6 +121,7 @@ type DatabasesService interface {
 	Create(context.Context, *CreateDatabaseRequest) (*Database, error)
 	Get(context.Context, *GetDatabaseRequest) (*Database, error)
 	List(context.Context, *ListDatabasesRequest, ...ListOption) ([]*Database, error)
+	ListRegions(context.Context, *ListDatabaseRegionsRequest, ...ListOption) ([]*Region, error)
 	Delete(context.Context, *DeleteDatabaseRequest) (*DatabaseDeletionRequest, error)
 	UpdateSettings(context.Context, *UpdateDatabaseSettingsRequest) (*Database, error)
 	GetThrottler(context.Context, *GetDatabaseThrottlerRequest) (*DatabaseThrottler, error)
@@ -207,6 +213,29 @@ func (ds *databasesService) List(ctx context.Context, listReq *ListDatabasesRequ
 	}
 
 	return dbResponse.Databases, nil
+}
+
+func (ds *databasesService) ListRegions(ctx context.Context, listReq *ListDatabaseRegionsRequest, opts ...ListOption) ([]*Region, error) {
+	pathStr := path.Join(databasesAPIPath(listReq.Organization), listReq.Database, "regions")
+
+	defaultOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(defaultOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := ds.client.newRequest(http.MethodGet, pathStr, nil, WithQueryParams(*defaultOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list database regions: %w", err)
+	}
+
+	resp := &regionsResponse{}
+	if err := ds.client.do(ctx, req, resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Regions, nil
 }
 
 func (ds *databasesService) Create(ctx context.Context, createReq *CreateDatabaseRequest) (*Database, error) {

--- a/internal/planetscale/organizations_test.go
+++ b/internal/planetscale/organizations_test.go
@@ -119,6 +119,7 @@ func TestOrganizations_ListRegions(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	want := []*Region{
 		{
+			ID:      "my-cool-org",
 			Name:    "US East",
 			Slug:    "us-east",
 			Enabled: true,

--- a/internal/planetscale/read_only_regions_test.go
+++ b/internal/planetscale/read_only_regions_test.go
@@ -18,6 +18,7 @@ func TestReadOnlyRegions_List(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.Method, qt.Equals, http.MethodGet)
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/read-only-regions")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "100")
 		w.WriteHeader(200)
 		out := `{
   "data": [

--- a/internal/planetscale/regions.go
+++ b/internal/planetscale/regions.go
@@ -9,12 +9,16 @@ import (
 const regionsAPIPath = "v1/regions"
 
 type Region struct {
-	Slug      string `json:"slug"`
-	Provider  string `json:"provider"`
-	Name      string `json:"display_name"`
-	Location  string `json:"location"`
-	Enabled   bool   `json:"enabled"`
-	IsDefault bool   `json:"current_default"`
+	ID                  string   `json:"id"`
+	Slug                string   `json:"slug"`
+	Provider            string   `json:"provider"`
+	Name                string   `json:"display_name"`
+	Location            string   `json:"location"`
+	Enabled             bool     `json:"enabled"`
+	IsDefault           bool     `json:"current_default"`
+	PublicIPAddresses   []string `json:"public_ip_addresses"`
+	MySQLSupported      bool     `json:"mysql_supported"`
+	PostgreSQLSupported bool     `json:"postgresql_supported"`
 }
 
 type regionsResponse struct {

--- a/internal/planetscale/regions_test.go
+++ b/internal/planetscale/regions_test.go
@@ -43,6 +43,7 @@ func TestRegions_List(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	want := []*Region{
 		{
+			ID:        "my-cool-org",
 			Slug:      "us-east",
 			Provider:  "AWS",
 			Name:      "US East",


### PR DESCRIPTION
## Summary
- add database-scoped commands for listing available and configured read-only regions
- add paginated client support, human/JSON output, mocks, tests, and corrected region discovery help
- document the new agent-facing discovery commands

## Test plan
- [x] `go test ./internal/planetscale ./internal/cmd/database ./internal/cmd/password`
- [x] `go test ./...`
- [x] `go vet ./internal/planetscale ./internal/mock ./internal/cmd/database ./internal/cmd/password`
- [x] `staticcheck ./internal/planetscale ./internal/mock ./internal/cmd/database ./internal/cmd/password`