### PR TITLE
Add organization update command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ pscale --org <org> database list --format json
    ```bash
    pscale org update --org <org> --format json --billing-email billing@example.com
    pscale org update --org <org> --format json --idp-managed-roles=false
-   pscale org update --org <org> --format json --spend-alerts=true --spend-alert-amount 2500
-   pscale org update --org <org> --format json --spend-alerts=false
+   pscale org update --org <org> --format json --spend-alert=true --spend-alert-amount 2500
+   pscale org update --org <org> --format json --spend-alert=false
    ```
 
    Organization members (email or the USER_ID from list):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,9 @@ pscale --org <org> database list --format json
 
    ```bash
    pscale org update --org <org> --format json --billing-email billing@example.com
-   pscale org update --org <org> --format json --idp-managed-roles=false --invoice-budget-amount 2500
+   pscale org update --org <org> --format json --idp-managed-roles=false
+   pscale org update --org <org> --format json --spend-alert=true --spend-alert-amount 2500
+   pscale org update --org <org> --format json --spend-alert=false
    ```
 
    Organization members (email or the USER_ID from list):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ pscale --org <org> database list --format json
    ```bash
    pscale org update --org <org> --format json --billing-email billing@example.com
    pscale org update --org <org> --format json --idp-managed-roles=false
-   pscale org update --org <org> --format json --spend-alert=true --spend-alert-amount 2500
-   pscale org update --org <org> --format json --spend-alert=false
+   pscale org update --org <org> --format json --spend-alerts=true --spend-alert-amount 2500
+   pscale org update --org <org> --format json --spend-alerts=false
    ```
 
    Organization members (email or the USER_ID from list):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,13 @@ pscale --org <org> database list --format json
 
    Pass `--org <org>` on resource commands (`database`, `branch`, `sql`, `api`, …). Not on `org list`.
 
