### PR TITLE
Add organization team management commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ pscale --org <org> database list --format json
 
    ```bash
    pscale org member list --org <org> --format json
+   pscale org member list --org <org> --format json --page 2 --per-page 25
    pscale org member show user@example.com --org <org> --format json
    pscale org member update user@example.com --org <org> --format json --role member
    pscale org member remove user@example.com --org <org> --format json --force
@@ -101,11 +102,13 @@ Organization teams and team members:
 
 ```bash
 pscale org team list --org <org> --format json
+pscale org team list --org <org> --format json --page 2 --per-page 25
 pscale org team show <team-id-or-name> --org <org> --format json
 pscale org team create --name <name> --description <description> --org <org> --format json
 pscale org team update <team> --name <name> --description <description> --org <org> --format json
 pscale org team delete <team> --org <org> --format json --force
 pscale org team member list <team> --org <org> --format json
+pscale org team member list <team> --org <org> --format json --page 2 --per-page 25
 pscale org team member add <team> <email-or-id> --org <org> --format json
 pscale org team member remove <team> <email-or-id> --org <org> --format json --force
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,21 @@ pscale --org <org> database list --format json
 
    Only org admins can change another member's role or remove someone else. Nobody can change their own role. `--role` is `admin`, `member`, or `analyst`.
 
