### PR TITLE
Add query traffic budget insights command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,7 @@ Two complementary read-only surfaces. When diagnosing database health or perform
 ```bash
 pscale insights queries <database> <branch> --org <org> --format json --sort totalTime   # top queries; sorts: totalTime, count, p99Latency, rowsRead, rowsReadPerReturned, errorCount, ...
 pscale insights queries samples <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # recent executions; keyspace from queries list
+pscale insights queries traffic-budgets <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # traffic budgets affecting a query fingerprint
 pscale insights errors <database> <branch> --org <org> --format json                     # failing queries with error messages
 pscale insights errors show <database> <branch> <fingerprint> --org <org> --format json  # individual queries behind one error fingerprint (use error_fingerprint from the errors list)
 pscale insights anomalies <database> <branch> --org <org> --format json                  # detected resource anomalies (CPU, memory, IOPS, rows)

--- a/internal/cmd/insights/queries.go
+++ b/internal/cmd/insights/queries.go
@@ -120,6 +120,7 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.period, "period", "", "Time period to aggregate over (e.g. 1h, 1d)")
 
 	cmd.AddCommand(QuerySamplesCmd(ch))
+	cmd.AddCommand(QueryTrafficBudgetsCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/insights/query_traffic_budgets.go
+++ b/internal/cmd/insights/query_traffic_budgets.go
@@ -1,0 +1,59 @@
+package insights
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmd/trafficcontrol"
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func QueryTrafficBudgetsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var keyspace string
+
+	cmd := &cobra.Command{
+		Use:     "traffic-budgets <database> <branch> <fingerprint>",
+		Short:   "List traffic budgets affecting a query fingerprint",
+		Aliases: []string{"ls"},
+		Args:    cmdutil.RequiredArgs("database", "branch", "fingerprint"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			database, branch, fingerprint := args[0], args[1], args[2]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching traffic budgets for fingerprint %s on %s/%s...",
+				printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch)))
+			defer end()
+
+			budgets, err := client.QueryInsights.ListQueryTrafficBudgets(ctx, &ps.ListQueryTrafficBudgetsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Fingerprint:  fingerprint,
+			}, ps.WithKeyspace(keyspace))
+			if err != nil {
+				return notFoundError(ch, err, database, branch)
+			}
+			end()
+
+			if len(budgets) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No traffic budgets affect fingerprint %s on %s/%s.\n",
+					printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(trafficcontrol.ToTrafficBudgets(budgets))
+		},
+	}
+
+	cmd.Flags().StringVar(&keyspace, "keyspace", "", "Keyspace for the fingerprint")
+
+	return cmd
+}

--- a/internal/cmd/insights/query_traffic_budgets_test.go
+++ b/internal/cmd/insights/query_traffic_budgets_test.go
@@ -1,0 +1,62 @@
+package insights
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestQueryTrafficBudgetsCmd(t *testing.T) {
+	c := qt.New(t)
+
+	budgets := []*ps.TrafficBudget{{
+		ID:        "budget-1",
+		Name:      "App queries",
+		Mode:      "enforce",
+		CreatedAt: time.Date(2026, 8, 11, 18, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 8, 11, 18, 0, 0, 0, time.UTC),
+	}}
+	svc := &mock.QueryInsightsService{
+		ListQueryTrafficBudgetsFn: func(ctx context.Context, req *ps.ListQueryTrafficBudgetsRequest, opts ...ps.ListOption) ([]*ps.TrafficBudget, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Database, qt.Equals, "mydb")
+			c.Assert(req.Branch, qt.Equals, "main")
+			c.Assert(req.Fingerprint, qt.Equals, "b129e8fa")
+
+			values := url.Values{}
+			listOpts := &ps.ListOptions{URLValues: &values}
+			for _, opt := range opts {
+				c.Assert(opt(listOpts), qt.IsNil)
+			}
+			c.Assert(values.Get("keyspace"), qt.Equals, "mydb")
+
+			return budgets, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
+
+	cmd := QueryTrafficBudgetsCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--keyspace", "mydb"})
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(svc.ListQueryTrafficBudgetsFnInvoked, qt.IsTrue)
+	c.Assert(cmd.Aliases, qt.DeepEquals, []string{"ls"})
+
+	var out []map[string]any
+	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)
+	c.Assert(out, qt.HasLen, 1)
+	c.Assert(out[0]["id"], qt.Equals, "budget-1")
+	c.Assert(out[0]["name"], qt.Equals, "App queries")
+}

--- a/internal/cmd/trafficcontrol/budget_list.go
+++ b/internal/cmd/trafficcontrol/budget_list.go
@@ -62,7 +62,7 @@ func BudgetListCmd(ch *cmdutil.Helper) *cobra.Command {
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toTrafficBudgets(budgets))
+			return ch.Printer.PrintResource(ToTrafficBudgets(budgets))
 		},
 	}
 

--- a/internal/cmd/trafficcontrol/traffic_control.go
+++ b/internal/cmd/trafficcontrol/traffic_control.go
@@ -88,7 +88,7 @@ func toTrafficBudget(b *ps.TrafficBudget) *TrafficBudget {
 	}
 }
 
-func toTrafficBudgets(budgets []*ps.TrafficBudget) []*TrafficBudget {
+func ToTrafficBudgets(budgets []*ps.TrafficBudget) []*TrafficBudget {
 	out := make([]*TrafficBudget, 0, len(budgets))
 	for _, b := range budgets {
 		out = append(out, toTrafficBudget(b))

--- a/internal/mock/insights.go
+++ b/internal/mock/insights.go
@@ -13,6 +13,9 @@ type QueryInsightsService struct {
 	ListQuerySamplesFn        func(context.Context, *ps.ListQuerySamplesRequest, ...ps.ListOption) ([]*ps.QuerySample, error)
 	ListQuerySamplesFnInvoked bool
 
+	ListQueryTrafficBudgetsFn        func(context.Context, *ps.ListQueryTrafficBudgetsRequest, ...ps.ListOption) ([]*ps.TrafficBudget, error)
+	ListQueryTrafficBudgetsFnInvoked bool
+
 	ListErrorsFn        func(context.Context, *ps.ListQueryInsightsErrorsRequest, ...ps.ListOption) ([]*ps.QueryInsightError, error)
 	ListErrorsFnInvoked bool
 
@@ -53,6 +56,11 @@ func (s *QueryInsightsService) GetAnomaly(ctx context.Context, req *ps.GetAnomal
 func (s *QueryInsightsService) ListQuerySamples(ctx context.Context, req *ps.ListQuerySamplesRequest, opts ...ps.ListOption) ([]*ps.QuerySample, error) {
 	s.ListQuerySamplesFnInvoked = true
 	return s.ListQuerySamplesFn(ctx, req, opts...)
+}
+
+func (s *QueryInsightsService) ListQueryTrafficBudgets(ctx context.Context, req *ps.ListQueryTrafficBudgetsRequest, opts ...ps.ListOption) ([]*ps.TrafficBudget, error) {
+	s.ListQueryTrafficBudgetsFnInvoked = true
+	return s.ListQueryTrafficBudgetsFn(ctx, req, opts...)
 }
 
 func (s *QueryInsightsService) ListErrors(ctx context.Context, req *ps.ListQueryInsightsErrorsRequest, opts ...ps.ListOption) ([]*ps.QueryInsightError, error) {

--- a/internal/planetscale/insights.go
+++ b/internal/planetscale/insights.go
@@ -15,6 +15,7 @@ var _ QueryInsightsService = &queryInsightsService{}
 type QueryInsightsService interface {
 	ListQueries(context.Context, *ListQueryInsightsRequest, ...ListOption) ([]*QueryInsight, error)
 	ListQuerySamples(context.Context, *ListQuerySamplesRequest, ...ListOption) ([]*QuerySample, error)
+	ListQueryTrafficBudgets(context.Context, *ListQueryTrafficBudgetsRequest, ...ListOption) ([]*TrafficBudget, error)
 	ListErrors(context.Context, *ListQueryInsightsErrorsRequest, ...ListOption) ([]*QueryInsightError, error)
 	ListErrorQueries(context.Context, *ListErrorQueriesRequest, ...ListOption) ([]*QuerySample, error)
 	ListAnomalies(context.Context, *ListAnomaliesRequest, ...ListOption) ([]*Anomaly, error)
@@ -167,6 +168,13 @@ type ListQuerySamplesRequest struct {
 	Fingerprint  string
 }
 
+type ListQueryTrafficBudgetsRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Fingerprint  string
+}
+
 // WithSort returns a ListOption that sets the "sort" and "dir" URL parameters.
 func WithSort(sort, dir string) ListOption {
 	return func(opt *ListOptions) error {
@@ -301,6 +309,23 @@ func (s *queryInsightsService) ListQuerySamples(ctx context.Context, request *Li
 
 	resp := &querySamplesResponse{}
 	if err := s.client.do(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}
+
+func (s *queryInsightsService) ListQueryTrafficBudgets(ctx context.Context, request *ListQueryTrafficBudgetsRequest, opts ...ListOption) ([]*TrafficBudget, error) {
+	listOpts := defaultListOptions(opts...)
+
+	pathStr := path.Join(insightsFingerprintAPIPath(request.Organization, request.Database, request.Branch, request.Fingerprint), "traffic", "budgets")
+	req, err := s.client.newRequest(http.MethodGet, pathStr, nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &trafficBudgetsResponse{}
+	if err := s.client.do(ctx, req, resp); err != nil {
 		return nil, err
 	}
 

--- a/internal/planetscale/insights_test.go
+++ b/internal/planetscale/insights_test.go
@@ -307,6 +307,56 @@ func TestQueryInsights_ListQuerySamples(t *testing.T) {
 	})
 }
 
+func TestQueryInsights_ListQueryTrafficBudgets(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/planetscale-go-test-db/branches/main/insights/b129e8fa/traffic/budgets")
+		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "10")
+		c.Assert(r.URL.Query().Get("keyspace"), qt.Equals, "public")
+
+		out := `{
+			"type": "list",
+			"data": [{
+				"id": "budget-1",
+				"name": "App queries",
+				"mode": "enforce",
+				"capacity": 100,
+				"rate": 50,
+				"burst": null,
+				"concurrency": null,
+				"warning_threshold": 80,
+				"rules": [],
+				"actor": {"id": "actor-1", "display_name": "User", "avatar_url": ""},
+				"created_at": "2026-08-11T18:00:00.000Z",
+				"updated_at": "2026-08-11T18:00:00.000Z"
+			}]
+		}`
+		_, err := w.Write([]byte(out))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	budgets, err := client.QueryInsights.ListQueryTrafficBudgets(context.Background(), &ListQueryTrafficBudgetsRequest{
+		Organization: testOrg,
+		Database:     testDatabase,
+		Branch:       "main",
+		Fingerprint:  "b129e8fa",
+	}, WithPage(2), WithPerPage(10), WithKeyspace("public"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(budgets, qt.HasLen, 1)
+	c.Assert(budgets[0].ID, qt.Equals, "budget-1")
+	c.Assert(budgets[0].Name, qt.Equals, "App queries")
+	c.Assert(*budgets[0].Capacity, qt.Equals, 100)
+}
+
 func TestQueryInsights_ListTags(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
## Summary
- add an Insights client method for traffic budgets affecting a query fingerprint
- add `pscale insights queries traffic-budgets` with `ls` alias and optional keyspace filtering
- reuse traffic-control budget rendering and document the command

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`