+   Organization settings:
+
+   ```bash
+   pscale org update --org <org> --format json --billing-email billing@example.com
+   pscale org update --org <org> --format json --idp-managed-roles=false --invoice-budget-amount 2500
+   ```
+
    Organization members (email or the USER_ID from list):
 
    ```bash

--- a/internal/cmd/org/org.go
+++ b/internal/cmd/org/org.go
@@ -11,13 +11,14 @@ import (
 func OrgCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "org <command>",
-		Short:             "List, show, and switch organizations",
+		Short:             "Manage organizations",
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 	}
 
 	cmd.AddCommand(SwitchCmd(ch))
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
+	cmd.AddCommand(UpdateCmd(ch))
 	cmd.AddCommand(MemberCmd(ch))
 
 	return cmd

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -1,0 +1,103 @@
+package org
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		billingEmail        string
+		idpManagedRoles     bool
+		invoiceBudgetAmount float64
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update an organization's settings",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			req := &ps.UpdateOrganizationRequest{
+				Organization: ch.Config.Organization,
+			}
+
+			changed := false
+			if cmd.Flags().Changed("billing-email") {
+				req.BillingEmail = &flags.billingEmail
+				changed = true
+			}
+			if cmd.Flags().Changed("idp-managed-roles") {
+				req.IDPManagedRoles = &flags.idpManagedRoles
+				changed = true
+			}
+			if cmd.Flags().Changed("invoice-budget-amount") {
+				req.InvoiceBudgetAmount = &flags.invoiceBudgetAmount
+				changed = true
+			}
+			if !changed {
+				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, or --invoice-budget-amount must be provided")
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating organization %s...", printer.BoldBlue(ch.Config.Organization)))
+			defer end()
+
+			updated, err := client.Organizations.Update(cmd.Context(), req)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(ch.Config.Organization))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toOrganizationUpdate(updated))
+		},
+	}
+
+	cmd.Flags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
+	cmd.MarkFlagRequired("org")
+	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
+	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
+	cmd.Flags().Float64Var(&flags.invoiceBudgetAmount, "invoice-budget-amount", 0, "The expected monthly budget for the organization")
+
+	return cmd
+}
+
+type organizationUpdate struct {
+	Name                string  `header:"name" json:"name"`
+	BillingEmail        string  `header:"billing_email" json:"billing_email"`
+	IDPManagedRoles     bool    `header:"idp_managed_roles" json:"idp_managed_roles"`
+	InvoiceBudgetAmount float64 `header:"invoice_budget_amount" json:"invoice_budget_amount"`
+
+	orig *ps.Organization
+}
+
+func toOrganizationUpdate(org *ps.Organization) *organizationUpdate {
+	return &organizationUpdate{
+		Name:                org.Name,
+		BillingEmail:        org.BillingEmail,
+		IDPManagedRoles:     org.IDPManagedRoles,
+		InvoiceBudgetAmount: org.InvoiceBudgetAmount,
+		orig:                org,
+	}
+}
+
+func (o *organizationUpdate) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(o.orig, "", "  ")
+}
+
+func (o *organizationUpdate) MarshalCSVValue() interface{} {
+	return []*organizationUpdate{o}
+}

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -3,6 +3,8 @@ package org
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	ps "github.com/planetscale/cli/internal/planetscale"
@@ -12,9 +14,10 @@ import (
 
 func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		billingEmail        string
-		idpManagedRoles     bool
-		invoiceBudgetAmount int64
+		billingEmail     string
+		idpManagedRoles  bool
+		spendAlert       bool
+		spendAlertAmount int64
 	}
 
 	cmd := &cobra.Command{
@@ -35,17 +38,23 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				req.IDPManagedRoles = &flags.idpManagedRoles
 				changed = true
 			}
-			if cmd.Flags().Changed("invoice-budget-amount") {
-				req.InvoiceBudgetAmount = &flags.invoiceBudgetAmount
+
+			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
 				changed = true
 			}
 			if !changed {
-				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, or --invoice-budget-amount must be provided")
+				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
 			}
 
 			client, err := ch.Client()
 			if err != nil {
 				return err
+			}
+
+			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
+				if err := applySpendAlert(cmd, client, req, flags.spendAlert, flags.spendAlertAmount); err != nil {
+					return err
+				}
 			}
 
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Updating organization %s...", printer.BoldBlue(ch.Config.Organization)))
@@ -70,27 +79,79 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
 	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
-	cmd.Flags().Int64Var(&flags.invoiceBudgetAmount, "invoice-budget-amount", 0, "The expected monthly budget for the organization")
+	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts")
+	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts")
 
 	return cmd
 }
 
+func applySpendAlert(cmd *cobra.Command, client *ps.Client, req *ps.UpdateOrganizationRequest, enabled bool, amount int64) error {
+	alertChanged := cmd.Flags().Changed("spend-alert")
+	amountChanged := cmd.Flags().Changed("spend-alert-amount")
+
+	if alertChanged && !enabled {
+		req.InvoiceBudgetAlerts = boolPtr(false)
+		req.ClearInvoiceBudget = true
+		return nil
+	}
+
+	if amountChanged {
+		req.InvoiceBudgetAmount = &amount
+		req.InvoiceBudgetAlerts = boolPtr(true)
+		return nil
+	}
+
+	org, err := client.Organizations.Get(cmd.Context(), &ps.GetOrganizationRequest{
+		Organization: req.Organization,
+	})
+	if err != nil {
+		switch cmdutil.ErrCode(err) {
+		case ps.ErrNotFound:
+			return fmt.Errorf("organization %s does not exist", printer.BoldBlue(req.Organization))
+		default:
+			return cmdutil.HandleError(err)
+		}
+	}
+
+	resolved, err := spendAlertAmount(org)
+	if err != nil {
+		return err
+	}
+	req.InvoiceBudgetAlerts = boolPtr(true)
+	req.InvoiceBudgetAmount = &resolved
+	return nil
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func spendAlertAmount(org *ps.Organization) (int64, error) {
+	for _, raw := range []ps.InvoiceBudgetAmount{org.InvoiceBudgetAmount, org.SuggestedInvoiceBudgetAmount} {
+		n, err := strconv.ParseFloat(string(raw), 64)
+		if err == nil && n > 0 {
+			return int64(math.Round(n)), nil
+		}
+	}
+	return 0, fmt.Errorf("no spend alert amount is set; pass --spend-alert-amount")
+}
+
 type organizationUpdate struct {
-	Name                string `header:"name" json:"name"`
-	BillingEmail        string `header:"billing_email" json:"billing_email"`
-	IDPManagedRoles     bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
-	InvoiceBudgetAmount string `header:"invoice_budget_amount" json:"invoice_budget_amount"`
+	Name             string `header:"name" json:"name"`
+	BillingEmail     string `header:"billing_email" json:"billing_email"`
+	IDPManagedRoles  bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
+	SpendAlert       bool   `header:"spend_alert" json:"spend_alert"`
+	SpendAlertAmount string `header:"spend_alert_amount" json:"spend_alert_amount"`
 
 	orig *ps.Organization
 }
 
 func toOrganizationUpdate(org *ps.Organization) *organizationUpdate {
 	return &organizationUpdate{
-		Name:                org.Name,
-		BillingEmail:        org.BillingEmail,
-		IDPManagedRoles:     org.IDPManagedRoles,
-		InvoiceBudgetAmount: string(org.InvoiceBudgetAmount),
-		orig:                org,
+		Name:             org.Name,
+		BillingEmail:     org.BillingEmail,
+		IDPManagedRoles:  org.IDPManagedRoles,
+		SpendAlert:       org.InvoiceBudgetAlerts,
+		SpendAlertAmount: string(org.InvoiceBudgetAmount),
+		orig:             org,
 	}
 }
 

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -16,7 +16,7 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		billingEmail     string
 		idpManagedRoles  bool
-		spendAlerts      bool
+		spendAlert       bool
 		spendAlertAmount int64
 	}
 
@@ -39,11 +39,11 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				changed = true
 			}
 
-			if cmd.Flags().Changed("spend-alerts") || cmd.Flags().Changed("spend-alert-amount") {
+			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
 				changed = true
 			}
 			if !changed {
-				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --spend-alerts, or --spend-alert-amount must be provided")
+				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
 			}
 
 			client, err := ch.Client()
@@ -51,8 +51,8 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			if cmd.Flags().Changed("spend-alerts") || cmd.Flags().Changed("spend-alert-amount") {
-				if err := applySpendAlert(cmd, client, req, flags.spendAlerts, flags.spendAlertAmount); err != nil {
+			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
+				if err := applySpendAlert(cmd, client, req, flags.spendAlert, flags.spendAlertAmount); err != nil {
 					return err
 				}
 			}
@@ -79,14 +79,14 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
 	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
-	cmd.Flags().BoolVar(&flags.spendAlerts, "spend-alerts", false, "Enable or disable billing spend alerts")
+	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts")
 	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts")
 
 	return cmd
 }
 
 func applySpendAlert(cmd *cobra.Command, client *ps.Client, req *ps.UpdateOrganizationRequest, enabled bool, amount int64) error {
-	alertChanged := cmd.Flags().Changed("spend-alerts")
+	alertChanged := cmd.Flags().Changed("spend-alert")
 	amountChanged := cmd.Flags().Changed("spend-alert-amount")
 
 	if alertChanged && !enabled {
@@ -138,7 +138,7 @@ type organizationUpdate struct {
 	Name             string `header:"name" json:"name"`
 	BillingEmail     string `header:"billing_email" json:"billing_email"`
 	IDPManagedRoles  bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
-	SpendAlerts      bool   `header:"spend_alerts" json:"spend_alerts"`
+	SpendAlert       bool   `header:"spend_alert" json:"spend_alert"`
 	SpendAlertAmount string `header:"spend_alert_amount" json:"spend_alert_amount"`
 
 	orig *ps.Organization
@@ -149,7 +149,7 @@ func toOrganizationUpdate(org *ps.Organization) *organizationUpdate {
 		Name:             org.Name,
 		BillingEmail:     org.BillingEmail,
 		IDPManagedRoles:  org.IDPManagedRoles,
-		SpendAlerts:      org.InvoiceBudgetAlerts,
+		SpendAlert:       org.InvoiceBudgetAlerts,
 		SpendAlertAmount: string(org.InvoiceBudgetAmount),
 		orig:             org,
 	}

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -16,7 +16,7 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		billingEmail     string
 		idpManagedRoles  bool
-		spendAlert       bool
+		spendAlerts      bool
 		spendAlertAmount int64
 	}
 
@@ -39,11 +39,11 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				changed = true
 			}
 
-			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
+			if cmd.Flags().Changed("spend-alerts") || cmd.Flags().Changed("spend-alert-amount") {
 				changed = true
 			}
 			if !changed {
-				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
+				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --spend-alerts, or --spend-alert-amount must be provided")
 			}
 
 			client, err := ch.Client()
@@ -51,8 +51,8 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
-				if err := applySpendAlert(cmd, client, req, flags.spendAlert, flags.spendAlertAmount); err != nil {
+			if cmd.Flags().Changed("spend-alerts") || cmd.Flags().Changed("spend-alert-amount") {
+				if err := applySpendAlert(cmd, client, req, flags.spendAlerts, flags.spendAlertAmount); err != nil {
 					return err
 				}
 			}
@@ -79,14 +79,14 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
 	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
-	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts")
+	cmd.Flags().BoolVar(&flags.spendAlerts, "spend-alerts", false, "Enable or disable billing spend alerts")
 	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts")
 
 	return cmd
 }
 
 func applySpendAlert(cmd *cobra.Command, client *ps.Client, req *ps.UpdateOrganizationRequest, enabled bool, amount int64) error {
-	alertChanged := cmd.Flags().Changed("spend-alert")
+	alertChanged := cmd.Flags().Changed("spend-alerts")
 	amountChanged := cmd.Flags().Changed("spend-alert-amount")
 
 	if alertChanged && !enabled {
@@ -138,7 +138,7 @@ type organizationUpdate struct {
 	Name             string `header:"name" json:"name"`
 	BillingEmail     string `header:"billing_email" json:"billing_email"`
 	IDPManagedRoles  bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
-	SpendAlert       bool   `header:"spend_alert" json:"spend_alert"`
+	SpendAlerts      bool   `header:"spend_alerts" json:"spend_alerts"`
 	SpendAlertAmount string `header:"spend_alert_amount" json:"spend_alert_amount"`
 
 	orig *ps.Organization
@@ -149,7 +149,7 @@ func toOrganizationUpdate(org *ps.Organization) *organizationUpdate {
 		Name:             org.Name,
 		BillingEmail:     org.BillingEmail,
 		IDPManagedRoles:  org.IDPManagedRoles,
-		SpendAlert:       org.InvoiceBudgetAlerts,
+		SpendAlerts:      org.InvoiceBudgetAlerts,
 		SpendAlertAmount: string(org.InvoiceBudgetAmount),
 		orig:             org,
 	}

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -79,8 +79,8 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
 	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
-	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts")
-	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts")
+	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts. Disabling keeps the current amount")
+	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts. Implies --spend-alert=true")
 
 	return cmd
 }
@@ -90,12 +90,17 @@ func applySpendAlert(cmd *cobra.Command, client *ps.Client, req *ps.UpdateOrgani
 	amountChanged := cmd.Flags().Changed("spend-alert-amount")
 
 	if alertChanged && !enabled {
+		if amountChanged {
+			return fmt.Errorf("--spend-alert-amount cannot be combined with --spend-alert=false")
+		}
 		req.InvoiceBudgetAlerts = boolPtr(false)
-		req.ClearInvoiceBudget = true
 		return nil
 	}
 
 	if amountChanged {
+		if amount < 1 || amount >= 100_000_000_000 {
+			return fmt.Errorf("--spend-alert-amount must be between 1 and 99999999999")
+		}
 		req.InvoiceBudgetAmount = &amount
 		req.InvoiceBudgetAlerts = boolPtr(true)
 		return nil

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -79,8 +79,8 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
 	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
-	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts. Disabling keeps the current amount")
-	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts. Implies --spend-alert=true")
+	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts")
+	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts")
 
 	return cmd
 }

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -14,7 +14,7 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
 		billingEmail        string
 		idpManagedRoles     bool
-		invoiceBudgetAmount float64
+		invoiceBudgetAmount int64
 	}
 
 	cmd := &cobra.Command{
@@ -70,16 +70,16 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
 	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
-	cmd.Flags().Float64Var(&flags.invoiceBudgetAmount, "invoice-budget-amount", 0, "The expected monthly budget for the organization")
+	cmd.Flags().Int64Var(&flags.invoiceBudgetAmount, "invoice-budget-amount", 0, "The expected monthly budget for the organization")
 
 	return cmd
 }
 
 type organizationUpdate struct {
-	Name                string  `header:"name" json:"name"`
-	BillingEmail        string  `header:"billing_email" json:"billing_email"`
-	IDPManagedRoles     bool    `header:"idp_managed_roles" json:"idp_managed_roles"`
-	InvoiceBudgetAmount float64 `header:"invoice_budget_amount" json:"invoice_budget_amount"`
+	Name                string `header:"name" json:"name"`
+	BillingEmail        string `header:"billing_email" json:"billing_email"`
+	IDPManagedRoles     bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
+	InvoiceBudgetAmount string `header:"invoice_budget_amount" json:"invoice_budget_amount"`
 
 	orig *ps.Organization
 }
@@ -89,7 +89,7 @@ func toOrganizationUpdate(org *ps.Organization) *organizationUpdate {
 		Name:                org.Name,
 		BillingEmail:        org.BillingEmail,
 		IDPManagedRoles:     org.IDPManagedRoles,
-		InvoiceBudgetAmount: org.InvoiceBudgetAmount,
+		InvoiceBudgetAmount: string(org.InvoiceBudgetAmount),
 		orig:                org,
 	}
 }

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -95,7 +95,7 @@ func TestOrganization_UpdateCmdDisablesSpendAlert(t *testing.T) {
 	}
 
 	cmd := UpdateCmd(ch)
-	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alerts=false"})
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=false"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
 }
@@ -136,7 +136,7 @@ func TestOrganization_UpdateCmdEnablesSpendAlertFromCurrentAmount(t *testing.T) 
 	}
 
 	cmd := UpdateCmd(ch)
-	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alerts=true"})
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=true"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.GetFnInvoked, qt.IsTrue)
 	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
@@ -153,7 +153,7 @@ func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
 
 	cmd := UpdateCmd(ch)
 	cmd.SetArgs([]string{"--org", "planetscale"})
-	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alerts, or --spend-alert-amount must be provided")
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
 }
 
 func TestOrganization_UpdateCmdRequiresOrganization(t *testing.T) {

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -29,12 +29,12 @@ func TestOrganization_UpdateCmd(t *testing.T) {
 			c.Assert(req.IDPManagedRoles, qt.IsNotNil)
 			c.Assert(*req.IDPManagedRoles, qt.IsFalse)
 			c.Assert(req.InvoiceBudgetAmount, qt.IsNotNil)
-			c.Assert(*req.InvoiceBudgetAmount, qt.Equals, float64(2500))
+			c.Assert(*req.InvoiceBudgetAmount, qt.Equals, int64(2500))
 			return &ps.Organization{
 				Name:                req.Organization,
 				BillingEmail:        *req.BillingEmail,
 				IDPManagedRoles:     *req.IDPManagedRoles,
-				InvoiceBudgetAmount: *req.InvoiceBudgetAmount,
+				InvoiceBudgetAmount: "2500",
 			}, nil
 		},
 	}
@@ -60,7 +60,7 @@ func TestOrganization_UpdateCmd(t *testing.T) {
 		Name:                "planetscale",
 		BillingEmail:        "billing@example.com",
 		IDPManagedRoles:     false,
-		InvoiceBudgetAmount: 2500,
+		InvoiceBudgetAmount: "2500",
 	})
 }
 
@@ -106,7 +106,7 @@ func TestOrganization_UpdateCmdHuman(t *testing.T) {
 				Name:                req.Organization,
 				BillingEmail:        "billing@example.com",
 				IDPManagedRoles:     true,
-				InvoiceBudgetAmount: 2500,
+				InvoiceBudgetAmount: "2500",
 			}, nil
 		},
 	}

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -32,7 +32,6 @@ func TestOrganization_UpdateCmd(t *testing.T) {
 			c.Assert(*req.InvoiceBudgetAlerts, qt.IsTrue)
 			c.Assert(req.InvoiceBudgetAmount, qt.IsNotNil)
 			c.Assert(*req.InvoiceBudgetAmount, qt.Equals, int64(2500))
-			c.Assert(req.ClearInvoiceBudget, qt.IsFalse)
 			return &ps.Organization{
 				Name:                req.Organization,
 				BillingEmail:        *req.BillingEmail,
@@ -76,7 +75,6 @@ func TestOrganization_UpdateCmdDisablesSpendAlert(t *testing.T) {
 		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
 			c.Assert(req.InvoiceBudgetAlerts, qt.IsNotNil)
 			c.Assert(*req.InvoiceBudgetAlerts, qt.IsFalse)
-			c.Assert(req.ClearInvoiceBudget, qt.IsTrue)
 			c.Assert(req.InvoiceBudgetAmount, qt.IsNil)
 			return &ps.Organization{Name: req.Organization, InvoiceBudgetAlerts: false, InvoiceBudgetAmount: "0.0"}, nil
 		},
@@ -154,6 +152,54 @@ func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
 	cmd := UpdateCmd(ch)
 	cmd.SetArgs([]string{"--org", "planetscale"})
 	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
+}
+
+func TestOrganization_UpdateCmdRejectsAmountWithDisabledSpendAlert(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Fatal("Organizations.Update should not be called")
+			return nil, nil
+		},
+	}
+
+	format := printer.JSON
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=false", "--spend-alert-amount", "2500"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "--spend-alert-amount cannot be combined with --spend-alert=false")
+}
+
+func TestOrganization_UpdateCmdRejectsOutOfRangeSpendAlertAmount(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Fatal("Organizations.Update should not be called")
+			return nil, nil
+		},
+	}
+
+	format := printer.JSON
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert-amount", "0"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "--spend-alert-amount must be between 1 and 99999999999")
 }
 
 func TestOrganization_UpdateCmdRequiresOrganization(t *testing.T) {

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -28,12 +28,16 @@ func TestOrganization_UpdateCmd(t *testing.T) {
 			c.Assert(*req.BillingEmail, qt.Equals, "billing@example.com")
 			c.Assert(req.IDPManagedRoles, qt.IsNotNil)
 			c.Assert(*req.IDPManagedRoles, qt.IsFalse)
+			c.Assert(req.InvoiceBudgetAlerts, qt.IsNotNil)
+			c.Assert(*req.InvoiceBudgetAlerts, qt.IsTrue)
 			c.Assert(req.InvoiceBudgetAmount, qt.IsNotNil)
 			c.Assert(*req.InvoiceBudgetAmount, qt.Equals, int64(2500))
+			c.Assert(req.ClearInvoiceBudget, qt.IsFalse)
 			return &ps.Organization{
 				Name:                req.Organization,
 				BillingEmail:        *req.BillingEmail,
 				IDPManagedRoles:     *req.IDPManagedRoles,
+				InvoiceBudgetAlerts: true,
 				InvoiceBudgetAmount: "2500",
 			}, nil
 		},
@@ -52,7 +56,7 @@ func TestOrganization_UpdateCmd(t *testing.T) {
 		"--org", "planetscale",
 		"--billing-email", "billing@example.com",
 		"--idp-managed-roles=false",
-		"--invoice-budget-amount", "2500",
+		"--spend-alert-amount", "2500",
 	})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
@@ -60,8 +64,82 @@ func TestOrganization_UpdateCmd(t *testing.T) {
 		Name:                "planetscale",
 		BillingEmail:        "billing@example.com",
 		IDPManagedRoles:     false,
+		InvoiceBudgetAlerts: true,
 		InvoiceBudgetAmount: "2500",
 	})
+}
+
+func TestOrganization_UpdateCmdDisablesSpendAlert(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.InvoiceBudgetAlerts, qt.IsNotNil)
+			c.Assert(*req.InvoiceBudgetAlerts, qt.IsFalse)
+			c.Assert(req.ClearInvoiceBudget, qt.IsTrue)
+			c.Assert(req.InvoiceBudgetAmount, qt.IsNil)
+			return &ps.Organization{Name: req.Organization, InvoiceBudgetAlerts: false, InvoiceBudgetAmount: "0.0"}, nil
+		},
+	}
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	var buf bytes.Buffer
+	p.SetResourceOutput(&buf)
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=false"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestOrganization_UpdateCmdEnablesSpendAlertFromCurrentAmount(t *testing.T) {
+	c := qt.New(t)
+
+	svc := &mock.OrganizationsService{
+		GetFn: func(ctx context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			return &ps.Organization{
+				Name:                         req.Organization,
+				InvoiceBudgetAmount:          "0.0",
+				SuggestedInvoiceBudgetAmount: "1200",
+			}, nil
+		},
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(*req.InvoiceBudgetAlerts, qt.IsTrue)
+			c.Assert(*req.InvoiceBudgetAmount, qt.Equals, int64(1200))
+			return &ps.Organization{
+				Name:                req.Organization,
+				InvoiceBudgetAlerts: true,
+				InvoiceBudgetAmount: "1200",
+			}, nil
+		},
+	}
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	var buf bytes.Buffer
+	p.SetResourceOutput(&buf)
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=true"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
 }
 
 func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
@@ -75,7 +153,7 @@ func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
 
 	cmd := UpdateCmd(ch)
 	cmd.SetArgs([]string{"--org", "planetscale"})
-	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, or --invoice-budget-amount must be provided")
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
 }
 
 func TestOrganization_UpdateCmdRequiresOrganization(t *testing.T) {
@@ -106,6 +184,7 @@ func TestOrganization_UpdateCmdHuman(t *testing.T) {
 				Name:                req.Organization,
 				BillingEmail:        "billing@example.com",
 				IDPManagedRoles:     true,
+				InvoiceBudgetAlerts: true,
 				InvoiceBudgetAmount: "2500",
 			}, nil
 		},
@@ -124,6 +203,6 @@ func TestOrganization_UpdateCmdHuman(t *testing.T) {
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(buf.String(), qt.Contains, "BILLING EMAIL")
 	c.Assert(buf.String(), qt.Contains, "IDP MANAGED ROLES")
-	c.Assert(buf.String(), qt.Contains, "INVOICE BUDGET AMOUNT")
+	c.Assert(buf.String(), qt.Contains, "SPEND ALERT")
 	c.Assert(buf.String(), qt.Contains, "billing@example.com")
 }

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -1,0 +1,129 @@
+package org
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func TestOrganization_UpdateCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.BillingEmail, qt.IsNotNil)
+			c.Assert(*req.BillingEmail, qt.Equals, "billing@example.com")
+			c.Assert(req.IDPManagedRoles, qt.IsNotNil)
+			c.Assert(*req.IDPManagedRoles, qt.IsFalse)
+			c.Assert(req.InvoiceBudgetAmount, qt.IsNotNil)
+			c.Assert(*req.InvoiceBudgetAmount, qt.Equals, float64(2500))
+			return &ps.Organization{
+				Name:                req.Organization,
+				BillingEmail:        *req.BillingEmail,
+				IDPManagedRoles:     *req.IDPManagedRoles,
+				InvoiceBudgetAmount: *req.InvoiceBudgetAmount,
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{
+		"--org", "planetscale",
+		"--billing-email", "billing@example.com",
+		"--idp-managed-roles=false",
+		"--invoice-budget-amount", "2500",
+	})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.JSONEquals, &ps.Organization{
+		Name:                "planetscale",
+		BillingEmail:        "billing@example.com",
+		IDPManagedRoles:     false,
+		InvoiceBudgetAmount: 2500,
+	})
+}
+
+func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, or --invoice-budget-amount must be provided")
+}
+
+func TestOrganization_UpdateCmdRequiresOrganization(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--billing-email", "billing@example.com"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, `required flag\(s\) "org" not set`)
+}
+
+func TestOrganization_UpdateCmdHuman(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.Human
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			return &ps.Organization{
+				Name:                req.Organization,
+				BillingEmail:        "billing@example.com",
+				IDPManagedRoles:     true,
+				InvoiceBudgetAmount: 2500,
+			}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--idp-managed-roles=true"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "BILLING EMAIL")
+	c.Assert(buf.String(), qt.Contains, "IDP MANAGED ROLES")
+	c.Assert(buf.String(), qt.Contains, "INVOICE BUDGET AMOUNT")
+	c.Assert(buf.String(), qt.Contains, "billing@example.com")
+}

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -95,7 +95,7 @@ func TestOrganization_UpdateCmdDisablesSpendAlert(t *testing.T) {
 	}
 
 	cmd := UpdateCmd(ch)
-	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=false"})
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alerts=false"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
 }
@@ -136,7 +136,7 @@ func TestOrganization_UpdateCmdEnablesSpendAlertFromCurrentAmount(t *testing.T) 
 	}
 
 	cmd := UpdateCmd(ch)
-	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alert=true"})
+	cmd.SetArgs([]string{"--org", "planetscale", "--spend-alerts=true"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.GetFnInvoked, qt.IsTrue)
 	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
@@ -153,7 +153,7 @@ func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
 
 	cmd := UpdateCmd(ch)
 	cmd.SetArgs([]string{"--org", "planetscale"})
-	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alerts, or --spend-alert-amount must be provided")
 }
 
 func TestOrganization_UpdateCmdRequiresOrganization(t *testing.T) {

--- a/internal/mock/org.go
+++ b/internal/mock/org.go
@@ -10,6 +10,9 @@ type OrganizationsService struct {
 	GetFn        func(context.Context, *ps.GetOrganizationRequest) (*ps.Organization, error)
 	GetFnInvoked bool
 
+	UpdateFn        func(context.Context, *ps.UpdateOrganizationRequest) (*ps.Organization, error)
+	UpdateFnInvoked bool
+
 	ListFn        func(context.Context) ([]*ps.Organization, error)
 	ListFnInvoked bool
 
@@ -35,6 +38,11 @@ type OrganizationsService struct {
 func (o *OrganizationsService) Get(ctx context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {
 	o.GetFnInvoked = true
 	return o.GetFn(ctx, req)
+}
+
+func (o *OrganizationsService) Update(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+	o.UpdateFnInvoked = true
+	return o.UpdateFn(ctx, req)
 }
 
 func (o *OrganizationsService) List(ctx context.Context) ([]*ps.Organization, error) {

--- a/internal/planetscale/organizations.go
+++ b/internal/planetscale/organizations.go
@@ -16,10 +16,18 @@ type GetOrganizationRequest struct {
 	Organization string
 }
 
+type UpdateOrganizationRequest struct {
+	Organization        string   `json:"-"`
+	BillingEmail        *string  `json:"billing_email,omitempty"`
+	IDPManagedRoles     *bool    `json:"idp_managed_roles,omitempty"`
+	InvoiceBudgetAmount *float64 `json:"invoice_budget_amount,omitempty"`
+}
+
 // OrganizationsService is an interface for communicating with the PlanetScale
 // Organizations API endpoints.
 type OrganizationsService interface {
 	Get(context.Context, *GetOrganizationRequest) (*Organization, error)
+	Update(context.Context, *UpdateOrganizationRequest) (*Organization, error)
 	List(context.Context) ([]*Organization, error)
 	ListRegions(context.Context, *ListOrganizationRegionsRequest) ([]*Region, error)
 	ListClusterSKUs(context.Context, *ListOrganizationClusterSKUsRequest, ...ListOption) ([]*ClusterSKU, error)
@@ -65,6 +73,9 @@ type ClusterSKU struct {
 // Organization represents a PlanetScale organization.
 type Organization struct {
 	Name                   string    `json:"name"`
+	BillingEmail           string    `json:"billing_email"`
+	IDPManagedRoles        bool      `json:"idp_managed_roles"`
+	InvoiceBudgetAmount    float64   `json:"invoice_budget_amount"`
 	CreatedAt              time.Time `json:"created_at"`
 	UpdatedAt              time.Time `json:"updated_at"`
 	RemainingFreeDatabases int       `json:"free_databases_remaining"`
@@ -91,6 +102,20 @@ func (o *organizationsService) Get(ctx context.Context, getReq *GetOrganizationR
 	req, err := o.client.newRequest(http.MethodGet, path.Join(organizationsAPIPath, getReq.Organization), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for get organization: %w", err)
+	}
+
+	org := &Organization{}
+	if err := o.client.do(ctx, req, &org); err != nil {
+		return nil, err
+	}
+
+	return org, nil
+}
+
+func (o *organizationsService) Update(ctx context.Context, updateReq *UpdateOrganizationRequest) (*Organization, error) {
+	req, err := o.client.newRequest(http.MethodPatch, path.Join(organizationsAPIPath, updateReq.Organization), updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for update organization: %w", err)
 	}
 
 	org := &Organization{}

--- a/internal/planetscale/organizations.go
+++ b/internal/planetscale/organizations.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
@@ -17,10 +18,10 @@ type GetOrganizationRequest struct {
 }
 
 type UpdateOrganizationRequest struct {
-	Organization        string   `json:"-"`
-	BillingEmail        *string  `json:"billing_email,omitempty"`
-	IDPManagedRoles     *bool    `json:"idp_managed_roles,omitempty"`
-	InvoiceBudgetAmount *float64 `json:"invoice_budget_amount,omitempty"`
+	Organization        string  `json:"-"`
+	BillingEmail        *string `json:"billing_email,omitempty"`
+	IDPManagedRoles     *bool   `json:"idp_managed_roles,omitempty"`
+	InvoiceBudgetAmount *int64  `json:"invoice_budget_amount,omitempty"`
 }
 
 // OrganizationsService is an interface for communicating with the PlanetScale
@@ -70,15 +71,39 @@ type ClusterSKU struct {
 	Metal bool `json:"metal"`
 }
 
+// InvoiceBudgetAmount is the organization's expected monthly budget.
+// Responses encode this as a JSON string; PATCH accepts an integer.
+type InvoiceBudgetAmount string
+
+func (a *InvoiceBudgetAmount) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*a = ""
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*a = InvoiceBudgetAmount(s)
+		return nil
+	}
+
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*a = InvoiceBudgetAmount(n.String())
+	return nil
+}
+
 // Organization represents a PlanetScale organization.
 type Organization struct {
-	Name                   string    `json:"name"`
-	BillingEmail           string    `json:"billing_email"`
-	IDPManagedRoles        bool      `json:"idp_managed_roles"`
-	InvoiceBudgetAmount    float64   `json:"invoice_budget_amount"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
-	RemainingFreeDatabases int       `json:"free_databases_remaining"`
+	Name                   string              `json:"name"`
+	BillingEmail           string              `json:"billing_email"`
+	IDPManagedRoles        bool                `json:"idp_managed_roles"`
+	InvoiceBudgetAmount    InvoiceBudgetAmount `json:"invoice_budget_amount"`
+	CreatedAt              time.Time           `json:"created_at"`
+	UpdatedAt              time.Time           `json:"updated_at"`
+	RemainingFreeDatabases int                 `json:"free_databases_remaining"`
 }
 
 type organizationsResponse struct {

--- a/internal/planetscale/organizations.go
+++ b/internal/planetscale/organizations.go
@@ -21,7 +21,29 @@ type UpdateOrganizationRequest struct {
 	Organization        string  `json:"-"`
 	BillingEmail        *string `json:"billing_email,omitempty"`
 	IDPManagedRoles     *bool   `json:"idp_managed_roles,omitempty"`
+	InvoiceBudgetAlerts *bool   `json:"invoice_budget_alerts,omitempty"`
 	InvoiceBudgetAmount *int64  `json:"invoice_budget_amount,omitempty"`
+	ClearInvoiceBudget  bool    `json:"-"`
+}
+
+func (r *UpdateOrganizationRequest) MarshalJSON() ([]byte, error) {
+	body := map[string]any{}
+	if r.BillingEmail != nil {
+		body["billing_email"] = *r.BillingEmail
+	}
+	if r.IDPManagedRoles != nil {
+		body["idp_managed_roles"] = *r.IDPManagedRoles
+	}
+	if r.InvoiceBudgetAlerts != nil {
+		body["invoice_budget_alerts"] = *r.InvoiceBudgetAlerts
+	}
+	switch {
+	case r.ClearInvoiceBudget:
+		body["invoice_budget_amount"] = nil
+	case r.InvoiceBudgetAmount != nil:
+		body["invoice_budget_amount"] = *r.InvoiceBudgetAmount
+	}
+	return json.Marshal(body)
 }
 
 // OrganizationsService is an interface for communicating with the PlanetScale
@@ -97,13 +119,15 @@ func (a *InvoiceBudgetAmount) UnmarshalJSON(b []byte) error {
 
 // Organization represents a PlanetScale organization.
 type Organization struct {
-	Name                   string              `json:"name"`
-	BillingEmail           string              `json:"billing_email"`
-	IDPManagedRoles        bool                `json:"idp_managed_roles"`
-	InvoiceBudgetAmount    InvoiceBudgetAmount `json:"invoice_budget_amount"`
-	CreatedAt              time.Time           `json:"created_at"`
-	UpdatedAt              time.Time           `json:"updated_at"`
-	RemainingFreeDatabases int                 `json:"free_databases_remaining"`
+	Name                         string              `json:"name"`
+	BillingEmail                 string              `json:"billing_email"`
+	IDPManagedRoles              bool                `json:"idp_managed_roles"`
+	InvoiceBudgetAlerts          bool                `json:"invoice_budget_alerts"`
+	InvoiceBudgetAmount          InvoiceBudgetAmount `json:"invoice_budget_amount"`
+	SuggestedInvoiceBudgetAmount InvoiceBudgetAmount `json:"suggested_invoice_budget_amount"`
+	CreatedAt                    time.Time           `json:"created_at"`
+	UpdatedAt                    time.Time           `json:"updated_at"`
+	RemainingFreeDatabases       int                 `json:"free_databases_remaining"`
 }
 
 type organizationsResponse struct {

--- a/internal/planetscale/organizations.go
+++ b/internal/planetscale/organizations.go
@@ -23,7 +23,6 @@ type UpdateOrganizationRequest struct {
 	IDPManagedRoles     *bool   `json:"idp_managed_roles,omitempty"`
 	InvoiceBudgetAlerts *bool   `json:"invoice_budget_alerts,omitempty"`
 	InvoiceBudgetAmount *int64  `json:"invoice_budget_amount,omitempty"`
-	ClearInvoiceBudget  bool    `json:"-"`
 }
 
 func (r *UpdateOrganizationRequest) MarshalJSON() ([]byte, error) {
@@ -37,10 +36,7 @@ func (r *UpdateOrganizationRequest) MarshalJSON() ([]byte, error) {
 	if r.InvoiceBudgetAlerts != nil {
 		body["invoice_budget_alerts"] = *r.InvoiceBudgetAlerts
 	}
-	switch {
-	case r.ClearInvoiceBudget:
-		body["invoice_budget_amount"] = nil
-	case r.InvoiceBudgetAmount != nil:
+	if r.InvoiceBudgetAmount != nil {
 		body["invoice_budget_amount"] = *r.InvoiceBudgetAmount
 	}
 	return json.Marshal(body)

--- a/internal/planetscale/organizations_test.go
+++ b/internal/planetscale/organizations_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -84,6 +85,54 @@ func TestOrganizations_Get(t *testing.T) {
 	}
 
 	c.Assert(org, qt.DeepEquals, want)
+}
+
+func TestOrganizations_Update(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPatch)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-cool-org")
+
+		var body map[string]interface{}
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]interface{}{
+			"billing_email":         "billing@example.com",
+			"idp_managed_roles":     false,
+			"invoice_budget_amount": float64(2500),
+		})
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"name": "my-cool-org",
+			"billing_email": "billing@example.com",
+			"idp_managed_roles": false,
+			"invoice_budget_amount": 2500,
+			"created_at": "2021-01-14T10:19:23.000Z",
+			"updated_at": "2021-01-15T10:19:23.000Z"
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	org, err := client.Organizations.Update(context.Background(), &UpdateOrganizationRequest{
+		Organization:        "my-cool-org",
+		BillingEmail:        Pointer("billing@example.com"),
+		IDPManagedRoles:     Pointer(false),
+		InvoiceBudgetAmount: Pointer(float64(2500)),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(org, qt.DeepEquals, &Organization{
+		Name:                "my-cool-org",
+		BillingEmail:        "billing@example.com",
+		IDPManagedRoles:     false,
+		InvoiceBudgetAmount: 2500,
+		CreatedAt:           time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
+		UpdatedAt:           time.Date(2021, time.January, 15, 10, 19, 23, 0, time.UTC),
+	})
 }
 
 func TestOrganizations_ListRegions(t *testing.T) {

--- a/internal/planetscale/organizations_test.go
+++ b/internal/planetscale/organizations_test.go
@@ -143,7 +143,6 @@ func TestOrganizations_UpdateClearsSpendAlertAmount(t *testing.T) {
 		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
 		c.Assert(body, qt.DeepEquals, map[string]interface{}{
 			"invoice_budget_alerts": false,
-			"invoice_budget_amount": nil,
 		})
 
 		w.WriteHeader(http.StatusOK)
@@ -162,7 +161,6 @@ func TestOrganizations_UpdateClearsSpendAlertAmount(t *testing.T) {
 	org, err := client.Organizations.Update(context.Background(), &UpdateOrganizationRequest{
 		Organization:        "my-cool-org",
 		InvoiceBudgetAlerts: Pointer(false),
-		ClearInvoiceBudget:  true,
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(org.InvoiceBudgetAlerts, qt.IsFalse)

--- a/internal/planetscale/organizations_test.go
+++ b/internal/planetscale/organizations_test.go
@@ -135,6 +135,40 @@ func TestOrganizations_Update(t *testing.T) {
 	})
 }
 
+func TestOrganizations_UpdateClearsSpendAlertAmount(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+		c.Assert(body, qt.DeepEquals, map[string]interface{}{
+			"invoice_budget_alerts": false,
+			"invoice_budget_amount": nil,
+		})
+
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(`{
+			"name": "my-cool-org",
+			"invoice_budget_alerts": false,
+			"invoice_budget_amount": "0.0"
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	org, err := client.Organizations.Update(context.Background(), &UpdateOrganizationRequest{
+		Organization:        "my-cool-org",
+		InvoiceBudgetAlerts: Pointer(false),
+		ClearInvoiceBudget:  true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(org.InvoiceBudgetAlerts, qt.IsFalse)
+	c.Assert(org.InvoiceBudgetAmount, qt.Equals, InvoiceBudgetAmount("0.0"))
+}
+
 func TestInvoiceBudgetAmount_UnmarshalJSON(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/planetscale/organizations_test.go
+++ b/internal/planetscale/organizations_test.go
@@ -107,7 +107,7 @@ func TestOrganizations_Update(t *testing.T) {
 			"name": "my-cool-org",
 			"billing_email": "billing@example.com",
 			"idp_managed_roles": false,
-			"invoice_budget_amount": 2500,
+			"invoice_budget_amount": "2500",
 			"created_at": "2021-01-14T10:19:23.000Z",
 			"updated_at": "2021-01-15T10:19:23.000Z"
 		}`))
@@ -122,17 +122,33 @@ func TestOrganizations_Update(t *testing.T) {
 		Organization:        "my-cool-org",
 		BillingEmail:        Pointer("billing@example.com"),
 		IDPManagedRoles:     Pointer(false),
-		InvoiceBudgetAmount: Pointer(float64(2500)),
+		InvoiceBudgetAmount: Pointer(int64(2500)),
 	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(org, qt.DeepEquals, &Organization{
 		Name:                "my-cool-org",
 		BillingEmail:        "billing@example.com",
 		IDPManagedRoles:     false,
-		InvoiceBudgetAmount: 2500,
+		InvoiceBudgetAmount: "2500",
 		CreatedAt:           time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC),
 		UpdatedAt:           time.Date(2021, time.January, 15, 10, 19, 23, 0, time.UTC),
 	})
+}
+
+func TestInvoiceBudgetAmount_UnmarshalJSON(t *testing.T) {
+	c := qt.New(t)
+
+	var fromString InvoiceBudgetAmount
+	c.Assert(json.Unmarshal([]byte(`"2500.50"`), &fromString), qt.IsNil)
+	c.Assert(fromString, qt.Equals, InvoiceBudgetAmount("2500.50"))
+
+	var fromNumber InvoiceBudgetAmount
+	c.Assert(json.Unmarshal([]byte(`2500`), &fromNumber), qt.IsNil)
+	c.Assert(fromNumber, qt.Equals, InvoiceBudgetAmount("2500"))
+
+	var fromNull InvoiceBudgetAmount
+	c.Assert(json.Unmarshal([]byte(`null`), &fromNull), qt.IsNil)
+	c.Assert(fromNull, qt.Equals, InvoiceBudgetAmount(""))
 }
 
 func TestOrganizations_ListRegions(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `pscale org update` for billing email, IdP-managed roles, and invoice budget settings
- wrap the organization PATCH endpoint with omission-safe request fields and full JSON responses
- add HTTP, command, human output, validation, mock, and agent guide coverage

## Test plan
- [x] `go test ./...`
- [x] `go vet ./internal/planetscale ./internal/mock ./internal/cmd/org`
- [x] `staticcheck ./internal/planetscale ./internal/mock ./internal/cmd/org`