### PR TITLE
Add backup update for protected status

### DIFF
--- a/internal/cmd/backup/backup.go
+++ b/internal/cmd/backup/backup.go
@@ -25,6 +25,7 @@ func BackupCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.AddCommand(CreateCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
+	cmd.AddCommand(UpdateCmd(ch))
 	cmd.AddCommand(DeleteCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(RestoreCmd(ch))
@@ -40,6 +41,7 @@ type Backup struct {
 	Name        string `header:"name" json:"name"`
 	State       string `header:"state" json:"state"`
 	Size        int64  `header:"size" json:"size"`
+	Protected   bool   `header:"protected" json:"protected"`
 	CreatedAt   int64  `header:"created_at,timestamp(ms|utc|human)" json:"created_at"`
 	UpdatedAt   int64  `header:"updated_at,timestamp(ms|utc|human)" json:"updated_at"`
 	StartedAt   int64  `header:"started_at,timestamp(ms|utc|human)" json:"started_at"`
@@ -70,6 +72,7 @@ func toBackup(backup *ps.Backup) *Backup {
 		Name:        backup.Name,
 		State:       backup.State,
 		Size:        backup.Size,
+		Protected:   backup.Protected,
 		CreatedAt:   backup.CreatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
 		UpdatedAt:   backup.UpdatedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),
 		StartedAt:   backup.StartedAt.UTC().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)),

--- a/internal/cmd/backup/update.go
+++ b/internal/cmd/backup/update.go
@@ -1,0 +1,70 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		protected bool
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update <database> <branch> <backup-id>",
+		Short: "Update a backup's protected status",
+		Long: `Update a backup's protected status.
+
+--protected must be passed. Use --protected=false to disable protection.`,
+		Example: `  pscale backup update mydb main backup-id --protected
+  pscale backup update mydb main backup-id --protected=false`,
+		Args: cmdutil.RequiredArgs("database", "branch", "backup-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, backup := args[0], args[1], args[2]
+
+			if !cmd.Flags().Changed("protected") {
+				return fmt.Errorf("--protected must be provided")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating backup %s for %s", printer.BoldBlue(backup), printer.BoldBlue(branch)))
+			defer end()
+
+			bkp, err := client.Backups.Update(ctx, &ps.UpdateBackupRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Backup:       backup,
+				Protected:    flags.protected,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("backup %s does not exist in branch %s of %s (organization: %s)",
+						printer.BoldBlue(backup), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+
+			end()
+
+			return ch.Printer.PrintResource(toBackup(bkp))
+		},
+	}
+
+	cmd.Flags().BoolVar(&flags.protected, "protected", false,
+		"Protect the backup from deletion (use --protected=false to disable)")
+
+	return cmd
+}

--- a/internal/cmd/backup/update_test.go
+++ b/internal/cmd/backup/update_test.go
@@ -1,0 +1,134 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestBackup_UpdateCmd_SetsProtected(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	backup := "mybackup"
+
+	res := &ps.Backup{Name: "foo", Protected: true}
+
+	svc := &mock.BackupsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateBackupRequest) (*ps.Backup, error) {
+			c.Assert(req.Organization, qt.Equals, org)
+			c.Assert(req.Database, qt.Equals, db)
+			c.Assert(req.Branch, qt.Equals, branch)
+			c.Assert(req.Backup, qt.Equals, backup)
+			c.Assert(req.Protected, qt.IsTrue)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, branch, backup, "--protected"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBackup_UpdateCmd_SetsProtectedFalse(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	org := "planetscale"
+	db := "planetscale"
+	branch := "development"
+	backup := "mybackup"
+
+	res := &ps.Backup{Name: "foo", Protected: false}
+
+	svc := &mock.BackupsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateBackupRequest) (*ps.Backup, error) {
+			c.Assert(req.Protected, qt.IsFalse)
+			return res, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config: &config.Config{
+			Organization: org,
+		},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{
+				Backups: svc,
+			}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{db, branch, backup, "--protected=false"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, res)
+}
+
+func TestBackup_UpdateCmd_RequiresProtectedFlag(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.BackupsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateBackupRequest) (*ps.Backup, error) {
+			c.Fatal("Backups.Update should not be called without --protected")
+			return nil, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Backups: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"planetscale", "main", "backup-id"})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--protected must be provided")
+	c.Assert(svc.UpdateFnInvoked, qt.IsFalse)
+}

--- a/internal/mock/backup.go
+++ b/internal/mock/backup.go
@@ -13,6 +13,9 @@ type BackupsService struct {
 	GetFn        func(context.Context, *ps.GetBackupRequest) (*ps.Backup, error)
 	GetFnInvoked bool
 
+	UpdateFn        func(context.Context, *ps.UpdateBackupRequest) (*ps.Backup, error)
+	UpdateFnInvoked bool
+
 	ListFn        func(context.Context, *ps.ListBackupsRequest) ([]*ps.Backup, error)
 	ListFnInvoked bool
 
@@ -33,6 +36,11 @@ func (b *BackupsService) List(ctx context.Context, req *ps.ListBackupsRequest) (
 func (b *BackupsService) Get(ctx context.Context, req *ps.GetBackupRequest) (*ps.Backup, error) {
 	b.GetFnInvoked = true
 	return b.GetFn(ctx, req)
+}
+
+func (b *BackupsService) Update(ctx context.Context, req *ps.UpdateBackupRequest) (*ps.Backup, error) {
+	b.UpdateFnInvoked = true
+	return b.UpdateFn(ctx, req)
 }
 
 func (b *BackupsService) Delete(ctx context.Context, req *ps.DeleteBackupRequest) error {

--- a/internal/planetscale/backups.go
+++ b/internal/planetscale/backups.go
@@ -14,6 +14,7 @@ type Backup struct {
 	Name        string    `json:"name"`
 	State       string    `json:"state"`
 	Size        int64     `json:"size"`
+	Protected   bool      `json:"protected"`
 	Actor       *Actor    `json:"actor"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
@@ -59,12 +60,19 @@ type DeleteBackupRequest struct {
 	Backup       string
 }
 
-// BackupsService is an interface for communicating with the PlanetScale
-// backup API endpoint.
+type UpdateBackupRequest struct {
+	Organization string `json:"-"`
+	Database     string `json:"-"`
+	Branch       string `json:"-"`
+	Backup       string `json:"-"`
+	Protected    bool   `json:"protected"`
+}
+
 type BackupsService interface {
 	Create(context.Context, *CreateBackupRequest) (*Backup, error)
 	List(context.Context, *ListBackupsRequest) ([]*Backup, error)
 	Get(context.Context, *GetBackupRequest) (*Backup, error)
+	Update(context.Context, *UpdateBackupRequest) (*Backup, error)
 	Delete(context.Context, *DeleteBackupRequest) error
 }
 
@@ -100,6 +108,21 @@ func (d *backupsService) Create(ctx context.Context, createReq *CreateBackupRequ
 func (d *backupsService) Get(ctx context.Context, getReq *GetBackupRequest) (*Backup, error) {
 	path := backupAPIPath(getReq.Organization, getReq.Database, getReq.Branch, getReq.Backup)
 	req, err := d.client.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	backup := &Backup{}
+	if err := d.client.do(ctx, req, &backup); err != nil {
+		return nil, err
+	}
+
+	return backup, nil
+}
+
+func (d *backupsService) Update(ctx context.Context, updateReq *UpdateBackupRequest) (*Backup, error) {
+	path := backupAPIPath(updateReq.Organization, updateReq.Database, updateReq.Branch, updateReq.Backup)
+	req, err := d.client.newRequest(http.MethodPatch, path, updateReq)
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/internal/planetscale/backups.go
+++ b/internal/planetscale/backups.go
@@ -2,10 +2,12 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"time"
 )
 
@@ -66,6 +68,14 @@ type UpdateBackupRequest struct {
 	Branch       string `json:"-"`
 	Backup       string `json:"-"`
 	Protected    bool   `json:"protected"`
+}
+
+// MarshalJSON encodes protected as a string because the API ignores a JSON
+// false, which would silently leave the backup protected.
+func (r *UpdateBackupRequest) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{
+		"protected": strconv.FormatBool(r.Protected),
+	})
 }
 
 type BackupsService interface {

--- a/internal/planetscale/backups_test.go
+++ b/internal/planetscale/backups_test.go
@@ -162,7 +162,7 @@ func TestBackups_Update(t *testing.T) {
 		var body map[string]any
 		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
 		c.Assert(body, qt.DeepEquals, map[string]any{
-			"protected": true,
+			"protected": "true",
 		})
 
 		w.WriteHeader(200)
@@ -197,4 +197,33 @@ func TestBackups_Update(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(backup, qt.DeepEquals, want)
+}
+
+func TestBackups_UpdateUnprotects(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]any{
+			"protected": "false",
+		})
+
+		_, err := w.Write([]byte(`{"id":"planetscale-go-test-backup","name":"planetscale-go-test-backup","protected":false}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	backup, err := client.Backups.Update(context.Background(), &UpdateBackupRequest{
+		Organization: "my-org",
+		Database:     "planetscale-go-test-db",
+		Branch:       "my-branch",
+		Backup:       testBackup,
+		Protected:    false,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(backup.Protected, qt.IsFalse)
 }

--- a/internal/planetscale/backups_test.go
+++ b/internal/planetscale/backups_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -142,6 +143,54 @@ func TestBackups_Get(t *testing.T) {
 	want := &Backup{
 		PublicID:  "planetscale-go-test-backup",
 		Name:      testBackup,
+		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+	}
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(backup, qt.DeepEquals, want)
+}
+
+func TestBackups_Update(t *testing.T) {
+	c := qt.New(t)
+
+	wantURL := "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/my-branch/backups/planetscale-go-test-backup"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.String(), qt.DeepEquals, wantURL)
+
+		var body map[string]any
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]any{
+			"protected": true,
+		})
+
+		w.WriteHeader(200)
+		out := `{"id":"planetscale-go-test-backup","type":"backup","name":"planetscale-go-test-backup","protected":true,"created_at":"2021-01-14T10:19:23.000Z","updated_at":"2021-01-14T10:19:23.000Z"}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	ctx := context.Background()
+	org := "my-org"
+	db := "planetscale-go-test-db"
+	branch := "my-branch"
+
+	backup, err := client.Backups.Update(ctx, &UpdateBackupRequest{
+		Organization: org,
+		Database:     db,
+		Branch:       branch,
+		Backup:       testBackup,
+		Protected:    true,
+	})
+
+	want := &Backup{
+		PublicID:  "planetscale-go-test-backup",
+		Name:      testBackup,
+		Protected: true,
 		CreatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		UpdatedAt: time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 	}


### PR DESCRIPTION
## Summary
- Wrap OpenAPI `update_backup` (`PATCH .../backups/{id}` with `{protected: bool}`) on the PlanetScale client, including `Protected` on `Backup`.
- Add `pscale backup update <database> <branch> <backup-id> --protected` / `--protected=false`, requiring the flag to be set (`Changed`).
- Human and JSON output match `backup show`; mock and tests cover the client and command.

## Test plan
- [x] `go test ./internal/planetscale/ ./internal/cmd/backup/`
- [x] `go vet` and `staticcheck` on the changed packages
- [x] `pscale backup update <database> <branch> <backup-id> --org <org> --format json --protected`
- [x] `pscale backup update <database> <branch> <backup-id> --org <org> --format json --protected=false`
- [x] Confirm omitting `--protected` errors without calling the API