+Organization teams and team members:
+
+```bash
+pscale org team list --org <org> --format json
+pscale org team show <team-id-or-name> --org <org> --format json
+pscale org team create --name <name> --description <description> --org <org> --format json
+pscale org team update <team> --name <name> --description <description> --org <org> --format json
+pscale org team delete <team> --org <org> --format json --force
+pscale org team member list <team> --org <org> --format json
+pscale org team member add <team> <email-or-id> --org <org> --format json
+pscale org team member remove <team> <email-or-id> --org <org> --format json --force
+```
+
+Team identifiers may be IDs, names, or slugs. Team and membership deletion requires approval before using `--force`. SSO/directory-managed teams cannot be updated, deleted, or have members added or removed through the API.
+
 5. **Discover resources** before SQL:
 
    ```bash

--- a/internal/cmd/org/org.go
+++ b/internal/cmd/org/org.go
@@ -19,6 +19,7 @@ func OrgCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(ListCmd(ch))
 	cmd.AddCommand(MemberCmd(ch))
+	cmd.AddCommand(TeamCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/org/team.go
+++ b/internal/cmd/org/team.go
@@ -1,0 +1,496 @@
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func TeamCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team <command>",
+		Short: "Manage organization teams",
+	}
+	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
+	cmd.MarkPersistentFlagRequired("org")
+	cmd.AddCommand(TeamListCmd(ch))
+	cmd.AddCommand(TeamShowCmd(ch))
+	cmd.AddCommand(TeamCreateCmd(ch))
+	cmd.AddCommand(TeamUpdateCmd(ch))
+	cmd.AddCommand(TeamDeleteCmd(ch))
+	cmd.AddCommand(TeamMemberCmd(ch))
+	return cmd
+}
+
+type organizationTeam struct {
+	ID          string `header:"id" json:"id"`
+	Name        string `header:"name" json:"name"`
+	Slug        string `header:"slug" json:"slug"`
+	Description string `header:"description" json:"description"`
+	Members     int    `header:"members" json:"members"`
+	Managed     bool   `header:"managed" json:"managed"`
+	orig        *ps.OrganizationTeam
+}
+
+func toOrganizationTeam(team *ps.OrganizationTeam) *organizationTeam {
+	description := ""
+	if team.Description != nil {
+		description = *team.Description
+	}
+	return &organizationTeam{
+		ID:          team.ID,
+		Name:        team.Name,
+		Slug:        team.Slug,
+		Description: description,
+		Members:     len(team.Members),
+		Managed:     team.Managed,
+		orig:        team,
+	}
+}
+
+func toOrganizationTeams(teams []*ps.OrganizationTeam) []*organizationTeam {
+	out := make([]*organizationTeam, 0, len(teams))
+	for _, team := range teams {
+		out = append(out, toOrganizationTeam(team))
+	}
+	return out
+}
+
+func (t *organizationTeam) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(t.orig, "", "  ")
+}
+
+func (t *organizationTeam) MarshalCSVValue() interface{} {
+	return []*organizationTeam{t}
+}
+
+type organizationTeamMember struct {
+	ID     string `header:"id" json:"id"`
+	UserID string `header:"user_id" json:"user_id"`
+	Name   string `header:"name" json:"name"`
+	Email  string `header:"email" json:"email"`
+	orig   *ps.OrganizationTeamMembership
+}
+
+func toOrganizationTeamMember(member *ps.OrganizationTeamMembership) *organizationTeamMember {
+	name := member.User.DisplayName
+	if name == "" {
+		name = member.User.Name
+	}
+	return &organizationTeamMember{
+		ID:     member.ID,
+		UserID: member.User.ID,
+		Name:   name,
+		Email:  member.User.Email,
+		orig:   member,
+	}
+}
+
+func toOrganizationTeamMembers(members []*ps.OrganizationTeamMembership) []*organizationTeamMember {
+	out := make([]*organizationTeamMember, 0, len(members))
+	for _, member := range members {
+		out = append(out, toOrganizationTeamMember(member))
+	}
+	return out
+}
+
+func (m *organizationTeamMember) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(m.orig, "", "  ")
+}
+
+func (m *organizationTeamMember) MarshalCSVValue() interface{} {
+	return []*organizationTeamMember{m}
+}
+
+func teamNotFound(org, id string) error {
+	return fmt.Errorf("team %s does not exist in organization %s", printer.BoldBlue(id), printer.BoldBlue(org))
+}
+
+func resolveTeam(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, id string) (*ps.OrganizationTeam, error) {
+	org := ch.Config.Organization
+	team, err := client.Organizations.GetTeam(ctx, &ps.GetOrganizationTeamRequest{
+		Organization: org,
+		Team:         id,
+	})
+	if err == nil {
+		return team, nil
+	}
+	if cmdutil.ErrCode(err) != ps.ErrNotFound {
+		return nil, cmdutil.HandleError(err)
+	}
+
+	const perPage = 100
+	for _, query := range []string{id, ""} {
+		page := 1
+		for {
+			teams, listErr := client.Organizations.ListTeams(ctx, &ps.ListOrganizationTeamsRequest{
+				Organization: org,
+				Query:        query,
+			}, ps.WithPage(page), ps.WithPerPage(perPage))
+			if listErr != nil {
+				return nil, cmdutil.HandleError(listErr)
+			}
+			for _, candidate := range teams {
+				if candidate.ID == id || strings.EqualFold(candidate.Name, id) || strings.EqualFold(candidate.Slug, id) {
+					return candidate, nil
+				}
+			}
+			if len(teams) < perPage {
+				break
+			}
+			page++
+		}
+	}
+	return nil, teamNotFound(org, id)
+}
+
+func TeamListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		query   string
+		page    int
+		perPage int
+	}
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List organization teams",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			teams, err := client.Organizations.ListTeams(cmd.Context(), &ps.ListOrganizationTeamsRequest{
+				Organization: ch.Config.Organization,
+				Query:        flags.query,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if len(teams) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Println("No teams found.")
+				return nil
+			}
+			return ch.Printer.PrintResource(toOrganizationTeams(teams))
+		},
+	}
+	cmd.Flags().StringVar(&flags.query, "query", "", "Filter teams by name")
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+func TeamShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <team-id-or-name>",
+		Short: "Show an organization team",
+		Args:  cmdutil.RequiredArgs("team-id-or-name"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			if err != nil {
+				return err
+			}
+			return ch.Printer.PrintResource(toOrganizationTeam(team))
+		},
+	}
+}
+
+func TeamCreateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		name        string
+		description string
+	}
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an organization team",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.name == "" {
+				return fmt.Errorf("must specify --name")
+			}
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := client.Organizations.CreateTeam(cmd.Context(), &ps.CreateOrganizationTeamRequest{
+				Organization: ch.Config.Organization,
+				Name:         flags.name,
+				Description:  flags.description,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Created team %s in %s.\n", printer.BoldBlue(team.Name), printer.BoldBlue(ch.Config.Organization))
+				return nil
+			}
+			return ch.Printer.PrintResource(toOrganizationTeam(team))
+		},
+	}
+	cmd.Flags().StringVar(&flags.name, "name", "", "Name of the team")
+	cmd.Flags().StringVar(&flags.description, "description", "", "Description of the team")
+	cmd.MarkFlagRequired("name")
+	return cmd
+}
+
+func TeamUpdateCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		name        string
+		description string
+	}
+	cmd := &cobra.Command{
+		Use:   "update <team>",
+		Short: "Update an organization team",
+		Args:  cmdutil.RequiredArgs("team"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("description") {
+				return fmt.Errorf("must specify --name or --description")
+			}
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			if err != nil {
+				return err
+			}
+			req := &ps.UpdateOrganizationTeamRequest{
+				Organization: ch.Config.Organization,
+				Team:         team.Slug,
+			}
+			if cmd.Flags().Changed("name") {
+				req.Name = &flags.name
+			}
+			if cmd.Flags().Changed("description") {
+				req.Description = &flags.description
+			}
+			updated, err := client.Organizations.UpdateTeam(cmd.Context(), req)
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Updated team %s in %s.\n", printer.BoldBlue(updated.Name), printer.BoldBlue(ch.Config.Organization))
+				return nil
+			}
+			return ch.Printer.PrintResource(toOrganizationTeam(updated))
+		},
+	}
+	cmd.Flags().StringVar(&flags.name, "name", "", "New name for the team")
+	cmd.Flags().StringVar(&flags.description, "description", "", "New description for the team")
+	return cmd
+}
+
+func TeamDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:     "delete <team>",
+		Short:   "Delete an organization team",
+		Aliases: []string{"rm"},
+		Args:    cmdutil.RequiredArgs("team"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			if err != nil {
+				return err
+			}
+			if !force {
+				if err := ch.Printer.ConfirmCommand(team.Name, "delete organization team", "deletion of organization team"); err != nil {
+					return err
+				}
+			}
+			err = client.Organizations.DeleteTeam(cmd.Context(), &ps.DeleteOrganizationTeamRequest{
+				Organization: ch.Config.Organization,
+				Team:         team.Slug,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Deleted team %s from %s.\n", printer.BoldBlue(team.Name), printer.BoldBlue(ch.Config.Organization))
+				return nil
+			}
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "team deleted",
+				"org":    ch.Config.Organization,
+				"team":   team.ID,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Delete the team without confirmation")
+	return cmd
+}
+
+func TeamMemberCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "member <command>",
+		Short: "Manage organization team members",
+	}
+	cmd.AddCommand(TeamMemberListCmd(ch))
+	cmd.AddCommand(TeamMemberAddCmd(ch))
+	cmd.AddCommand(TeamMemberRemoveCmd(ch))
+	return cmd
+}
+
+func TeamMemberListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+	cmd := &cobra.Command{
+		Use:     "list <team>",
+		Short:   "List members of an organization team",
+		Aliases: []string{"ls"},
+		Args:    cmdutil.RequiredArgs("team"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			if err != nil {
+				return err
+			}
+			members, err := client.Organizations.ListTeamMembers(cmd.Context(), &ps.ListOrganizationTeamMembersRequest{
+				Organization: ch.Config.Organization,
+				Team:         team.Slug,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if len(members) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Println("No team members found.")
+				return nil
+			}
+			return ch.Printer.PrintResource(toOrganizationTeamMembers(members))
+		},
+	}
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+func TeamMemberAddCmd(ch *cmdutil.Helper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <team> <email-or-id>",
+		Short: "Add an organization member to a team",
+		Args:  cmdutil.RequiredArgs("team", "email-or-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			if err != nil {
+				return err
+			}
+			member, err := resolveMember(cmd.Context(), ch, client, args[1])
+			if err != nil {
+				return err
+			}
+			added, err := client.Organizations.AddTeamMember(cmd.Context(), &ps.AddOrganizationTeamMemberRequest{
+				Organization: ch.Config.Organization,
+				Team:         team.Slug,
+				UserID:       member.User.ID,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Added %s to team %s.\n", printer.BoldBlue(member.User.Email), printer.BoldBlue(team.Name))
+				return nil
+			}
+			return ch.Printer.PrintResource(toOrganizationTeamMember(added))
+		},
+	}
+}
+
+func resolveTeamMember(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, team, id string) (*ps.OrganizationTeamMembership, error) {
+	page := 1
+	const perPage = 100
+	for {
+		members, err := client.Organizations.ListTeamMembers(ctx, &ps.ListOrganizationTeamMembersRequest{
+			Organization: ch.Config.Organization,
+			Team:         team,
+		}, ps.WithPage(page), ps.WithPerPage(perPage))
+		if err != nil {
+			return nil, cmdutil.HandleError(err)
+		}
+		for _, member := range members {
+			if member.ID == id || member.User.ID == id || strings.EqualFold(member.User.Email, id) {
+				return member, nil
+			}
+		}
+		if len(members) < perPage {
+			break
+		}
+		page++
+	}
+	return nil, fmt.Errorf("member %s does not belong to team %s", printer.BoldBlue(id), printer.BoldBlue(team))
+}
+
+func TeamMemberRemoveCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		force           bool
+		deletePasswords bool
+	}
+	cmd := &cobra.Command{
+		Use:     "remove <team> <email-or-id>",
+		Short:   "Remove a member from an organization team",
+		Aliases: []string{"rm"},
+		Args:    cmdutil.RequiredArgs("team", "email-or-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			if err != nil {
+				return err
+			}
+			member, err := resolveTeamMember(cmd.Context(), ch, client, team.Slug, args[1])
+			if err != nil {
+				return err
+			}
+			if !flags.force {
+				if err := ch.Printer.ConfirmCommand(member.User.Email, "remove organization team member", "removal of organization team member"); err != nil {
+					return err
+				}
+			}
+			err = client.Organizations.RemoveTeamMember(cmd.Context(), &ps.RemoveOrganizationTeamMemberRequest{
+				Organization:    ch.Config.Organization,
+				Team:            team.Slug,
+				ID:              member.ID,
+				DeletePasswords: flags.deletePasswords,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Removed %s from team %s.\n", printer.BoldBlue(member.User.Email), printer.BoldBlue(team.Name))
+				return nil
+			}
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "team member removed",
+				"org":    ch.Config.Organization,
+				"team":   team.ID,
+				"user":   member.User.ID,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&flags.force, "force", false, "Remove the team member without confirmation")
+	cmd.Flags().BoolVar(&flags.deletePasswords, "delete-passwords", false, "Delete passwords created through this team")
+	return cmd
+}

--- a/internal/cmd/org/team.go
+++ b/internal/cmd/org/team.go
@@ -150,42 +150,6 @@ func resolveTeam(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, id 
 	return nil, teamNotFound(org, id)
 }
 
-func TeamListCmd(ch *cmdutil.Helper) *cobra.Command {
-	var flags struct {
-		query   string
-		page    int
-		perPage int
-	}
-	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "List organization teams",
-		Aliases: []string{"ls"},
-		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := ch.Client()
-			if err != nil {
-				return err
-			}
-			teams, err := client.Organizations.ListTeams(cmd.Context(), &ps.ListOrganizationTeamsRequest{
-				Organization: ch.Config.Organization,
-				Query:        flags.query,
-			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
-			if err != nil {
-				return cmdutil.HandleError(err)
-			}
-			if len(teams) == 0 && ch.Printer.Format() == printer.Human {
-				ch.Printer.Println("No teams found.")
-				return nil
-			}
-			return ch.Printer.PrintResource(toOrganizationTeams(teams))
-		},
-	}
-	cmd.Flags().StringVar(&flags.query, "query", "", "Filter teams by name")
-	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
-	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
-	return cmd
-}
-
 func TeamShowCmd(ch *cmdutil.Helper) *cobra.Command {
 	return &cobra.Command{
 		Use:   "show <team-id-or-name>",
@@ -350,28 +314,45 @@ func TeamMemberListCmd(ch *cmdutil.Helper) *cobra.Command {
 		perPage int
 	}
 	cmd := &cobra.Command{
-		Use:     "list <team>",
-		Short:   "List members of an organization team",
+		Use:   "list <team>",
+		Short: "List members of an organization team",
+		Long: `List members of an organization team.
+
+Results are paginated: 100 members per page by default. Use --page and
+--per-page to walk teams with more members than one page holds.`,
 		Aliases: []string{"ls"},
 		Args:    cmdutil.RequiredArgs("team"),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
 			client, err := ch.Client()
 			if err != nil {
 				return err
 			}
-			team, err := resolveTeam(cmd.Context(), ch, client, args[0])
+			team, err := resolveTeam(ctx, ch, client, args[0])
 			if err != nil {
 				return err
 			}
-			members, err := client.Organizations.ListTeamMembers(cmd.Context(), &ps.ListOrganizationTeamMembersRequest{
-				Organization: ch.Config.Organization,
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching members of team %s...", printer.BoldBlue(team.Name)))
+			defer end()
+
+			members, err := client.Organizations.ListTeamMembers(ctx, &ps.ListOrganizationTeamMembersRequest{
+				Organization: org,
 				Team:         team.Slug,
 			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
 			if err != nil {
 				return cmdutil.HandleError(err)
 			}
+			end()
+
 			if len(members) == 0 && ch.Printer.Format() == printer.Human {
-				ch.Printer.Println("No team members found.")
+				if flags.page > 0 {
+					ch.Printer.Println("No team members found on this page.")
+				} else {
+					ch.Printer.Printf("No members in team %s.\n", printer.BoldBlue(team.Name))
+				}
 				return nil
 			}
 			return ch.Printer.PrintResource(toOrganizationTeamMembers(members))

--- a/internal/cmd/org/team_list.go
+++ b/internal/cmd/org/team_list.go
@@ -1,0 +1,73 @@
+package org
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func TeamListCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		query   string
+		page    int
+		perPage int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List organization teams",
+		Long: `List organization teams.
+
+Results are paginated: 100 teams per page by default. Use --page and
+--per-page to walk organizations with more teams than one page holds.`,
+		Args:    cobra.NoArgs,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching teams of %s...", printer.BoldBlue(org)))
+			defer end()
+
+			teams, err := client.Organizations.ListTeams(ctx, &ps.ListOrganizationTeamsRequest{
+				Organization: org,
+				Query:        flags.query,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(org))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(teams) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page > 0 {
+					ch.Printer.Println("No teams found on this page.")
+				} else if flags.query != "" {
+					ch.Printer.Printf("No teams in %s match %s.\n", printer.BoldBlue(org), printer.BoldBlue(flags.query))
+				} else {
+					ch.Printer.Printf("No teams in %s.\n", printer.BoldBlue(org))
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toOrganizationTeams(teams))
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.query, "query", "", "Filter teams by name")
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}

--- a/internal/cmd/org/team_test.go
+++ b/internal/cmd/org/team_test.go
@@ -1,0 +1,226 @@
+package org
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func testTeam() *ps.OrganizationTeam {
+	description := "Platform team"
+	return &ps.OrganizationTeam{
+		ID:          "team-1",
+		DisplayName: "Platform",
+		Name:        "Platform",
+		Slug:        "platform",
+		Description: &description,
+		Managed:     false,
+	}
+}
+
+func testTeamMember() *ps.OrganizationTeamMembership {
+	return &ps.OrganizationTeamMembership{
+		ID: "membership-1",
+		User: ps.OrganizationTeamUser{
+			ID:          "user-1",
+			DisplayName: "Ada Lovelace",
+			Name:        "Ada",
+			Email:       "ada@example.com",
+		},
+	}
+}
+
+func teamHelper(svc *mock.OrganizationsService, format printer.Format, buf *bytes.Buffer) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(buf)
+	p.SetHumanOutput(buf)
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+}
+
+func getTestTeam(_ context.Context, req *ps.GetOrganizationTeamRequest) (*ps.OrganizationTeam, error) {
+	if req.Team == "platform" || req.Team == "team-1" {
+		return testTeam(), nil
+	}
+	return nil, &ps.Error{Code: ps.ErrNotFound}
+}
+
+func TestOrg_TeamListCmd(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		ListTeamsFn: func(ctx context.Context, req *ps.ListOrganizationTeamsRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeam, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			c.Assert(req.Query, qt.Equals, "plat")
+			listOpts := &ps.ListOptions{URLValues: &url.Values{}}
+			for _, opt := range opts {
+				c.Assert(opt(listOpts), qt.IsNil)
+			}
+			c.Assert(listOpts.URLValues.Get("page"), qt.Equals, "2")
+			c.Assert(listOpts.URLValues.Get("per_page"), qt.Equals, "25")
+			return []*ps.OrganizationTeam{testTeam()}, nil
+		},
+	}
+	cmd := TeamListCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"--query", "plat", "--page", "2", "--per-page", "25"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, `"slug": "platform"`)
+}
+
+func TestOrg_TeamShowCmd_ResolvesName(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		ListTeamsFn: func(ctx context.Context, req *ps.ListOrganizationTeamsRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeam, error) {
+			c.Assert(req.Query == "Platform Team" || req.Query == "Platform" || req.Query == "", qt.IsTrue)
+			return []*ps.OrganizationTeam{testTeam()}, nil
+		},
+	}
+	cmd := TeamShowCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"Platform Team"})
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, `team .* does not exist in organization .*`)
+
+	cmd = TeamShowCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"Platform"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.ListTeamsFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"id": "team-1"`)
+}
+
+func TestOrg_TeamCreateAndUpdateCmd(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		CreateTeamFn: func(ctx context.Context, req *ps.CreateOrganizationTeamRequest) (*ps.OrganizationTeam, error) {
+			c.Assert(req.Name, qt.Equals, "Platform")
+			c.Assert(req.Description, qt.Equals, "Owns the platform")
+			return testTeam(), nil
+		},
+		UpdateTeamFn: func(ctx context.Context, req *ps.UpdateOrganizationTeamRequest) (*ps.OrganizationTeam, error) {
+			c.Assert(req.Team, qt.Equals, "platform")
+			c.Assert(req.Name, qt.IsNil)
+			c.Assert(req.Description, qt.IsNotNil)
+			c.Assert(*req.Description, qt.Equals, "")
+			return testTeam(), nil
+		},
+	}
+	ch := teamHelper(svc, printer.JSON, &buf)
+	create := TeamCreateCmd(ch)
+	create.SetArgs([]string{"--name", "Platform", "--description", "Owns the platform"})
+	c.Assert(create.Execute(), qt.IsNil)
+	c.Assert(svc.CreateTeamFnInvoked, qt.IsTrue)
+
+	update := TeamUpdateCmd(ch)
+	update.SetArgs([]string{"platform", "--description", ""})
+	c.Assert(update.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateTeamFnInvoked, qt.IsTrue)
+}
+
+func TestOrg_TeamDeleteCmd(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		DeleteTeamFn: func(ctx context.Context, req *ps.DeleteOrganizationTeamRequest) error {
+			c.Assert(req.Team, qt.Equals, "platform")
+			return nil
+		},
+	}
+	cmd := TeamDeleteCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"team-1", "--force"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.DeleteTeamFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"result": "team deleted"`)
+}
+
+func TestOrg_TeamMemberListCmd(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		ListTeamMembersFn: func(ctx context.Context, req *ps.ListOrganizationTeamMembersRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeamMembership, error) {
+			c.Assert(req.Team, qt.Equals, "platform")
+			listOpts := &ps.ListOptions{URLValues: &url.Values{}}
+			for _, opt := range opts {
+				c.Assert(opt(listOpts), qt.IsNil)
+			}
+			c.Assert(listOpts.URLValues.Get("page"), qt.Equals, "3")
+			c.Assert(listOpts.URLValues.Get("per_page"), qt.Equals, "50")
+			return []*ps.OrganizationTeamMembership{testTeamMember()}, nil
+		},
+	}
+	cmd := TeamMemberListCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"platform", "--page", "3", "--per-page", "50"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, `"email": "ada@example.com"`)
+}
+
+func TestOrg_TeamMemberAddCmd(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		ListMembersFn: func(ctx context.Context, req *ps.ListOrganizationMembersRequest, opts ...ps.ListOption) ([]*ps.OrganizationMembership, error) {
+			return []*ps.OrganizationMembership{testMember()}, nil
+		},
+		AddTeamMemberFn: func(ctx context.Context, req *ps.AddOrganizationTeamMemberRequest) (*ps.OrganizationTeamMembership, error) {
+			c.Assert(req.Team, qt.Equals, "platform")
+			c.Assert(req.UserID, qt.Equals, "user-1")
+			return testTeamMember(), nil
+		},
+	}
+	cmd := TeamMemberAddCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"platform", "ada@example.com"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.AddTeamMemberFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"id": "membership-1"`)
+}
+
+func TestOrg_TeamMemberRemoveCmd(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		ListTeamMembersFn: func(ctx context.Context, req *ps.ListOrganizationTeamMembersRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeamMembership, error) {
+			return []*ps.OrganizationTeamMembership{testTeamMember()}, nil
+		},
+		RemoveTeamMemberFn: func(ctx context.Context, req *ps.RemoveOrganizationTeamMemberRequest) error {
+			c.Assert(req.Team, qt.Equals, "platform")
+			c.Assert(req.ID, qt.Equals, "membership-1")
+			c.Assert(req.DeletePasswords, qt.IsTrue)
+			return nil
+		},
+	}
+	cmd := TeamMemberRemoveCmd(teamHelper(svc, printer.JSON, &buf))
+	cmd.SetArgs([]string{"platform", "ada@example.com", "--force", "--delete-passwords"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.RemoveTeamMemberFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"result": "team member removed"`)
+}
+
+func TestOrg_TeamCmdIncludesSubcommands(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	cmd := TeamCmd(teamHelper(&mock.OrganizationsService{}, printer.Human, &buf))
+	for _, name := range []string{"list", "show", "create", "update", "delete", "member"} {
+		found, _, err := cmd.Find([]string{name})
+		c.Assert(err, qt.IsNil)
+		c.Assert(found.Name(), qt.Equals, name)
+	}
+}

--- a/internal/cmd/org/team_test.go
+++ b/internal/cmd/org/team_test.go
@@ -80,6 +80,21 @@ func TestOrg_TeamListCmd(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, `"slug": "platform"`)
 }
 
+func TestOrg_TeamListCmd_EmptyPage(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		ListTeamsFn: func(ctx context.Context, req *ps.ListOrganizationTeamsRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeam, error) {
+			return nil, nil
+		},
+	}
+	cmd := TeamListCmd(teamHelper(svc, printer.Human, &buf))
+	cmd.SetArgs([]string{"--page", "4"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "No teams found on this page.")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "No teams in")
+}
+
 func TestOrg_TeamShowCmd_ResolvesName(t *testing.T) {
 	c := qt.New(t)
 	var buf bytes.Buffer
@@ -169,6 +184,22 @@ func TestOrg_TeamMemberListCmd(t *testing.T) {
 	cmd.SetArgs([]string{"platform", "--page", "3", "--per-page", "50"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(buf.String(), qt.Contains, `"email": "ada@example.com"`)
+}
+
+func TestOrg_TeamMemberListCmd_EmptyPage(t *testing.T) {
+	c := qt.New(t)
+	var buf bytes.Buffer
+	svc := &mock.OrganizationsService{
+		GetTeamFn: getTestTeam,
+		ListTeamMembersFn: func(ctx context.Context, req *ps.ListOrganizationTeamMembersRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeamMembership, error) {
+			return nil, nil
+		},
+	}
+	cmd := TeamMemberListCmd(teamHelper(svc, printer.Human, &buf))
+	cmd.SetArgs([]string{"platform", "--page", "4"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "No team members found on this page.")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "No members in team")
 }
 
 func TestOrg_TeamMemberAddCmd(t *testing.T) {

--- a/internal/mock/org.go
+++ b/internal/mock/org.go
@@ -30,6 +30,30 @@ type OrganizationsService struct {
 
 	RemoveMemberFn        func(context.Context, *ps.RemoveOrganizationMemberRequest) error
 	RemoveMemberFnInvoked bool
+
+	ListTeamsFn        func(context.Context, *ps.ListOrganizationTeamsRequest, ...ps.ListOption) ([]*ps.OrganizationTeam, error)
+	ListTeamsFnInvoked bool
+
+	GetTeamFn        func(context.Context, *ps.GetOrganizationTeamRequest) (*ps.OrganizationTeam, error)
+	GetTeamFnInvoked bool
+
+	CreateTeamFn        func(context.Context, *ps.CreateOrganizationTeamRequest) (*ps.OrganizationTeam, error)
+	CreateTeamFnInvoked bool
+
+	UpdateTeamFn        func(context.Context, *ps.UpdateOrganizationTeamRequest) (*ps.OrganizationTeam, error)
+	UpdateTeamFnInvoked bool
+
+	DeleteTeamFn        func(context.Context, *ps.DeleteOrganizationTeamRequest) error
+	DeleteTeamFnInvoked bool
+
+	ListTeamMembersFn        func(context.Context, *ps.ListOrganizationTeamMembersRequest, ...ps.ListOption) ([]*ps.OrganizationTeamMembership, error)
+	ListTeamMembersFnInvoked bool
+
+	AddTeamMemberFn        func(context.Context, *ps.AddOrganizationTeamMemberRequest) (*ps.OrganizationTeamMembership, error)
+	AddTeamMemberFnInvoked bool
+
+	RemoveTeamMemberFn        func(context.Context, *ps.RemoveOrganizationTeamMemberRequest) error
+	RemoveTeamMemberFnInvoked bool
 }
 
 func (o *OrganizationsService) Get(ctx context.Context, req *ps.GetOrganizationRequest) (*ps.Organization, error) {
@@ -70,4 +94,44 @@ func (o *OrganizationsService) UpdateMember(ctx context.Context, req *ps.UpdateO
 func (o *OrganizationsService) RemoveMember(ctx context.Context, req *ps.RemoveOrganizationMemberRequest) error {
 	o.RemoveMemberFnInvoked = true
 	return o.RemoveMemberFn(ctx, req)
+}
+
+func (o *OrganizationsService) ListTeams(ctx context.Context, req *ps.ListOrganizationTeamsRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeam, error) {
+	o.ListTeamsFnInvoked = true
+	return o.ListTeamsFn(ctx, req, opts...)
+}
+
+func (o *OrganizationsService) GetTeam(ctx context.Context, req *ps.GetOrganizationTeamRequest) (*ps.OrganizationTeam, error) {
+	o.GetTeamFnInvoked = true
+	return o.GetTeamFn(ctx, req)
+}
+
+func (o *OrganizationsService) CreateTeam(ctx context.Context, req *ps.CreateOrganizationTeamRequest) (*ps.OrganizationTeam, error) {
+	o.CreateTeamFnInvoked = true
+	return o.CreateTeamFn(ctx, req)
+}
+
+func (o *OrganizationsService) UpdateTeam(ctx context.Context, req *ps.UpdateOrganizationTeamRequest) (*ps.OrganizationTeam, error) {
+	o.UpdateTeamFnInvoked = true
+	return o.UpdateTeamFn(ctx, req)
+}
+
+func (o *OrganizationsService) DeleteTeam(ctx context.Context, req *ps.DeleteOrganizationTeamRequest) error {
+	o.DeleteTeamFnInvoked = true
+	return o.DeleteTeamFn(ctx, req)
+}
+
+func (o *OrganizationsService) ListTeamMembers(ctx context.Context, req *ps.ListOrganizationTeamMembersRequest, opts ...ps.ListOption) ([]*ps.OrganizationTeamMembership, error) {
+	o.ListTeamMembersFnInvoked = true
+	return o.ListTeamMembersFn(ctx, req, opts...)
+}
+
+func (o *OrganizationsService) AddTeamMember(ctx context.Context, req *ps.AddOrganizationTeamMemberRequest) (*ps.OrganizationTeamMembership, error) {
+	o.AddTeamMemberFnInvoked = true
+	return o.AddTeamMemberFn(ctx, req)
+}
+
+func (o *OrganizationsService) RemoveTeamMember(ctx context.Context, req *ps.RemoveOrganizationTeamMemberRequest) error {
+	o.RemoveTeamMemberFnInvoked = true
+	return o.RemoveTeamMemberFn(ctx, req)
 }

--- a/internal/planetscale/organization_teams.go
+++ b/internal/planetscale/organization_teams.go
@@ -1,0 +1,246 @@
+package planetscale
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+)
+
+type OrganizationTeamActor struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	AvatarURL   string `json:"avatar_url"`
+}
+
+type OrganizationTeamUser struct {
+	ID                      string          `json:"id"`
+	DisplayName             string          `json:"display_name"`
+	Name                    string          `json:"name"`
+	Email                   string          `json:"email"`
+	AvatarURL               string          `json:"avatar_url"`
+	CreatedAt               time.Time       `json:"created_at"`
+	UpdatedAt               time.Time       `json:"updated_at"`
+	TwoFactorAuthConfigured bool            `json:"two_factor_auth_configured"`
+	DefaultOrganization     json.RawMessage `json:"default_organization"`
+	SSO                     *bool           `json:"sso"`
+	Managed                 *bool           `json:"managed"`
+	DirectoryManaged        *bool           `json:"directory_managed"`
+	EmailVerified           *bool           `json:"email_verified"`
+}
+
+type OrganizationTeamDatabase struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	URL         string `json:"url"`
+	BranchesURL string `json:"branches_url"`
+}
+
+type OrganizationTeam struct {
+	ID               string                     `json:"id"`
+	DisplayName      string                     `json:"display_name"`
+	Creator          OrganizationTeamActor      `json:"creator"`
+	Members          []OrganizationTeamUser     `json:"members"`
+	Databases        []OrganizationTeamDatabase `json:"databases"`
+	AnalystDatabases []OrganizationTeamDatabase `json:"analyst_databases"`
+	Name             string                     `json:"name"`
+	Slug             string                     `json:"slug"`
+	CreatedAt        time.Time                  `json:"created_at"`
+	UpdatedAt        time.Time                  `json:"updated_at"`
+	Description      *string                    `json:"description"`
+	Managed          bool                       `json:"managed"`
+}
+
+type OrganizationTeamMembership struct {
+	ID        string                `json:"id"`
+	User      OrganizationTeamUser  `json:"user"`
+	Actor     OrganizationTeamActor `json:"actor"`
+	CreatedAt time.Time             `json:"created_at"`
+	UpdatedAt time.Time             `json:"updated_at"`
+	Passwords []json.RawMessage     `json:"passwords"`
+}
+
+type organizationTeamsResponse struct {
+	Data []*OrganizationTeam `json:"data"`
+}
+
+type organizationTeamMembersResponse struct {
+	Data []*OrganizationTeamMembership `json:"data"`
+}
+
+type ListOrganizationTeamsRequest struct {
+	Organization string
+	Query        string
+}
+
+type GetOrganizationTeamRequest struct {
+	Organization string
+	Team         string
+}
+
+type CreateOrganizationTeamRequest struct {
+	Organization string `json:"-"`
+	Name         string `json:"name"`
+	Description  string `json:"description,omitempty"`
+}
+
+type UpdateOrganizationTeamRequest struct {
+	Organization string  `json:"-"`
+	Team         string  `json:"-"`
+	Name         *string `json:"name,omitempty"`
+	Description  *string `json:"description,omitempty"`
+}
+
+type DeleteOrganizationTeamRequest struct {
+	Organization string
+	Team         string
+}
+
+type ListOrganizationTeamMembersRequest struct {
+	Organization string
+	Team         string
+}
+
+type AddOrganizationTeamMemberRequest struct {
+	Organization string `json:"-"`
+	Team         string `json:"-"`
+	UserID       string `json:"user_id"`
+}
+
+type RemoveOrganizationTeamMemberRequest struct {
+	Organization    string
+	Team            string
+	ID              string
+	DeletePasswords bool
+}
+
+func organizationTeamsAPIPath(org string) string {
+	return path.Join(organizationsAPIPath, org, "teams")
+}
+
+func organizationTeamAPIPath(org, team string) string {
+	return path.Join(organizationTeamsAPIPath(org), team)
+}
+
+func organizationTeamMembersAPIPath(org, team string) string {
+	return path.Join(organizationTeamAPIPath(org, team), "members")
+}
+
+func (o *organizationsService) ListTeams(ctx context.Context, listReq *ListOrganizationTeamsRequest, opts ...ListOption) ([]*OrganizationTeam, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+	if listReq.Query != "" {
+		listOpts.URLValues.Set("q", listReq.Query)
+	}
+
+	req, err := o.client.newRequest(http.MethodGet, organizationTeamsAPIPath(listReq.Organization), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list organization teams: %w", err)
+	}
+
+	resp := &organizationTeamsResponse{}
+	if err := o.client.do(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (o *organizationsService) GetTeam(ctx context.Context, getReq *GetOrganizationTeamRequest) (*OrganizationTeam, error) {
+	req, err := o.client.newRequest(http.MethodGet, organizationTeamAPIPath(getReq.Organization, getReq.Team), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get organization team: %w", err)
+	}
+
+	team := &OrganizationTeam{}
+	if err := o.client.do(ctx, req, team); err != nil {
+		return nil, err
+	}
+	return team, nil
+}
+
+func (o *organizationsService) CreateTeam(ctx context.Context, createReq *CreateOrganizationTeamRequest) (*OrganizationTeam, error) {
+	req, err := o.client.newRequest(http.MethodPost, organizationTeamsAPIPath(createReq.Organization), createReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for create organization team: %w", err)
+	}
+
+	team := &OrganizationTeam{}
+	if err := o.client.do(ctx, req, team); err != nil {
+		return nil, err
+	}
+	return team, nil
+}
+
+func (o *organizationsService) UpdateTeam(ctx context.Context, updateReq *UpdateOrganizationTeamRequest) (*OrganizationTeam, error) {
+	req, err := o.client.newRequest(http.MethodPatch, organizationTeamAPIPath(updateReq.Organization, updateReq.Team), updateReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for update organization team: %w", err)
+	}
+
+	team := &OrganizationTeam{}
+	if err := o.client.do(ctx, req, team); err != nil {
+		return nil, err
+	}
+	return team, nil
+}
+
+func (o *organizationsService) DeleteTeam(ctx context.Context, deleteReq *DeleteOrganizationTeamRequest) error {
+	req, err := o.client.newRequest(http.MethodDelete, organizationTeamAPIPath(deleteReq.Organization, deleteReq.Team), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for delete organization team: %w", err)
+	}
+	return o.client.do(ctx, req, nil)
+}
+
+func (o *organizationsService) ListTeamMembers(ctx context.Context, listReq *ListOrganizationTeamMembersRequest, opts ...ListOption) ([]*OrganizationTeamMembership, error) {
+	listOpts := defaultListOptions(WithPerPage(100))
+	for _, opt := range opts {
+		if err := opt(listOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := o.client.newRequest(http.MethodGet, organizationTeamMembersAPIPath(listReq.Organization, listReq.Team), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list organization team members: %w", err)
+	}
+
+	resp := &organizationTeamMembersResponse{}
+	if err := o.client.do(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return resp.Data, nil
+}
+
+func (o *organizationsService) AddTeamMember(ctx context.Context, addReq *AddOrganizationTeamMemberRequest) (*OrganizationTeamMembership, error) {
+	req, err := o.client.newRequest(http.MethodPost, organizationTeamMembersAPIPath(addReq.Organization, addReq.Team), addReq)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for add organization team member: %w", err)
+	}
+
+	membership := &OrganizationTeamMembership{}
+	if err := o.client.do(ctx, req, membership); err != nil {
+		return nil, err
+	}
+	return membership, nil
+}
+
+func (o *organizationsService) RemoveTeamMember(ctx context.Context, removeReq *RemoveOrganizationTeamMemberRequest) error {
+	values := url.Values{}
+	if removeReq.DeletePasswords {
+		values.Set("delete_passwords", "true")
+	}
+	apiPath := path.Join(organizationTeamMembersAPIPath(removeReq.Organization, removeReq.Team), removeReq.ID)
+	req, err := o.client.newRequest(http.MethodDelete, apiPath, nil, WithQueryParams(values))
+	if err != nil {
+		return fmt.Errorf("error creating request for remove organization team member: %w", err)
+	}
+	return o.client.do(ctx, req, nil)
+}

--- a/internal/planetscale/organization_teams_test.go
+++ b/internal/planetscale/organization_teams_test.go
@@ -1,0 +1,141 @@
+package planetscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+const organizationTeamJSON = `{"id":"team-1","display_name":"Platform","creator":{"id":"user-2","display_name":"Grace","avatar_url":""},"members":[],"databases":[],"analyst_databases":[],"name":"Platform","slug":"platform","created_at":"2026-08-25T10:00:00Z","updated_at":"2026-08-25T10:00:00Z","description":"Platform team","managed":false}`
+
+const organizationTeamMemberJSON = `{"id":"membership-1","user":{"id":"user-1","display_name":"Ada Lovelace","name":"Ada","email":"ada@example.com","avatar_url":"","created_at":"2026-08-25T10:00:00Z","updated_at":"2026-08-25T10:00:00Z","two_factor_auth_configured":true,"default_organization":null},"actor":{"id":"user-2","display_name":"Grace","avatar_url":""},"created_at":"2026-08-25T10:00:00Z","updated_at":"2026-08-25T10:00:00Z","passwords":[]}`
+
+func TestOrganizations_ListTeams(t *testing.T) {
+	c := qt.New(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams")
+		c.Assert(r.URL.Query().Get("q"), qt.Equals, "plat")
+		c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+		c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "25")
+		_, err := w.Write([]byte(`{"data":[` + organizationTeamJSON + `]}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	teams, err := client.Organizations.ListTeams(context.Background(), &ListOrganizationTeamsRequest{
+		Organization: "my-org",
+		Query:        "plat",
+	}, WithPage(2), WithPerPage(25))
+	c.Assert(err, qt.IsNil)
+	c.Assert(teams, qt.HasLen, 1)
+	c.Assert(teams[0].Slug, qt.Equals, "platform")
+	c.Assert(*teams[0].Description, qt.Equals, "Platform team")
+}
+
+func TestOrganizations_TeamMutations(t *testing.T) {
+	c := qt.New(t)
+	var requestNumber int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber++
+		switch requestNumber {
+		case 1:
+			c.Assert(r.Method, qt.Equals, http.MethodGet)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams/platform")
+		case 2:
+			c.Assert(r.Method, qt.Equals, http.MethodPost)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams")
+			var body CreateOrganizationTeamRequest
+			c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+			c.Assert(body.Name, qt.Equals, "Platform")
+		case 3:
+			c.Assert(r.Method, qt.Equals, http.MethodPatch)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams/platform")
+			var body map[string]string
+			c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+			c.Assert(body, qt.DeepEquals, map[string]string{"description": ""})
+		case 4:
+			c.Assert(r.Method, qt.Equals, http.MethodDelete)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams/platform")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		_, err := w.Write([]byte(organizationTeamJSON))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	team, err := client.Organizations.GetTeam(context.Background(), &GetOrganizationTeamRequest{Organization: "my-org", Team: "platform"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(team.ID, qt.Equals, "team-1")
+	_, err = client.Organizations.CreateTeam(context.Background(), &CreateOrganizationTeamRequest{Organization: "my-org", Name: "Platform"})
+	c.Assert(err, qt.IsNil)
+	description := ""
+	_, err = client.Organizations.UpdateTeam(context.Background(), &UpdateOrganizationTeamRequest{Organization: "my-org", Team: "platform", Description: &description})
+	c.Assert(err, qt.IsNil)
+	err = client.Organizations.DeleteTeam(context.Background(), &DeleteOrganizationTeamRequest{Organization: "my-org", Team: "platform"})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestOrganizations_TeamMembers(t *testing.T) {
+	c := qt.New(t)
+	var requestNumber int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestNumber++
+		switch requestNumber {
+		case 1:
+			c.Assert(r.Method, qt.Equals, http.MethodGet)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams/platform/members")
+			c.Assert(r.URL.Query().Get("page"), qt.Equals, "3")
+			c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "50")
+			_, err := w.Write([]byte(`{"data":[` + organizationTeamMemberJSON + `]}`))
+			c.Assert(err, qt.IsNil)
+		case 2:
+			c.Assert(r.Method, qt.Equals, http.MethodPost)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams/platform/members")
+			var body map[string]string
+			c.Assert(json.NewDecoder(r.Body).Decode(&body), qt.IsNil)
+			c.Assert(body["user_id"], qt.Equals, "user-1")
+			_, err := w.Write([]byte(organizationTeamMemberJSON))
+			c.Assert(err, qt.IsNil)
+		case 3:
+			c.Assert(r.Method, qt.Equals, http.MethodDelete)
+			c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/teams/platform/members/membership-1")
+			c.Assert(r.URL.Query().Get("delete_passwords"), qt.Equals, "true")
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	members, err := client.Organizations.ListTeamMembers(context.Background(), &ListOrganizationTeamMembersRequest{
+		Organization: "my-org",
+		Team:         "platform",
+	}, WithPage(3), WithPerPage(50))
+	c.Assert(err, qt.IsNil)
+	c.Assert(members, qt.HasLen, 1)
+	c.Assert(members[0].User.Email, qt.Equals, "ada@example.com")
+	added, err := client.Organizations.AddTeamMember(context.Background(), &AddOrganizationTeamMemberRequest{
+		Organization: "my-org",
+		Team:         "platform",
+		UserID:       "user-1",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(added.ID, qt.Equals, "membership-1")
+	err = client.Organizations.RemoveTeamMember(context.Background(), &RemoveOrganizationTeamMemberRequest{
+		Organization:    "my-org",
+		Team:            "platform",
+		ID:              "membership-1",
+		DeletePasswords: true,
+	})
+	c.Assert(err, qt.IsNil)
+}

--- a/internal/planetscale/organizations.go
+++ b/internal/planetscale/organizations.go
@@ -27,6 +27,14 @@ type OrganizationsService interface {
 	GetMember(context.Context, *GetOrganizationMemberRequest) (*OrganizationMembership, error)
 	UpdateMember(context.Context, *UpdateOrganizationMemberRequest) (*OrganizationMembership, error)
 	RemoveMember(context.Context, *RemoveOrganizationMemberRequest) error
+	ListTeams(context.Context, *ListOrganizationTeamsRequest, ...ListOption) ([]*OrganizationTeam, error)
+	GetTeam(context.Context, *GetOrganizationTeamRequest) (*OrganizationTeam, error)
+	CreateTeam(context.Context, *CreateOrganizationTeamRequest) (*OrganizationTeam, error)
+	UpdateTeam(context.Context, *UpdateOrganizationTeamRequest) (*OrganizationTeam, error)
+	DeleteTeam(context.Context, *DeleteOrganizationTeamRequest) error
+	ListTeamMembers(context.Context, *ListOrganizationTeamMembersRequest, ...ListOption) ([]*OrganizationTeamMembership, error)
+	AddTeamMember(context.Context, *AddOrganizationTeamMemberRequest) (*OrganizationTeamMembership, error)
+	RemoveTeamMember(context.Context, *RemoveOrganizationTeamMemberRequest) error
 }
 
 // ListRegionsRequest encapsulates the request for getting a list of regions for


### PR DESCRIPTION
## Summary
- wrap the published organization team and team member API operations
- add paginated `pscale org team` commands with ID, name, and slug resolution
- preserve API objects in JSON output and require confirmation for destructive operations
- document team automation in `AGENTS.md`

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] `go run ./cmd/pscale org team --help`