### PR TITLE
Add specialized metrics query, table, tablet, and tag commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ pscale metrics tags <database> <branch> --org <org> --format json --metric queri
 - Specialized query, tablet, and tag metrics accept the filters exposed by their API endpoints. `--metric` and `--query-id` may be repeated or comma-separated. `--tag-set` is repeated for independent series; comma-separate keys inside one set (`Busername=alice,Senv=production`). Tag keys need the Insights type prefix from `insights tags`.
 - `metrics queries` requires a query selector. Use `--fingerprint` with `--keyspace`, or `--query-id` as `<fingerprint>-<keyspace>`. The short `id` from `insights queries` is not a query pattern ID.
 - `metrics tags` requires at least one `--tag-set`. `--budget-id` and `--rule-id` apply only to the `traffic_control_warnings` and `traffic_control_throttled` metrics.
-- `metrics tablets --workflow` applies only to `--metric vreplication_lag`.
+- `metrics tablets --workflow` applies only to `--metric vreplication_lag` and must name an existing workflow on the branch.
 - Filters that match nothing return zero-filled series rather than an empty response, so check the point values, not the series count.
 - `metrics tables` and `metrics keyspace-tables` preserve the untyped storage-metrics API response in JSON.
 - `metrics report` detects whether the database uses MySQL or PostgreSQL and queries a curated set of performance sections. It supports `--period`, custom `--from`/`--to` ranges, and `--steps`; JSON returns a composite report and CSV includes the section name on each row.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,11 +250,11 @@ pscale metrics tables <database> <branch> --org <org> --format json
 pscale metrics keyspace-tables <database> <branch> --org <org> --format json
 pscale metrics tablets <database> <branch> --org <org> --format json --metric replication_lag --period 1h
 pscale metrics tablets instant <database> <branch> --org <org> --format json --metric replication_lag
-pscale metrics tags <database> <branch> --org <org> --format json --metric queries --tag-set <tag-set> --period 1h
+pscale metrics tags <database> <branch> --org <org> --format json --metric queries --tag-set Busername=alice --tag-set Busername=bob --period 1h
 ```
 
 - For `metrics show` and `metrics instant`, `--metric` is required and may be repeated or comma-separated.
-- Specialized query, tablet, and tag metrics accept the filters exposed by their API endpoints. `--metric`, `--query-id`, and `--tag-set` may be repeated or comma-separated.
+- Specialized query, tablet, and tag metrics accept the filters exposed by their API endpoints. `--metric` and `--query-id` may be repeated or comma-separated. `--tag-set` is repeated for independent series; comma-separate keys inside one set (`Busername=alice,Senv=production`). Tag keys need the Insights type prefix from `insights tags`.
 - `metrics tables` and `metrics keyspace-tables` preserve the untyped storage-metrics API response in JSON.
 - `metrics report` detects whether the database uses MySQL or PostgreSQL and queries a curated set of performance sections. It supports `--period`, custom `--from`/`--to` ranges, and `--steps`; JSON returns a composite report and CSV includes the section name on each row.
 - Historical queries support `--period`, or a custom `--from`/`--to` ISO 8601 range, plus `--steps` and dimension filters such as `--tablet-type`, `--keyspace`, `--shard`, `--role`, `--pod`, and `--pods`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,9 +253,11 @@ pscale metrics tablets instant <database> <branch> --org <org> --format json --m
 pscale metrics tags <database> <branch> --org <org> --format json --metric queries --tag-set Busername=alice --tag-set Busername=bob --period 1h
 ```
 
-- For `metrics show` and `metrics instant`, `--metric` is required and may be repeated or comma-separated.
+- `--metric` is required for series and instant commands and may be repeated or comma-separated.
 - Specialized query, tablet, and tag metrics accept the filters exposed by their API endpoints. `--metric` and `--query-id` may be repeated or comma-separated. `--tag-set` is repeated for independent series; comma-separate keys inside one set (`Busername=alice,Senv=production`). Tag keys need the Insights type prefix from `insights tags`.
-- `metrics queries` returns series only for queries you select. Use `--fingerprint` with `--keyspace`, or `--query-id` as `<fingerprint>-<keyspace>`. The short `id` from `insights queries` is not a query pattern ID. Without a selector the response is an empty `series` array.
+- `metrics queries` requires a query selector. Use `--fingerprint` with `--keyspace`, or `--query-id` as `<fingerprint>-<keyspace>`. The short `id` from `insights queries` is not a query pattern ID.
+- `metrics tags` requires at least one `--tag-set`. `--budget-id` and `--rule-id` apply only to the `traffic_control_warnings` and `traffic_control_throttled` metrics.
+- `metrics tablets --workflow` applies only to `--metric vreplication_lag`.
 - Filters that match nothing return zero-filled series rather than an empty response, so check the point values, not the series count.
 - `metrics tables` and `metrics keyspace-tables` preserve the untyped storage-metrics API response in JSON.
 - `metrics report` detects whether the database uses MySQL or PostgreSQL and queries a curated set of performance sections. It supports `--period`, custom `--from`/`--to` ranges, and `--steps`; JSON returns a composite report and CSV includes the section name on each row.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,9 +245,17 @@ Query historical or current branch metrics through the public metrics API:
 pscale metrics show <database> <branch> --org <org> --format json --metric queries --metric latency_p99 --period 1h
 pscale metrics instant <database> <branch> --org <org> --format json --metric planetscale_volume_usage_percentage
 pscale metrics report <database> <branch> --org <org> --format json --period 1d
+pscale metrics queries <database> <branch> --org <org> --format json --metric latency_p99 --query-id <query-id> --period 1h
+pscale metrics tables <database> <branch> --org <org> --format json
+pscale metrics keyspace-tables <database> <branch> --org <org> --format json
+pscale metrics tablets <database> <branch> --org <org> --format json --metric replication_lag --period 1h
+pscale metrics tablets instant <database> <branch> --org <org> --format json --metric replication_lag
+pscale metrics tags <database> <branch> --org <org> --format json --metric queries --tag-set <tag-set> --period 1h
 ```
 
 - For `metrics show` and `metrics instant`, `--metric` is required and may be repeated or comma-separated.
+- Specialized query, tablet, and tag metrics accept the filters exposed by their API endpoints. `--metric`, `--query-id`, and `--tag-set` may be repeated or comma-separated.
+- `metrics tables` and `metrics keyspace-tables` preserve the untyped storage-metrics API response in JSON.
 - `metrics report` detects whether the database uses MySQL or PostgreSQL and queries a curated set of performance sections. It supports `--period`, custom `--from`/`--to` ranges, and `--steps`; JSON returns a composite report and CSV includes the section name on each row.
 - Historical queries support `--period`, or a custom `--from`/`--to` ISO 8601 range, plus `--steps` and dimension filters such as `--tablet-type`, `--keyspace`, `--shard`, `--role`, `--pod`, and `--pods`.
 - JSON preserves the API response: historical results contain `start_date`, `end_date`, `interval`, and `series`; each series contains `metric`, `label`, `labels`, and `[Unix timestamp, value]` points. Instant results contain current values grouped by their dimensions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,7 @@ Query historical or current branch metrics through the public metrics API:
 pscale metrics show <database> <branch> --org <org> --format json --metric queries --metric latency_p99 --period 1h
 pscale metrics instant <database> <branch> --org <org> --format json --metric planetscale_volume_usage_percentage
 pscale metrics report <database> <branch> --org <org> --format json --period 1d
-pscale metrics queries <database> <branch> --org <org> --format json --metric latency_p99 --query-id <query-id> --period 1h
+pscale metrics queries <database> <branch> --org <org> --format json --metric latency_p99 --fingerprint <fingerprint> --keyspace <keyspace> --period 1h
 pscale metrics tables <database> <branch> --org <org> --format json
 pscale metrics keyspace-tables <database> <branch> --org <org> --format json
 pscale metrics tablets <database> <branch> --org <org> --format json --metric replication_lag --period 1h
@@ -255,6 +255,8 @@ pscale metrics tags <database> <branch> --org <org> --format json --metric queri
 
 - For `metrics show` and `metrics instant`, `--metric` is required and may be repeated or comma-separated.
 - Specialized query, tablet, and tag metrics accept the filters exposed by their API endpoints. `--metric` and `--query-id` may be repeated or comma-separated. `--tag-set` is repeated for independent series; comma-separate keys inside one set (`Busername=alice,Senv=production`). Tag keys need the Insights type prefix from `insights tags`.
+- `metrics queries` returns series only for queries you select. Use `--fingerprint` with `--keyspace`, or `--query-id` as `<fingerprint>-<keyspace>`. The short `id` from `insights queries` is not a query pattern ID. Without a selector the response is an empty `series` array.
+- Filters that match nothing return zero-filled series rather than an empty response, so check the point values, not the series count.
 - `metrics tables` and `metrics keyspace-tables` preserve the untyped storage-metrics API response in JSON.
 - `metrics report` detects whether the database uses MySQL or PostgreSQL and queries a curated set of performance sections. It supports `--period`, custom `--from`/`--to` ranges, and `--steps`; JSON returns a composite report and CSV includes the section name on each row.
 - Historical queries support `--period`, or a custom `--from`/`--to` ISO 8601 range, plus `--steps` and dimension filters such as `--tablet-type`, `--keyspace`, `--shard`, `--role`, `--pod`, and `--pods`.

--- a/internal/cmd/metrics/metrics.go
+++ b/internal/cmd/metrics/metrics.go
@@ -26,6 +26,11 @@ or current value for use in scripts and analysis tools.`,
 	cmd.AddCommand(ShowCmd(ch))
 	cmd.AddCommand(InstantCmd(ch))
 	cmd.AddCommand(ReportCmd(ch))
+	cmd.AddCommand(QueriesCmd(ch))
+	cmd.AddCommand(TablesCmd(ch))
+	cmd.AddCommand(KeyspaceTablesCmd(ch))
+	cmd.AddCommand(TabletsCmd(ch))
+	cmd.AddCommand(TagsCmd(ch))
 
 	return cmd
 }

--- a/internal/cmd/metrics/metrics_test.go
+++ b/internal/cmd/metrics/metrics_test.go
@@ -242,11 +242,8 @@ func TestQueriesCmd_ForwardsSupportedFilters(t *testing.T) {
 	c := qt.New(t)
 	service := &mock.MetricsService{
 		GetQuerySeriesFn: func(ctx context.Context, req *ps.GetQueryMetricSeriesRequest) (*ps.MetricSeries, error) {
-			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99"})
-			c.Assert(req.QueryIDs, qt.DeepEquals, []string{
-				strings.Repeat("a", 64) + "-commerce",
-				strings.Repeat("b", 64) + "-commerce",
-			})
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99", "traffic_control_warnings"})
+			c.Assert(req.QueryIDs, qt.HasLen, 0)
 			c.Assert(req.Fingerprint, qt.Equals, "fingerprint-1")
 			c.Assert(req.Keyspace, qt.Equals, "commerce")
 			c.Assert(req.Period, qt.Equals, "1h")
@@ -262,8 +259,7 @@ func TestQueriesCmd_ForwardsSupportedFilters(t *testing.T) {
 	cmd := QueriesCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
 	cmd.SetArgs([]string{
 		"mydb", "main",
-		"--metric", "queries,latency_p99",
-		"--query-id", strings.Repeat("a", 64) + "-commerce," + strings.Repeat("b", 64) + "-commerce",
+		"--metric", "queries,latency_p99,traffic_control_warnings",
 		"--fingerprint", "fingerprint-1",
 		"--keyspace", "commerce",
 		"--period", "1h",
@@ -323,7 +319,7 @@ func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
 	c := qt.New(t)
 	service := &mock.MetricsService{
 		GetTabletSeriesFn: func(ctx context.Context, req *ps.GetTabletMetricSeriesRequest) (*ps.MetricSeries, error) {
-			c.Assert(req.Metrics, qt.DeepEquals, []string{"replication_lag", "pod_cpu_usage"})
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"replication_lag", "pod_cpu_usage", "vreplication_lag"})
 			c.Assert(req.From, qt.Equals, "2026-08-18T16:00:00Z")
 			c.Assert(req.To, qt.Equals, "2026-08-18T17:00:00Z")
 			c.Assert(req.Steps, qt.Equals, 60)
@@ -339,7 +335,7 @@ func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
 	cmd := TabletsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
 	cmd.SetArgs([]string{
 		"mydb", "main",
-		"--metric", "replication_lag,pod_cpu_usage",
+		"--metric", "replication_lag,pod_cpu_usage,vreplication_lag",
 		"--from", "2026-08-18T16:00:00Z",
 		"--to", "2026-08-18T17:00:00Z",
 		"--steps", "60",
@@ -379,7 +375,7 @@ func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
 	c := qt.New(t)
 	service := &mock.MetricsService{
 		GetTagSeriesFn: func(ctx context.Context, req *ps.GetTagMetricSeriesRequest) (*ps.MetricSeries, error) {
-			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99"})
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99", "traffic_control_warnings"})
 			c.Assert(req.TagSets, qt.DeepEquals, []map[string]string{
 				{"Busername": "alice", "Senv": "production"},
 				{"Busername": "bob"},
@@ -397,7 +393,7 @@ func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
 	cmd := TagsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
 	cmd.SetArgs([]string{
 		"mydb", "main",
-		"--metric", "queries,latency_p99",
+		"--metric", "queries,latency_p99,traffic_control_warnings",
 		"--tag-set", "Busername=alice,Senv=production",
 		"--tag-set", "Busername=bob",
 		"--period", "1d",
@@ -439,4 +435,31 @@ func TestParseTagSets(t *testing.T) {
 
 	_, err = parseTagSets([]string{"alice"})
 	c.Assert(err, qt.ErrorMatches, `invalid --tag-set "alice"; use key=value pairs with an Insights type prefix, for example Busername=alice`)
+
+	_, err = parseTagSets([]string{"username=alice"})
+	c.Assert(err, qt.ErrorMatches, `invalid tag key "username"; keys must start with B \(built-in\) or S \(custom\), for example Busername or Sapplication`)
+}
+
+func TestValidateQuerySelector(t *testing.T) {
+	c := qt.New(t)
+	validID := strings.Repeat("a", 64) + "-commerce"
+
+	c.Assert(validateQuerySelector([]string{validID}, "", ""), qt.IsNil)
+	c.Assert(validateQuerySelector(nil, "fingerprint", "commerce"), qt.IsNil)
+	c.Assert(validateQuerySelector(nil, "", ""), qt.ErrorMatches, "select at least one query with --query-id or with --fingerprint and --keyspace")
+	c.Assert(validateQuerySelector(nil, "fingerprint", ""), qt.ErrorMatches, "--fingerprint and --keyspace must be used together")
+	c.Assert(validateQuerySelector([]string{validID}, "fingerprint", "commerce"), qt.ErrorMatches, "--query-id cannot be combined with --fingerprint or --keyspace")
+}
+
+func TestValidateTrafficControlMetricFilters(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(validateTrafficControlMetricFilters([]string{"queries"}, "", ""), qt.IsNil)
+	c.Assert(validateTrafficControlMetricFilters([]string{"traffic_control_warnings"}, "budget", ""), qt.IsNil)
+	c.Assert(validateTrafficControlMetricFilters([]string{"traffic_control_throttled"}, "", "rule"), qt.IsNil)
+	c.Assert(
+		validateTrafficControlMetricFilters([]string{"queries"}, "budget", ""),
+		qt.ErrorMatches,
+		"--budget-id and --rule-id only apply to --metric traffic_control_warnings or traffic_control_throttled",
+	)
 }

--- a/internal/cmd/metrics/metrics_test.go
+++ b/internal/cmd/metrics/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	"github.com/planetscale/cli/internal/config"
@@ -235,4 +236,169 @@ func TestInstantCmd_CSVFlattensValues(t *testing.T) {
 	c.Assert(lines[0], qt.Equals, "metric,label,dimensions,value")
 	c.Assert(lines[1], qt.Contains, "planetscale_volume_usage_percentage,volume_usage")
 	c.Assert(lines[1], qt.Contains, "71.4")
+}
+
+func TestQueriesCmd_ForwardsSupportedFilters(t *testing.T) {
+	c := qt.New(t)
+	service := &mock.MetricsService{
+		GetQuerySeriesFn: func(ctx context.Context, req *ps.GetQueryMetricSeriesRequest) (*ps.MetricSeries, error) {
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99"})
+			c.Assert(req.QueryIDs, qt.DeepEquals, []string{"query-1", "query-2"})
+			c.Assert(req.Fingerprint, qt.Equals, "fingerprint-1")
+			c.Assert(req.Keyspace, qt.Equals, "commerce")
+			c.Assert(req.Period, qt.Equals, "1h")
+			c.Assert(req.TabletType, qt.Equals, "replica")
+			c.Assert(req.BudgetID, qt.Equals, "budget-1")
+			c.Assert(req.RuleID, qt.Equals, "rule-1")
+			c.Assert(req.Search, qt.Equals, "checkout")
+			return sampleSeries(), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd := QueriesCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
+	cmd.SetArgs([]string{
+		"mydb", "main",
+		"--metric", "queries,latency_p99",
+		"--query-id", "query-1,query-2",
+		"--fingerprint", "fingerprint-1",
+		"--keyspace", "commerce",
+		"--period", "1h",
+		"--tablet-type", "replica",
+		"--budget-id", "budget-1",
+		"--rule-id", "rule-1",
+		"--search", "checkout",
+	})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(service.GetQuerySeriesFnInvoked, qt.IsTrue)
+
+	var response ps.MetricSeries
+	c.Assert(json.Unmarshal(buf.Bytes(), &response), qt.IsNil)
+	c.Assert(response.Series, qt.HasLen, 1)
+}
+
+func TestStorageMetricsCommands_PreserveResponse(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		command func(*cmdutil.Helper) *cobra.Command
+		service *mock.MetricsService
+	}{
+		{
+			name:    "tables",
+			command: TablesCmd,
+			service: &mock.MetricsService{
+				GetTablesFn: func(context.Context, *ps.GetBranchMetricsRequest) (json.RawMessage, error) {
+					return json.RawMessage(`{"users":{"bytes":1048576}}`), nil
+				},
+			},
+		},
+		{
+			name:    "keyspace tables",
+			command: KeyspaceTablesCmd,
+			service: &mock.MetricsService{
+				GetKeyspaceTablesFn: func(context.Context, *ps.GetBranchMetricsRequest) (json.RawMessage, error) {
+					return json.RawMessage(`{"commerce":{"users":{"bytes":1048576}}}`), nil
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			var buf bytes.Buffer
+			cmd := test.command(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: test.service}))
+			cmd.SetArgs([]string{"mydb", "main"})
+			c.Assert(cmd.Execute(), qt.IsNil)
+			c.Assert(json.Valid(buf.Bytes()), qt.IsTrue)
+			c.Assert(buf.String(), qt.Contains, "1048576")
+		})
+	}
+}
+
+func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
+	c := qt.New(t)
+	service := &mock.MetricsService{
+		GetTabletSeriesFn: func(ctx context.Context, req *ps.GetTabletMetricSeriesRequest) (*ps.MetricSeries, error) {
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"replication_lag", "pod_cpu_usage"})
+			c.Assert(req.From, qt.Equals, "2026-08-18T16:00:00Z")
+			c.Assert(req.To, qt.Equals, "2026-08-18T17:00:00Z")
+			c.Assert(req.Steps, qt.Equals, 60)
+			c.Assert(req.Keyspace, qt.Equals, "commerce")
+			c.Assert(req.Shard, qt.Equals, "-80")
+			c.Assert(req.Pod, qt.Equals, "zone-a-0")
+			c.Assert(req.Workflow, qt.Equals, "move-tables")
+			return sampleSeries(), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd := TabletsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
+	cmd.SetArgs([]string{
+		"mydb", "main",
+		"--metric", "replication_lag,pod_cpu_usage",
+		"--from", "2026-08-18T16:00:00Z",
+		"--to", "2026-08-18T17:00:00Z",
+		"--steps", "60",
+		"--keyspace", "commerce",
+		"--shard", "-80",
+		"--pod", "zone-a-0",
+		"--workflow", "move-tables",
+	})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(service.GetTabletSeriesFnInvoked, qt.IsTrue)
+}
+
+func TestTabletsInstantCmd_UsesNestedUX(t *testing.T) {
+	c := qt.New(t)
+	service := &mock.MetricsService{
+		GetInstantTabletsFn: func(ctx context.Context, req *ps.GetInstantTabletMetricsRequest) (*ps.InstantMetrics, error) {
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"replication_lag", "primary_cpu_usage"})
+			c.Assert(req.Keyspace, qt.Equals, "commerce")
+			c.Assert(req.Shard, qt.Equals, "-80")
+			return sampleInstantMetrics(), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd := TabletsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
+	cmd.SetArgs([]string{
+		"instant", "mydb", "main",
+		"--metric", "replication_lag,primary_cpu_usage",
+		"--keyspace", "commerce",
+		"--shard", "-80",
+	})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(service.GetInstantTabletsFnInvoked, qt.IsTrue)
+}
+
+func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
+	c := qt.New(t)
+	service := &mock.MetricsService{
+		GetTagSeriesFn: func(ctx context.Context, req *ps.GetTagMetricSeriesRequest) (*ps.MetricSeries, error) {
+			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99"})
+			c.Assert(req.TagSets, qt.DeepEquals, []string{"service=checkout", "region=us-east"})
+			c.Assert(req.Period, qt.Equals, "1d")
+			c.Assert(req.TabletType, qt.Equals, "primary")
+			c.Assert(req.BudgetID, qt.Equals, "budget-1")
+			c.Assert(req.RuleID, qt.Equals, "rule-1")
+			c.Assert(req.Search, qt.Equals, "checkout")
+			return sampleSeries(), nil
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd := TagsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
+	cmd.SetArgs([]string{
+		"mydb", "main",
+		"--metric", "queries,latency_p99",
+		"--tag-set", "service=checkout,region=us-east",
+		"--period", "1d",
+		"--tablet-type", "primary",
+		"--budget-id", "budget-1",
+		"--rule-id", "rule-1",
+		"--search", "checkout",
+	})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(service.GetTagSeriesFnInvoked, qt.IsTrue)
 }

--- a/internal/cmd/metrics/metrics_test.go
+++ b/internal/cmd/metrics/metrics_test.go
@@ -243,7 +243,10 @@ func TestQueriesCmd_ForwardsSupportedFilters(t *testing.T) {
 	service := &mock.MetricsService{
 		GetQuerySeriesFn: func(ctx context.Context, req *ps.GetQueryMetricSeriesRequest) (*ps.MetricSeries, error) {
 			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99"})
-			c.Assert(req.QueryIDs, qt.DeepEquals, []string{"query-1", "query-2"})
+			c.Assert(req.QueryIDs, qt.DeepEquals, []string{
+				strings.Repeat("a", 64) + "-commerce",
+				strings.Repeat("b", 64) + "-commerce",
+			})
 			c.Assert(req.Fingerprint, qt.Equals, "fingerprint-1")
 			c.Assert(req.Keyspace, qt.Equals, "commerce")
 			c.Assert(req.Period, qt.Equals, "1h")
@@ -260,7 +263,7 @@ func TestQueriesCmd_ForwardsSupportedFilters(t *testing.T) {
 	cmd.SetArgs([]string{
 		"mydb", "main",
 		"--metric", "queries,latency_p99",
-		"--query-id", "query-1,query-2",
+		"--query-id", strings.Repeat("a", 64) + "-commerce," + strings.Repeat("b", 64) + "-commerce",
 		"--fingerprint", "fingerprint-1",
 		"--keyspace", "commerce",
 		"--period", "1h",
@@ -405,6 +408,23 @@ func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
 	})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(service.GetTagSeriesFnInvoked, qt.IsTrue)
+}
+
+func TestQueriesCmd_RejectsShortQueryID(t *testing.T) {
+	c := qt.New(t)
+	service := &mock.MetricsService{
+		GetQuerySeriesFn: func(ctx context.Context, req *ps.GetQueryMetricSeriesRequest) (*ps.MetricSeries, error) {
+			c.Fatal("Metrics.GetQuerySeries should not be called")
+			return nil, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	cmd := QueriesCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
+	cmd.SetArgs([]string{"mydb", "main", "--metric", "queries", "--query-id", "59801dae501c"})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `invalid --query-id "59801dae501c"; expected <fingerprint>-<keyspace>`)
 }
 
 func TestParseTagSets(t *testing.T) {

--- a/internal/cmd/metrics/metrics_test.go
+++ b/internal/cmd/metrics/metrics_test.go
@@ -377,7 +377,10 @@ func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
 	service := &mock.MetricsService{
 		GetTagSeriesFn: func(ctx context.Context, req *ps.GetTagMetricSeriesRequest) (*ps.MetricSeries, error) {
 			c.Assert(req.Metrics, qt.DeepEquals, []string{"queries", "latency_p99"})
-			c.Assert(req.TagSets, qt.DeepEquals, []string{"service=checkout", "region=us-east"})
+			c.Assert(req.TagSets, qt.DeepEquals, []map[string]string{
+				{"Busername": "alice", "Senv": "production"},
+				{"Busername": "bob"},
+			})
 			c.Assert(req.Period, qt.Equals, "1d")
 			c.Assert(req.TabletType, qt.Equals, "primary")
 			c.Assert(req.BudgetID, qt.Equals, "budget-1")
@@ -392,7 +395,8 @@ func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
 	cmd.SetArgs([]string{
 		"mydb", "main",
 		"--metric", "queries,latency_p99",
-		"--tag-set", "service=checkout,region=us-east",
+		"--tag-set", "Busername=alice,Senv=production",
+		"--tag-set", "Busername=bob",
 		"--period", "1d",
 		"--tablet-type", "primary",
 		"--budget-id", "budget-1",
@@ -401,4 +405,18 @@ func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {
 	})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(service.GetTagSeriesFnInvoked, qt.IsTrue)
+}
+
+func TestParseTagSets(t *testing.T) {
+	c := qt.New(t)
+
+	sets, err := parseTagSets([]string{"Busername=alice,Senv=production", "Busername=bob"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(sets, qt.DeepEquals, []map[string]string{
+		{"Busername": "alice", "Senv": "production"},
+		{"Busername": "bob"},
+	})
+
+	_, err = parseTagSets([]string{"alice"})
+	c.Assert(err, qt.ErrorMatches, `invalid --tag-set "alice"; use key=value pairs with an Insights type prefix, for example Busername=alice`)
 }

--- a/internal/cmd/metrics/metrics_test.go
+++ b/internal/cmd/metrics/metrics_test.go
@@ -321,7 +321,8 @@ func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
 		ListFn: func(ctx context.Context, req *ps.ListWorkflowsRequest) ([]*ps.Workflow, error) {
 			c.Assert(req.Database, qt.Equals, "mydb")
 			return []*ps.Workflow{{
-				ID:     "move-tables",
+				ID:     "opaque-workflow-id",
+				Name:   "move-tables",
 				Branch: ps.DatabaseBranch{Name: "main"},
 			}}, nil
 		},

--- a/internal/cmd/metrics/metrics_test.go
+++ b/internal/cmd/metrics/metrics_test.go
@@ -317,6 +317,15 @@ func TestStorageMetricsCommands_PreserveResponse(t *testing.T) {
 
 func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
 	c := qt.New(t)
+	workflows := &mock.WorkflowsService{
+		ListFn: func(ctx context.Context, req *ps.ListWorkflowsRequest) ([]*ps.Workflow, error) {
+			c.Assert(req.Database, qt.Equals, "mydb")
+			return []*ps.Workflow{{
+				ID:     "move-tables",
+				Branch: ps.DatabaseBranch{Name: "main"},
+			}}, nil
+		},
+	}
 	service := &mock.MetricsService{
 		GetTabletSeriesFn: func(ctx context.Context, req *ps.GetTabletMetricSeriesRequest) (*ps.MetricSeries, error) {
 			c.Assert(req.Metrics, qt.DeepEquals, []string{"replication_lag", "pod_cpu_usage", "vreplication_lag"})
@@ -332,7 +341,7 @@ func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	cmd := TabletsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service}))
+	cmd := TabletsCmd(metricsTestHelper(&buf, printer.JSON, &ps.Client{Metrics: service, Workflows: workflows}))
 	cmd.SetArgs([]string{
 		"mydb", "main",
 		"--metric", "replication_lag,pod_cpu_usage,vreplication_lag",
@@ -346,6 +355,7 @@ func TestTabletsCmd_ForwardsSupportedFilters(t *testing.T) {
 	})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(service.GetTabletSeriesFnInvoked, qt.IsTrue)
+	c.Assert(workflows.ListFnInvoked, qt.IsTrue)
 }
 
 func TestTabletsInstantCmd_UsesNestedUX(t *testing.T) {
@@ -369,6 +379,33 @@ func TestTabletsInstantCmd_UsesNestedUX(t *testing.T) {
 	})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(service.GetInstantTabletsFnInvoked, qt.IsTrue)
+}
+
+func TestTabletsCmd_RejectsUnknownWorkflow(t *testing.T) {
+	c := qt.New(t)
+	workflows := &mock.WorkflowsService{
+		ListFn: func(context.Context, *ps.ListWorkflowsRequest) ([]*ps.Workflow, error) {
+			return []*ps.Workflow{}, nil
+		},
+	}
+	service := &mock.MetricsService{
+		GetTabletSeriesFn: func(context.Context, *ps.GetTabletMetricSeriesRequest) (*ps.MetricSeries, error) {
+			c.Fatal("Metrics.GetTabletSeries should not be called")
+			return nil, nil
+		},
+	}
+
+	cmd := TabletsCmd(metricsTestHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{
+		Metrics:   service,
+		Workflows: workflows,
+	}))
+	cmd.SetArgs([]string{
+		"mydb", "main",
+		"--metric", "vreplication_lag",
+		"--workflow", "missing",
+	})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "workflow missing does not exist on branch main")
+	c.Assert(service.GetTabletSeriesFnInvoked, qt.IsFalse)
 }
 
 func TestTagsCmd_ForwardsSupportedFilters(t *testing.T) {

--- a/internal/cmd/metrics/show.go
+++ b/internal/cmd/metrics/show.go
@@ -51,6 +51,9 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			if cmd.Flags().Changed("steps") && flags.steps <= 0 {
 				return fmt.Errorf("--steps must be greater than zero")
 			}
+			if err := validateQueryIDs(flags.queryIDs); err != nil {
+				return err
+			}
 
 			client, err := ch.Client()
 			if err != nil {
@@ -112,7 +115,7 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.container, "container", "", "Filter by container")
 	cmd.Flags().StringVar(&flags.pod, "pod", "", "Filter by one pod")
 	cmd.Flags().StringSliceVar(&flags.pods, "pods", nil, "Filter by pods (repeat or comma-separate)")
-	cmd.Flags().StringSliceVar(&flags.queryIDs, "query-id", nil, "Filter by query pattern ID (repeat or comma-separate)")
+	cmd.Flags().StringSliceVar(&flags.queryIDs, "query-id", nil, "Filter by query pattern ID as <fingerprint>-<keyspace> (repeat or comma-separate)")
 	cmd.Flags().StringVar(&flags.fingerprint, "fingerprint", "", "Filter by query fingerprint")
 	cmd.Flags().StringVar(&flags.budgetID, "budget-id", "", "Filter by traffic budget ID")
 	cmd.Flags().StringVar(&flags.ruleID, "rule-id", "", "Filter by traffic rule ID")

--- a/internal/cmd/metrics/specialized.go
+++ b/internal/cmd/metrics/specialized.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -232,6 +233,11 @@ func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			database, branch := args[0], args[1]
+			tagSets, err := parseTagSets(flags.tagSets)
+			if err != nil {
+				return err
+			}
+
 			end := specializedMetricsProgress(ch, database, branch, "query tag")
 			defer end()
 
@@ -240,7 +246,7 @@ func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
 				Database:     database,
 				Branch:       branch,
 				Metrics:      flags.metrics,
-				TagSets:      flags.tagSets,
+				TagSets:      tagSets,
 				Period:       flags.period,
 				From:         flags.from,
 				To:           flags.to,
@@ -261,9 +267,35 @@ func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	addSpecializedSeriesFlags(cmd, &flags.specializedSeriesFlags)
 	addQueryDimensionFlags(cmd, &flags.queryDimensionFlags)
-	cmd.Flags().StringSliceVar(&flags.tagSets, "tag-set", nil, "Filter by tag set (repeat or comma-separate)")
+	cmd.Flags().StringArrayVar(&flags.tagSets, "tag-set", nil, "Tag set as key=value pairs. Repeat for independent series; comma-separate keys in one set (for example Busername=alice,Senv=production)")
 
 	return cmd
+}
+
+func parseTagSets(raw []string) ([]map[string]string, error) {
+	sets := make([]map[string]string, 0, len(raw))
+	for _, item := range raw {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			return nil, fmt.Errorf("--tag-set must be key=value pairs, for example Busername=alice")
+		}
+
+		set := map[string]string{}
+		for _, pair := range strings.Split(item, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				return nil, fmt.Errorf("--tag-set must be key=value pairs, for example Busername=alice")
+			}
+			key, value, ok := strings.Cut(pair, "=")
+			key = strings.TrimSpace(key)
+			if !ok || key == "" {
+				return nil, fmt.Errorf("invalid --tag-set %q; use key=value pairs with an Insights type prefix, for example Busername=alice", item)
+			}
+			set[key] = value
+		}
+		sets = append(sets, set)
+	}
+	return sets, nil
 }
 
 func addSpecializedSeriesFlags(cmd *cobra.Command, flags *specializedSeriesFlags) {

--- a/internal/cmd/metrics/specialized.go
+++ b/internal/cmd/metrics/specialized.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -43,6 +44,9 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err := validateSpecializedSeriesFlags(cmd, flags.specializedSeriesFlags); err != nil {
 				return err
 			}
+			if err := validateQueryIDs(flags.queryIDs); err != nil {
+				return err
+			}
 
 			client, err := ch.Client()
 			if err != nil {
@@ -81,7 +85,7 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	addSpecializedSeriesFlags(cmd, &flags.specializedSeriesFlags)
 	addQueryDimensionFlags(cmd, &flags.queryDimensionFlags)
-	cmd.Flags().StringSliceVar(&flags.queryIDs, "query-id", nil, "Filter by query pattern ID (repeat or comma-separate)")
+	cmd.Flags().StringSliceVar(&flags.queryIDs, "query-id", nil, "Filter by query pattern ID as <fingerprint>-<keyspace> (repeat or comma-separate)")
 	cmd.Flags().StringVar(&flags.fingerprint, "fingerprint", "", "Filter by query fingerprint")
 	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the query fingerprint")
 
@@ -270,6 +274,20 @@ func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringArrayVar(&flags.tagSets, "tag-set", nil, "Tag set as key=value pairs. Repeat for independent series; comma-separate keys in one set (for example Busername=alice,Senv=production)")
 
 	return cmd
+}
+
+// queryPatternIDPattern matches the API's query pattern ID: a 64 character
+// fingerprint joined to the keyspace by a dash. Anything else is silently
+// ignored by the API, which returns an empty series instead of an error.
+var queryPatternIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{64}-.+$`)
+
+func validateQueryIDs(ids []string) error {
+	for _, id := range ids {
+		if !queryPatternIDPattern.MatchString(id) {
+			return fmt.Errorf("invalid --query-id %q; expected <fingerprint>-<keyspace>, for example %s-mykeyspace. Use --fingerprint and --keyspace instead, or take both from `pscale insights queries`", id, strings.Repeat("a", 64))
+		}
+	}
+	return nil
 }
 
 func parseTagSets(raw []string) ([]map[string]string, error) {

--- a/internal/cmd/metrics/specialized.go
+++ b/internal/cmd/metrics/specialized.go
@@ -1,0 +1,338 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+type specializedSeriesFlags struct {
+	metrics []string
+	period  string
+	from    string
+	to      string
+	steps   int
+}
+
+type queryDimensionFlags struct {
+	tabletType string
+	budgetID   string
+	ruleID     string
+	search     string
+}
+
+func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		specializedSeriesFlags
+		queryDimensionFlags
+		queryIDs    []string
+		fingerprint string
+		keyspace    string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "queries <database> <branch>",
+		Short: "Show metrics for SQL queries",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateSpecializedSeriesFlags(cmd, flags.specializedSeriesFlags); err != nil {
+				return err
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			database, branch := args[0], args[1]
+			end := specializedMetricsProgress(ch, database, branch, "query")
+			defer end()
+
+			series, err := client.Metrics.GetQuerySeries(cmd.Context(), &ps.GetQueryMetricSeriesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Metrics:      flags.metrics,
+				QueryIDs:     flags.queryIDs,
+				Fingerprint:  flags.fingerprint,
+				Keyspace:     flags.keyspace,
+				Period:       flags.period,
+				From:         flags.from,
+				To:           flags.to,
+				Steps:        flags.steps,
+				TabletType:   flags.tabletType,
+				BudgetID:     flags.budgetID,
+				RuleID:       flags.ruleID,
+				Search:       flags.search,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			end()
+
+			return printSpecializedSeries(ch, database, branch, series)
+		},
+	}
+
+	addSpecializedSeriesFlags(cmd, &flags.specializedSeriesFlags)
+	addQueryDimensionFlags(cmd, &flags.queryDimensionFlags)
+	cmd.Flags().StringSliceVar(&flags.queryIDs, "query-id", nil, "Filter by query pattern ID (repeat or comma-separate)")
+	cmd.Flags().StringVar(&flags.fingerprint, "fingerprint", "", "Filter by query fingerprint")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the query fingerprint")
+
+	return cmd
+}
+
+func TablesCmd(ch *cmdutil.Helper) *cobra.Command {
+	return storageMetricsCmd(ch, "tables", "Show table storage metrics", func(client *ps.Client, cmd *cobra.Command, req *ps.GetBranchMetricsRequest) ([]byte, error) {
+		return client.Metrics.GetTables(cmd.Context(), req)
+	})
+}
+
+func KeyspaceTablesCmd(ch *cmdutil.Helper) *cobra.Command {
+	return storageMetricsCmd(ch, "keyspace-tables", "Show table storage metrics by keyspace", func(client *ps.Client, cmd *cobra.Command, req *ps.GetBranchMetricsRequest) ([]byte, error) {
+		return client.Metrics.GetKeyspaceTables(cmd.Context(), req)
+	})
+}
+
+func TabletsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		specializedSeriesFlags
+		keyspace string
+		shard    string
+		pod      string
+		workflow string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "tablets <database> <branch>",
+		Short: "Show tablet metric series",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateSpecializedSeriesFlags(cmd, flags.specializedSeriesFlags); err != nil {
+				return err
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			database, branch := args[0], args[1]
+			end := specializedMetricsProgress(ch, database, branch, "tablet")
+			defer end()
+
+			series, err := client.Metrics.GetTabletSeries(cmd.Context(), &ps.GetTabletMetricSeriesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Metrics:      flags.metrics,
+				Period:       flags.period,
+				From:         flags.from,
+				To:           flags.to,
+				Steps:        flags.steps,
+				Keyspace:     flags.keyspace,
+				Shard:        flags.shard,
+				Pod:          flags.pod,
+				Workflow:     flags.workflow,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			end()
+
+			return printSpecializedSeries(ch, database, branch, series)
+		},
+	}
+
+	addSpecializedSeriesFlags(cmd, &flags.specializedSeriesFlags)
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Filter by keyspace")
+	cmd.Flags().StringVar(&flags.shard, "shard", "", "Filter by shard")
+	cmd.Flags().StringVar(&flags.pod, "pod", "", "Filter by pod")
+	cmd.Flags().StringVar(&flags.workflow, "workflow", "", "Filter by VReplication workflow")
+	cmd.AddCommand(InstantTabletsCmd(ch))
+
+	return cmd
+}
+
+func InstantTabletsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		metrics  []string
+		keyspace string
+		shard    string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "instant <database> <branch>",
+		Short: "Show current tablet metric values",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			database, branch := args[0], args[1]
+			end := specializedMetricsProgress(ch, database, branch, "current tablet")
+			defer end()
+
+			metrics, err := client.Metrics.GetInstantTablets(cmd.Context(), &ps.GetInstantTabletMetricsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Metrics:      flags.metrics,
+				Keyspace:     flags.keyspace,
+				Shard:        flags.shard,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			end()
+
+			if ch.Printer.Format() == printer.JSON {
+				return ch.Printer.PrintJSON(metrics)
+			}
+			if ch.Printer.Format() == printer.CSV {
+				return ch.Printer.PrintResource(instantMetricCSVRows(metrics))
+			}
+			return ch.Printer.PrintResource(instantMetricHumanRows(metrics))
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&flags.metrics, "metric", nil, "Metric to query (repeat or comma-separate)")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Filter by keyspace")
+	cmd.Flags().StringVar(&flags.shard, "shard", "", "Filter by shard")
+
+	return cmd
+}
+
+func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		specializedSeriesFlags
+		queryDimensionFlags
+		tagSets []string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "tags <database> <branch>",
+		Short: "Show metrics grouped by query tags",
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateSpecializedSeriesFlags(cmd, flags.specializedSeriesFlags); err != nil {
+				return err
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			database, branch := args[0], args[1]
+			end := specializedMetricsProgress(ch, database, branch, "query tag")
+			defer end()
+
+			series, err := client.Metrics.GetTagSeries(cmd.Context(), &ps.GetTagMetricSeriesRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+				Metrics:      flags.metrics,
+				TagSets:      flags.tagSets,
+				Period:       flags.period,
+				From:         flags.from,
+				To:           flags.to,
+				Steps:        flags.steps,
+				TabletType:   flags.tabletType,
+				BudgetID:     flags.budgetID,
+				RuleID:       flags.ruleID,
+				Search:       flags.search,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			end()
+
+			return printSpecializedSeries(ch, database, branch, series)
+		},
+	}
+
+	addSpecializedSeriesFlags(cmd, &flags.specializedSeriesFlags)
+	addQueryDimensionFlags(cmd, &flags.queryDimensionFlags)
+	cmd.Flags().StringSliceVar(&flags.tagSets, "tag-set", nil, "Filter by tag set (repeat or comma-separate)")
+
+	return cmd
+}
+
+func addSpecializedSeriesFlags(cmd *cobra.Command, flags *specializedSeriesFlags) {
+	cmd.Flags().StringSliceVar(&flags.metrics, "metric", nil, "Metric to query (repeat or comma-separate)")
+	cmd.Flags().StringVar(&flags.period, "period", "", "Named time period to query (for example 1h, 12h, or 1d; defaults to 12h)")
+	cmd.Flags().StringVar(&flags.from, "from", "", "Start of a custom time range as an ISO 8601 timestamp")
+	cmd.Flags().StringVar(&flags.to, "to", "", "End of a custom time range as an ISO 8601 timestamp")
+	cmd.Flags().IntVar(&flags.steps, "steps", 0, "Requested number of data points")
+}
+
+func addQueryDimensionFlags(cmd *cobra.Command, flags *queryDimensionFlags) {
+	cmd.Flags().StringVar(&flags.tabletType, "tablet-type", "", "Filter by tablet type")
+	cmd.Flags().StringVar(&flags.budgetID, "budget-id", "", "Filter by traffic budget ID")
+	cmd.Flags().StringVar(&flags.ruleID, "rule-id", "", "Filter by traffic rule ID")
+	cmd.Flags().StringVarP(&flags.search, "search", "q", "", "Filter by search terms")
+}
+
+func validateSpecializedSeriesFlags(cmd *cobra.Command, flags specializedSeriesFlags) error {
+	if err := validateRangeFlags(cmd, flags.from, flags.to); err != nil {
+		return err
+	}
+	if cmd.Flags().Changed("steps") && flags.steps <= 0 {
+		return fmt.Errorf("--steps must be greater than zero")
+	}
+	return nil
+}
+
+func specializedMetricsProgress(ch *cmdutil.Helper, database, branch, kind string) func() {
+	return ch.Printer.PrintProgress(fmt.Sprintf("Fetching %s metrics for %s in %s...",
+		kind, printer.BoldBlue(branch), printer.BoldBlue(database)))
+}
+
+func printSpecializedSeries(ch *cmdutil.Helper, database, branch string, series *ps.MetricSeries) error {
+	switch ch.Printer.Format() {
+	case printer.JSON:
+		return ch.Printer.PrintJSON(series)
+	case printer.CSV:
+		return ch.Printer.PrintResource(metricPointRows(series))
+	default:
+		return printSeriesSummary(ch, database, branch, series)
+	}
+}
+
+func storageMetricsCmd(ch *cmdutil.Helper, use, short string, fetch func(*ps.Client, *cobra.Command, *ps.GetBranchMetricsRequest) ([]byte, error)) *cobra.Command {
+	return &cobra.Command{
+		Use:   use + " <database> <branch>",
+		Short: short,
+		Args:  cmdutil.RequiredArgs("database", "branch"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			database, branch := args[0], args[1]
+			end := specializedMetricsProgress(ch, database, branch, use)
+			defer end()
+
+			response, err := fetch(client, cmd, &ps.GetBranchMetricsRequest{
+				Organization: ch.Config.Organization,
+				Database:     database,
+				Branch:       branch,
+			})
+			if err != nil {
+				return cmdutil.HandleError(err)
+			}
+			end()
+
+			return ch.Printer.PrettyPrintJSON(response)
+		},
+	}
+}

--- a/internal/cmd/metrics/specialized.go
+++ b/internal/cmd/metrics/specialized.go
@@ -149,7 +149,7 @@ func TabletsCmd(ch *cmdutil.Helper) *cobra.Command {
 
 				found := false
 				for _, workflow := range workflows {
-					if workflow.ID == flags.workflow && workflow.Branch.Name == branch {
+					if workflow.Name == flags.workflow && workflow.Branch.Name == branch {
 						found = true
 						break
 					}

--- a/internal/cmd/metrics/specialized.go
+++ b/internal/cmd/metrics/specialized.go
@@ -47,6 +47,12 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err := validateQueryIDs(flags.queryIDs); err != nil {
 				return err
 			}
+			if err := validateQuerySelector(flags.queryIDs, flags.fingerprint, flags.keyspace); err != nil {
+				return err
+			}
+			if err := validateTrafficControlMetricFilters(flags.metrics, flags.budgetID, flags.ruleID); err != nil {
+				return err
+			}
 
 			client, err := ch.Client()
 			if err != nil {
@@ -88,6 +94,7 @@ func QueriesCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringSliceVar(&flags.queryIDs, "query-id", nil, "Filter by query pattern ID as <fingerprint>-<keyspace> (repeat or comma-separate)")
 	cmd.Flags().StringVar(&flags.fingerprint, "fingerprint", "", "Filter by query fingerprint")
 	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the query fingerprint")
+	cmd.MarkFlagRequired("metric") // nolint:errcheck
 
 	return cmd
 }
@@ -120,6 +127,9 @@ func TabletsCmd(ch *cmdutil.Helper) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateSpecializedSeriesFlags(cmd, flags.specializedSeriesFlags); err != nil {
 				return err
+			}
+			if flags.workflow != "" && !containsString(flags.metrics, "vreplication_lag") {
+				return fmt.Errorf("--workflow only applies to --metric vreplication_lag")
 			}
 
 			client, err := ch.Client()
@@ -159,6 +169,7 @@ func TabletsCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&flags.shard, "shard", "", "Filter by shard")
 	cmd.Flags().StringVar(&flags.pod, "pod", "", "Filter by pod")
 	cmd.Flags().StringVar(&flags.workflow, "workflow", "", "Filter by VReplication workflow")
+	cmd.MarkFlagRequired("metric") // nolint:errcheck
 	cmd.AddCommand(InstantTabletsCmd(ch))
 
 	return cmd
@@ -211,6 +222,7 @@ func InstantTabletsCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringSliceVar(&flags.metrics, "metric", nil, "Metric to query (repeat or comma-separate)")
 	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Filter by keyspace")
 	cmd.Flags().StringVar(&flags.shard, "shard", "", "Filter by shard")
+	cmd.MarkFlagRequired("metric") // nolint:errcheck
 
 	return cmd
 }
@@ -228,6 +240,12 @@ func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:  cmdutil.RequiredArgs("database", "branch"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateSpecializedSeriesFlags(cmd, flags.specializedSeriesFlags); err != nil {
+				return err
+			}
+			if len(flags.tagSets) == 0 {
+				return fmt.Errorf("at least one --tag-set must be provided")
+			}
+			if err := validateTrafficControlMetricFilters(flags.metrics, flags.budgetID, flags.ruleID); err != nil {
 				return err
 			}
 
@@ -272,6 +290,7 @@ func TagsCmd(ch *cmdutil.Helper) *cobra.Command {
 	addSpecializedSeriesFlags(cmd, &flags.specializedSeriesFlags)
 	addQueryDimensionFlags(cmd, &flags.queryDimensionFlags)
 	cmd.Flags().StringArrayVar(&flags.tagSets, "tag-set", nil, "Tag set as key=value pairs. Repeat for independent series; comma-separate keys in one set (for example Busername=alice,Senv=production)")
+	cmd.MarkFlagRequired("metric") // nolint:errcheck
 
 	return cmd
 }
@@ -288,6 +307,42 @@ func validateQueryIDs(ids []string) error {
 		}
 	}
 	return nil
+}
+
+func validateQuerySelector(ids []string, fingerprint, keyspace string) error {
+	hasIDs := len(ids) > 0
+	hasFingerprint := fingerprint != ""
+	hasKeyspace := keyspace != ""
+
+	if hasIDs && (hasFingerprint || hasKeyspace) {
+		return fmt.Errorf("--query-id cannot be combined with --fingerprint or --keyspace")
+	}
+	if hasFingerprint != hasKeyspace {
+		return fmt.Errorf("--fingerprint and --keyspace must be used together")
+	}
+	if !hasIDs && !hasFingerprint {
+		return fmt.Errorf("select at least one query with --query-id or with --fingerprint and --keyspace")
+	}
+	return nil
+}
+
+func validateTrafficControlMetricFilters(metrics []string, budgetID, ruleID string) error {
+	if budgetID == "" && ruleID == "" {
+		return nil
+	}
+	if containsString(metrics, "traffic_control_warnings") || containsString(metrics, "traffic_control_throttled") {
+		return nil
+	}
+	return fmt.Errorf("--budget-id and --rule-id only apply to --metric traffic_control_warnings or traffic_control_throttled")
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }
 
 func parseTagSets(raw []string) ([]map[string]string, error) {
@@ -308,6 +363,9 @@ func parseTagSets(raw []string) ([]map[string]string, error) {
 			key = strings.TrimSpace(key)
 			if !ok || key == "" {
 				return nil, fmt.Errorf("invalid --tag-set %q; use key=value pairs with an Insights type prefix, for example Busername=alice", item)
+			}
+			if len(key) < 2 || (key[0] != 'B' && key[0] != 'S') {
+				return nil, fmt.Errorf("invalid tag key %q; keys must start with B (built-in) or S (custom), for example Busername or Sapplication", key)
 			}
 			set[key] = value
 		}

--- a/internal/cmd/metrics/specialized.go
+++ b/internal/cmd/metrics/specialized.go
@@ -138,6 +138,27 @@ func TabletsCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			database, branch := args[0], args[1]
+			if flags.workflow != "" {
+				workflows, err := client.Workflows.List(cmd.Context(), &ps.ListWorkflowsRequest{
+					Organization: ch.Config.Organization,
+					Database:     database,
+				})
+				if err != nil {
+					return cmdutil.HandleError(err)
+				}
+
+				found := false
+				for _, workflow := range workflows {
+					if workflow.ID == flags.workflow && workflow.Branch.Name == branch {
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("workflow %s does not exist on branch %s", printer.BoldBlue(flags.workflow), printer.BoldBlue(branch))
+				}
+			}
+
 			end := specializedMetricsProgress(ch, database, branch, "tablet")
 			defer end()
 

--- a/internal/mock/metrics.go
+++ b/internal/mock/metrics.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"encoding/json"
 
 	ps "github.com/planetscale/cli/internal/planetscale"
 )
@@ -12,6 +13,24 @@ type MetricsService struct {
 
 	GetInstantFn        func(context.Context, *ps.GetInstantMetricsRequest) (*ps.InstantMetrics, error)
 	GetInstantFnInvoked bool
+
+	GetQuerySeriesFn        func(context.Context, *ps.GetQueryMetricSeriesRequest) (*ps.MetricSeries, error)
+	GetQuerySeriesFnInvoked bool
+
+	GetTablesFn        func(context.Context, *ps.GetBranchMetricsRequest) (json.RawMessage, error)
+	GetTablesFnInvoked bool
+
+	GetKeyspaceTablesFn        func(context.Context, *ps.GetBranchMetricsRequest) (json.RawMessage, error)
+	GetKeyspaceTablesFnInvoked bool
+
+	GetTabletSeriesFn        func(context.Context, *ps.GetTabletMetricSeriesRequest) (*ps.MetricSeries, error)
+	GetTabletSeriesFnInvoked bool
+
+	GetInstantTabletsFn        func(context.Context, *ps.GetInstantTabletMetricsRequest) (*ps.InstantMetrics, error)
+	GetInstantTabletsFnInvoked bool
+
+	GetTagSeriesFn        func(context.Context, *ps.GetTagMetricSeriesRequest) (*ps.MetricSeries, error)
+	GetTagSeriesFnInvoked bool
 }
 
 func (s *MetricsService) GetSeries(ctx context.Context, req *ps.GetMetricSeriesRequest) (*ps.MetricSeries, error) {
@@ -22,4 +41,34 @@ func (s *MetricsService) GetSeries(ctx context.Context, req *ps.GetMetricSeriesR
 func (s *MetricsService) GetInstant(ctx context.Context, req *ps.GetInstantMetricsRequest) (*ps.InstantMetrics, error) {
 	s.GetInstantFnInvoked = true
 	return s.GetInstantFn(ctx, req)
+}
+
+func (s *MetricsService) GetQuerySeries(ctx context.Context, req *ps.GetQueryMetricSeriesRequest) (*ps.MetricSeries, error) {
+	s.GetQuerySeriesFnInvoked = true
+	return s.GetQuerySeriesFn(ctx, req)
+}
+
+func (s *MetricsService) GetTables(ctx context.Context, req *ps.GetBranchMetricsRequest) (json.RawMessage, error) {
+	s.GetTablesFnInvoked = true
+	return s.GetTablesFn(ctx, req)
+}
+
+func (s *MetricsService) GetKeyspaceTables(ctx context.Context, req *ps.GetBranchMetricsRequest) (json.RawMessage, error) {
+	s.GetKeyspaceTablesFnInvoked = true
+	return s.GetKeyspaceTablesFn(ctx, req)
+}
+
+func (s *MetricsService) GetTabletSeries(ctx context.Context, req *ps.GetTabletMetricSeriesRequest) (*ps.MetricSeries, error) {
+	s.GetTabletSeriesFnInvoked = true
+	return s.GetTabletSeriesFn(ctx, req)
+}
+
+func (s *MetricsService) GetInstantTablets(ctx context.Context, req *ps.GetInstantTabletMetricsRequest) (*ps.InstantMetrics, error) {
+	s.GetInstantTabletsFnInvoked = true
+	return s.GetInstantTabletsFn(ctx, req)
+}
+
+func (s *MetricsService) GetTagSeries(ctx context.Context, req *ps.GetTagMetricSeriesRequest) (*ps.MetricSeries, error) {
+	s.GetTagSeriesFnInvoked = true
+	return s.GetTagSeriesFn(ctx, req)
 }

--- a/internal/planetscale/metrics.go
+++ b/internal/planetscale/metrics.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -220,8 +219,8 @@ func (s *metricsService) GetInstant(ctx context.Context, getReq *GetInstantMetri
 
 func (s *metricsService) GetQuerySeries(ctx context.Context, getReq *GetQueryMetricSeriesRequest) (*MetricSeries, error) {
 	query := url.Values{}
-	setQueryValues(query, "metrics", getReq.Metrics)
-	setQueryValues(query, "query_ids", getReq.QueryIDs)
+	addQueryValues(query, "metrics[]", getReq.Metrics)
+	addQueryValues(query, "query_ids[]", getReq.QueryIDs)
 	setQueryValue(query, "fingerprint", getReq.Fingerprint)
 	setQueryValue(query, "keyspace", getReq.Keyspace)
 	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
@@ -243,7 +242,7 @@ func (s *metricsService) GetKeyspaceTables(ctx context.Context, getReq *GetBranc
 
 func (s *metricsService) GetTabletSeries(ctx context.Context, getReq *GetTabletMetricSeriesRequest) (*MetricSeries, error) {
 	query := url.Values{}
-	setQueryValues(query, "metrics", getReq.Metrics)
+	addQueryValues(query, "metrics[]", getReq.Metrics)
 	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
 	setQueryValue(query, "keyspace", getReq.Keyspace)
 	setQueryValue(query, "shard", getReq.Shard)
@@ -255,7 +254,7 @@ func (s *metricsService) GetTabletSeries(ctx context.Context, getReq *GetTabletM
 
 func (s *metricsService) GetInstantTablets(ctx context.Context, getReq *GetInstantTabletMetricsRequest) (*InstantMetrics, error) {
 	query := url.Values{}
-	setQueryValues(query, "metrics", getReq.Metrics)
+	addQueryValues(query, "metrics[]", getReq.Metrics)
 	setQueryValue(query, "keyspace", getReq.Keyspace)
 	setQueryValue(query, "shard", getReq.Shard)
 
@@ -274,8 +273,8 @@ func (s *metricsService) GetInstantTablets(ctx context.Context, getReq *GetInsta
 
 func (s *metricsService) GetTagSeries(ctx context.Context, getReq *GetTagMetricSeriesRequest) (*MetricSeries, error) {
 	query := url.Values{}
-	setQueryValues(query, "metrics", getReq.Metrics)
-	setQueryValues(query, "tag_sets", getReq.TagSets)
+	addQueryValues(query, "metrics[]", getReq.Metrics)
+	addQueryValues(query, "tag_sets[]", getReq.TagSets)
 	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
 	setQueryValue(query, "tablet_type", getReq.TabletType)
 	setQueryValue(query, "budget_id", getReq.BudgetID)
@@ -329,12 +328,6 @@ func setSeriesRange(query url.Values, period, from, to string, steps int) {
 func setQueryValue(query url.Values, key, value string) {
 	if value != "" {
 		query.Set(key, value)
-	}
-}
-
-func setQueryValues(query url.Values, key string, values []string) {
-	if len(values) > 0 {
-		query.Set(key, strings.Join(values, ","))
 	}
 }
 

--- a/internal/planetscale/metrics.go
+++ b/internal/planetscale/metrics.go
@@ -150,7 +150,7 @@ type GetTagMetricSeriesRequest struct {
 	Database     string
 	Branch       string
 	Metrics      []string
-	TagSets      []string
+	TagSets      []map[string]string
 	Period       string
 	From         string
 	To           string
@@ -274,7 +274,7 @@ func (s *metricsService) GetInstantTablets(ctx context.Context, getReq *GetInsta
 func (s *metricsService) GetTagSeries(ctx context.Context, getReq *GetTagMetricSeriesRequest) (*MetricSeries, error) {
 	query := url.Values{}
 	addQueryValues(query, "metrics[]", getReq.Metrics)
-	addQueryValues(query, "tag_sets[]", getReq.TagSets)
+	addTagSetQueryValues(query, getReq.TagSets)
 	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
 	setQueryValue(query, "tablet_type", getReq.TabletType)
 	setQueryValue(query, "budget_id", getReq.BudgetID)
@@ -328,6 +328,17 @@ func setSeriesRange(query url.Values, period, from, to string, steps int) {
 func setQueryValue(query url.Values, key, value string) {
 	if value != "" {
 		query.Set(key, value)
+	}
+}
+
+func addTagSetQueryValues(query url.Values, sets []map[string]string) {
+	for i, set := range sets {
+		for key, value := range set {
+			if key == "" {
+				continue
+			}
+			query.Add(fmt.Sprintf("tag_sets[%d][tags][%s]", i, key), value)
+		}
 	}
 }
 

--- a/internal/planetscale/metrics.go
+++ b/internal/planetscale/metrics.go
@@ -2,11 +2,13 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -14,6 +16,12 @@ import (
 type MetricsService interface {
 	GetSeries(context.Context, *GetMetricSeriesRequest) (*MetricSeries, error)
 	GetInstant(context.Context, *GetInstantMetricsRequest) (*InstantMetrics, error)
+	GetQuerySeries(context.Context, *GetQueryMetricSeriesRequest) (*MetricSeries, error)
+	GetTables(context.Context, *GetBranchMetricsRequest) (json.RawMessage, error)
+	GetKeyspaceTables(context.Context, *GetBranchMetricsRequest) (json.RawMessage, error)
+	GetTabletSeries(context.Context, *GetTabletMetricSeriesRequest) (*MetricSeries, error)
+	GetInstantTablets(context.Context, *GetInstantTabletMetricsRequest) (*InstantMetrics, error)
+	GetTagSeries(context.Context, *GetTagMetricSeriesRequest) (*MetricSeries, error)
 }
 
 type metricsService struct {
@@ -90,6 +98,70 @@ type GetInstantMetricsRequest struct {
 	Pod          string
 }
 
+type GetBranchMetricsRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+}
+
+type GetQueryMetricSeriesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Metrics      []string
+	QueryIDs     []string
+	Fingerprint  string
+	Keyspace     string
+	Period       string
+	From         string
+	To           string
+	Steps        int
+	TabletType   string
+	BudgetID     string
+	RuleID       string
+	Search       string
+}
+
+type GetTabletMetricSeriesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Metrics      []string
+	Period       string
+	From         string
+	To           string
+	Steps        int
+	Keyspace     string
+	Shard        string
+	Pod          string
+	Workflow     string
+}
+
+type GetInstantTabletMetricsRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Metrics      []string
+	Keyspace     string
+	Shard        string
+}
+
+type GetTagMetricSeriesRequest struct {
+	Organization string
+	Database     string
+	Branch       string
+	Metrics      []string
+	TagSets      []string
+	Period       string
+	From         string
+	To           string
+	Steps        int
+	TabletType   string
+	BudgetID     string
+	RuleID       string
+	Search       string
+}
+
 func (s *metricsService) GetSeries(ctx context.Context, getReq *GetMetricSeriesRequest) (*MetricSeries, error) {
 	query := url.Values{}
 	addQueryValues(query, "metrics[]", getReq.Metrics)
@@ -146,13 +218,123 @@ func (s *metricsService) GetInstant(ctx context.Context, getReq *GetInstantMetri
 	return metrics, nil
 }
 
+func (s *metricsService) GetQuerySeries(ctx context.Context, getReq *GetQueryMetricSeriesRequest) (*MetricSeries, error) {
+	query := url.Values{}
+	setQueryValues(query, "metrics", getReq.Metrics)
+	setQueryValues(query, "query_ids", getReq.QueryIDs)
+	setQueryValue(query, "fingerprint", getReq.Fingerprint)
+	setQueryValue(query, "keyspace", getReq.Keyspace)
+	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
+	setQueryValue(query, "tablet_type", getReq.TabletType)
+	setQueryValue(query, "budget_id", getReq.BudgetID)
+	setQueryValue(query, "rule_id", getReq.RuleID)
+	setQueryValue(query, "q", getReq.Search)
+
+	return s.getSpecializedSeries(ctx, getReq.Organization, getReq.Database, getReq.Branch, "query", query)
+}
+
+func (s *metricsService) GetTables(ctx context.Context, getReq *GetBranchMetricsRequest) (json.RawMessage, error) {
+	return s.getRawMetrics(ctx, getReq, "tables")
+}
+
+func (s *metricsService) GetKeyspaceTables(ctx context.Context, getReq *GetBranchMetricsRequest) (json.RawMessage, error) {
+	return s.getRawMetrics(ctx, getReq, "keyspace-tables")
+}
+
+func (s *metricsService) GetTabletSeries(ctx context.Context, getReq *GetTabletMetricSeriesRequest) (*MetricSeries, error) {
+	query := url.Values{}
+	setQueryValues(query, "metrics", getReq.Metrics)
+	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
+	setQueryValue(query, "keyspace", getReq.Keyspace)
+	setQueryValue(query, "shard", getReq.Shard)
+	setQueryValue(query, "pod", getReq.Pod)
+	setQueryValue(query, "workflow", getReq.Workflow)
+
+	return s.getSpecializedSeries(ctx, getReq.Organization, getReq.Database, getReq.Branch, "tablets", query)
+}
+
+func (s *metricsService) GetInstantTablets(ctx context.Context, getReq *GetInstantTabletMetricsRequest) (*InstantMetrics, error) {
+	query := url.Values{}
+	setQueryValues(query, "metrics", getReq.Metrics)
+	setQueryValue(query, "keyspace", getReq.Keyspace)
+	setQueryValue(query, "shard", getReq.Shard)
+
+	req, err := s.client.newRequest(http.MethodGet, path.Join(metricsAPIPath(getReq.Organization, getReq.Database, getReq.Branch), "tablets-instant"), nil, WithQueryParams(query))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for instant tablet metrics: %w", err)
+	}
+
+	metrics := &InstantMetrics{}
+	if err := s.client.do(ctx, req, metrics); err != nil {
+		return nil, err
+	}
+
+	return metrics, nil
+}
+
+func (s *metricsService) GetTagSeries(ctx context.Context, getReq *GetTagMetricSeriesRequest) (*MetricSeries, error) {
+	query := url.Values{}
+	setQueryValues(query, "metrics", getReq.Metrics)
+	setQueryValues(query, "tag_sets", getReq.TagSets)
+	setSeriesRange(query, getReq.Period, getReq.From, getReq.To, getReq.Steps)
+	setQueryValue(query, "tablet_type", getReq.TabletType)
+	setQueryValue(query, "budget_id", getReq.BudgetID)
+	setQueryValue(query, "rule_id", getReq.RuleID)
+	setQueryValue(query, "q", getReq.Search)
+
+	return s.getSpecializedSeries(ctx, getReq.Organization, getReq.Database, getReq.Branch, "tag", query)
+}
+
+func (s *metricsService) getSpecializedSeries(ctx context.Context, org, database, branch, endpoint string, query url.Values) (*MetricSeries, error) {
+	req, err := s.client.newRequest(http.MethodGet, path.Join(metricsAPIPath(org, database, branch), endpoint), nil, WithQueryParams(query))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for branch %s metrics: %w", endpoint, err)
+	}
+
+	series := &MetricSeries{}
+	if err := s.client.do(ctx, req, series); err != nil {
+		return nil, err
+	}
+
+	return series, nil
+}
+
+func (s *metricsService) getRawMetrics(ctx context.Context, getReq *GetBranchMetricsRequest, endpoint string) (json.RawMessage, error) {
+	req, err := s.client.newRequest(http.MethodGet, path.Join(metricsAPIPath(getReq.Organization, getReq.Database, getReq.Branch), endpoint), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for branch %s metrics: %w", endpoint, err)
+	}
+
+	var response json.RawMessage
+	if err := s.client.do(ctx, req, &response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 func metricsAPIPath(org, db, branch string) string {
 	return path.Join("v1/organizations", org, "databases", db, "branches", branch, "metrics")
+}
+
+func setSeriesRange(query url.Values, period, from, to string, steps int) {
+	setQueryValue(query, "period", period)
+	setQueryValue(query, "from", from)
+	setQueryValue(query, "to", to)
+	if steps > 0 {
+		query.Set("steps", strconv.Itoa(steps))
+	}
 }
 
 func setQueryValue(query url.Values, key, value string) {
 	if value != "" {
 		query.Set(key, value)
+	}
+}
+
+func setQueryValues(query url.Values, key string, values []string) {
+	if len(values) > 0 {
+		query.Set(key, strings.Join(values, ","))
 	}
 }
 

--- a/internal/planetscale/metrics_test.go
+++ b/internal/planetscale/metrics_test.go
@@ -102,3 +102,200 @@ func TestMetrics_GetInstant(t *testing.T) {
 	c.Assert(metrics.Metrics, qt.HasLen, 1)
 	c.Assert(metrics.Metrics[0].Values[0]["value"], qt.Equals, 71.4)
 }
+
+func TestMetrics_GetQuerySeries(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/query")
+		query := r.URL.Query()
+		c.Assert(query.Get("metrics"), qt.Equals, "queries,latency_p99")
+		c.Assert(query.Get("query_ids"), qt.Equals, "query-1,query-2")
+		c.Assert(query.Get("fingerprint"), qt.Equals, "select-from-users")
+		c.Assert(query.Get("keyspace"), qt.Equals, "commerce")
+		c.Assert(query.Get("period"), qt.Equals, "1h")
+		c.Assert(query.Get("steps"), qt.Equals, "60")
+		c.Assert(query.Get("tablet_type"), qt.Equals, "replica")
+		c.Assert(query.Get("budget_id"), qt.Equals, "budget-1")
+		c.Assert(query.Get("rule_id"), qt.Equals, "rule-1")
+		c.Assert(query.Get("q"), qt.Equals, "checkout")
+		writeMetricSeriesResponse(c, w)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	series, err := client.Metrics.GetQuerySeries(context.Background(), &GetQueryMetricSeriesRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "main",
+		Metrics:      []string{"queries", "latency_p99"},
+		QueryIDs:     []string{"query-1", "query-2"},
+		Fingerprint:  "select-from-users",
+		Keyspace:     "commerce",
+		Period:       "1h",
+		Steps:        60,
+		TabletType:   "replica",
+		BudgetID:     "budget-1",
+		RuleID:       "rule-1",
+		Search:       "checkout",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(series.Series, qt.HasLen, 1)
+}
+
+func TestMetrics_GetStorageMetrics(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		get  func(context.Context, MetricsService, *GetBranchMetricsRequest) ([]byte, error)
+	}{
+		{
+			name: "tables",
+			path: "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tables",
+			get: func(ctx context.Context, service MetricsService, req *GetBranchMetricsRequest) ([]byte, error) {
+				return service.GetTables(ctx, req)
+			},
+		},
+		{
+			name: "keyspace tables",
+			path: "/v1/organizations/my-org/databases/my-db/branches/main/metrics/keyspace-tables",
+			get: func(ctx context.Context, service MetricsService, req *GetBranchMetricsRequest) ([]byte, error) {
+				return service.GetKeyspaceTables(ctx, req)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				c.Assert(r.URL.Path, qt.Equals, test.path)
+				_, err := w.Write([]byte(`{"commerce":{"users":1048576}}`))
+				c.Assert(err, qt.IsNil)
+			}))
+			defer ts.Close()
+
+			client, err := NewClient(WithBaseURL(ts.URL))
+			c.Assert(err, qt.IsNil)
+			response, err := test.get(context.Background(), client.Metrics, &GetBranchMetricsRequest{
+				Organization: "my-org",
+				Database:     "my-db",
+				Branch:       "main",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(response, qt.DeepEquals, []byte(`{"commerce":{"users":1048576}}`))
+		})
+	}
+}
+
+func TestMetrics_GetTabletSeries(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tablets")
+		query := r.URL.Query()
+		c.Assert(query.Get("metrics"), qt.Equals, "replication_lag,pod_cpu_usage")
+		c.Assert(query.Get("from"), qt.Equals, "2026-08-18T16:00:00Z")
+		c.Assert(query.Get("to"), qt.Equals, "2026-08-18T17:00:00Z")
+		c.Assert(query.Get("keyspace"), qt.Equals, "commerce")
+		c.Assert(query.Get("shard"), qt.Equals, "-80")
+		c.Assert(query.Get("pod"), qt.Equals, "zone-a-0")
+		c.Assert(query.Get("workflow"), qt.Equals, "move-tables")
+		writeMetricSeriesResponse(c, w)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	_, err = client.Metrics.GetTabletSeries(context.Background(), &GetTabletMetricSeriesRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "main",
+		Metrics:      []string{"replication_lag", "pod_cpu_usage"},
+		From:         "2026-08-18T16:00:00Z",
+		To:           "2026-08-18T17:00:00Z",
+		Keyspace:     "commerce",
+		Shard:        "-80",
+		Pod:          "zone-a-0",
+		Workflow:     "move-tables",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func TestMetrics_GetInstantTablets(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tablets-instant")
+		query := r.URL.Query()
+		c.Assert(query.Get("metrics"), qt.Equals, "replication_lag,primary_cpu_usage")
+		c.Assert(query.Get("keyspace"), qt.Equals, "commerce")
+		c.Assert(query.Get("shard"), qt.Equals, "-80")
+		_, err := w.Write([]byte(`{
+			"type":"InstantMetrics",
+			"branch":{"name":"main"},
+			"metrics":[{"metric":"replication_lag","label":"Replication lag","values":[{"value":0.2}]}]
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	metrics, err := client.Metrics.GetInstantTablets(context.Background(), &GetInstantTabletMetricsRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "main",
+		Metrics:      []string{"replication_lag", "primary_cpu_usage"},
+		Keyspace:     "commerce",
+		Shard:        "-80",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(metrics.Metrics, qt.HasLen, 1)
+}
+
+func TestMetrics_GetTagSeries(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tag")
+		query := r.URL.Query()
+		c.Assert(query.Get("metrics"), qt.Equals, "queries,latency_p99")
+		c.Assert(query.Get("tag_sets"), qt.Equals, "service=checkout,region=us-east")
+		c.Assert(query.Get("period"), qt.Equals, "1d")
+		c.Assert(query.Get("tablet_type"), qt.Equals, "primary")
+		c.Assert(query.Get("budget_id"), qt.Equals, "budget-1")
+		c.Assert(query.Get("rule_id"), qt.Equals, "rule-1")
+		c.Assert(query.Get("q"), qt.Equals, "checkout")
+		writeMetricSeriesResponse(c, w)
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+	_, err = client.Metrics.GetTagSeries(context.Background(), &GetTagMetricSeriesRequest{
+		Organization: "my-org",
+		Database:     "my-db",
+		Branch:       "main",
+		Metrics:      []string{"queries", "latency_p99"},
+		TagSets:      []string{"service=checkout", "region=us-east"},
+		Period:       "1d",
+		TabletType:   "primary",
+		BudgetID:     "budget-1",
+		RuleID:       "rule-1",
+		Search:       "checkout",
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func writeMetricSeriesResponse(c *qt.C, w http.ResponseWriter) {
+	_, err := w.Write([]byte(`{
+		"type":"MetricSeries",
+		"start_date":"2026-08-18T16:00:00Z",
+		"end_date":"2026-08-18T17:00:00Z",
+		"interval":60,
+		"series":[{"type":"TimeSeries","metric":"queries","label":"Queries","labels":{},"points":[[1787068800,912]]}]
+	}`))
+	c.Assert(err, qt.IsNil)
+}

--- a/internal/planetscale/metrics_test.go
+++ b/internal/planetscale/metrics_test.go
@@ -262,7 +262,9 @@ func TestMetrics_GetTagSeries(t *testing.T) {
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tag")
 		query := r.URL.Query()
 		c.Assert(query["metrics[]"], qt.DeepEquals, []string{"queries", "latency_p99"})
-		c.Assert(query["tag_sets[]"], qt.DeepEquals, []string{"service=checkout", "region=us-east"})
+		c.Assert(query.Get("tag_sets[0][tags][Busername]"), qt.Equals, "alice")
+		c.Assert(query.Get("tag_sets[0][tags][Senv]"), qt.Equals, "production")
+		c.Assert(query.Get("tag_sets[1][tags][Busername]"), qt.Equals, "bob")
 		c.Assert(query.Get("period"), qt.Equals, "1d")
 		c.Assert(query.Get("tablet_type"), qt.Equals, "primary")
 		c.Assert(query.Get("budget_id"), qt.Equals, "budget-1")
@@ -279,12 +281,15 @@ func TestMetrics_GetTagSeries(t *testing.T) {
 		Database:     "my-db",
 		Branch:       "main",
 		Metrics:      []string{"queries", "latency_p99"},
-		TagSets:      []string{"service=checkout", "region=us-east"},
-		Period:       "1d",
-		TabletType:   "primary",
-		BudgetID:     "budget-1",
-		RuleID:       "rule-1",
-		Search:       "checkout",
+		TagSets: []map[string]string{
+			{"Busername": "alice", "Senv": "production"},
+			{"Busername": "bob"},
+		},
+		Period:     "1d",
+		TabletType: "primary",
+		BudgetID:   "budget-1",
+		RuleID:     "rule-1",
+		Search:     "checkout",
 	})
 	c.Assert(err, qt.IsNil)
 }

--- a/internal/planetscale/metrics_test.go
+++ b/internal/planetscale/metrics_test.go
@@ -109,8 +109,8 @@ func TestMetrics_GetQuerySeries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/query")
 		query := r.URL.Query()
-		c.Assert(query.Get("metrics"), qt.Equals, "queries,latency_p99")
-		c.Assert(query.Get("query_ids"), qt.Equals, "query-1,query-2")
+		c.Assert(query["metrics[]"], qt.DeepEquals, []string{"queries", "latency_p99"})
+		c.Assert(query["query_ids[]"], qt.DeepEquals, []string{"query-1", "query-2"})
 		c.Assert(query.Get("fingerprint"), qt.Equals, "select-from-users")
 		c.Assert(query.Get("keyspace"), qt.Equals, "commerce")
 		c.Assert(query.Get("period"), qt.Equals, "1h")
@@ -195,7 +195,7 @@ func TestMetrics_GetTabletSeries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tablets")
 		query := r.URL.Query()
-		c.Assert(query.Get("metrics"), qt.Equals, "replication_lag,pod_cpu_usage")
+		c.Assert(query["metrics[]"], qt.DeepEquals, []string{"replication_lag", "pod_cpu_usage"})
 		c.Assert(query.Get("from"), qt.Equals, "2026-08-18T16:00:00Z")
 		c.Assert(query.Get("to"), qt.Equals, "2026-08-18T17:00:00Z")
 		c.Assert(query.Get("keyspace"), qt.Equals, "commerce")
@@ -229,7 +229,7 @@ func TestMetrics_GetInstantTablets(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tablets-instant")
 		query := r.URL.Query()
-		c.Assert(query.Get("metrics"), qt.Equals, "replication_lag,primary_cpu_usage")
+		c.Assert(query["metrics[]"], qt.DeepEquals, []string{"replication_lag", "primary_cpu_usage"})
 		c.Assert(query.Get("keyspace"), qt.Equals, "commerce")
 		c.Assert(query.Get("shard"), qt.Equals, "-80")
 		_, err := w.Write([]byte(`{
@@ -261,8 +261,8 @@ func TestMetrics_GetTagSeries(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/databases/my-db/branches/main/metrics/tag")
 		query := r.URL.Query()
-		c.Assert(query.Get("metrics"), qt.Equals, "queries,latency_p99")
-		c.Assert(query.Get("tag_sets"), qt.Equals, "service=checkout,region=us-east")
+		c.Assert(query["metrics[]"], qt.DeepEquals, []string{"queries", "latency_p99"})
+		c.Assert(query["tag_sets[]"], qt.DeepEquals, []string{"service=checkout", "region=us-east"})
 		c.Assert(query.Get("period"), qt.Equals, "1d")
 		c.Assert(query.Get("tablet_type"), qt.Equals, "primary")
 		c.Assert(query.Get("budget_id"), qt.Equals, "budget-1")


### PR DESCRIPTION
## Summary
- add client methods for the published query, table, keyspace-table, tablet, instant-tablet, and tag metrics paths
- add `pscale metrics queries`, `tables`, `keyspace-tables`, `tablets`, `tablets instant`, and `tags`
- preserve specialized API responses and document the commands in `AGENTS.md`

## Test plan
- [x] `gofmt` on changed Go files
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`