### PR TITLE
Use read-only replica names for role connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -390,9 +390,9 @@ pscale branch extensions list <database> <branch> --org <org> --format json
 pscale role default <database> <branch> --org <org> --format json
 pscale role reset-default <database> <branch> --org <org> --format json --force
 
-# Role connection details for a branch replica, regional read-only replica, or PgBouncer
+# Role connection details for a branch replica, read-only replica, or PgBouncer
 pscale role get <database> <branch> <role-id> --org <org> --format json --replica
-pscale role get <database> <branch> <role-id> --org <org> --format json --read-only-replica <region-slug>
+pscale role get <database> <branch> <role-id> --org <org> --format json --read-only-replica <replica-name>
 pscale role get <database> <branch> <role-id> --org <org> --format json --bouncer <bouncer-name>
 
 # Change parameters (repeat --parameters; keys are namespace.name)

--- a/internal/cmd/role/get.go
+++ b/internal/cmd/role/get.go
@@ -55,7 +55,7 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 						printer.BoldBlue(ch.Config.Organization),
 					}
 					if flags.readOnlyReplica != "" {
-						notFoundFormat = "role %s or a read-only replica in region %s was not found in branch %s of database %s (organization: %s)"
+						notFoundFormat = "role %s or read-only replica %s was not found in branch %s of database %s (organization: %s)"
 						notFoundArgs = []any{
 							printer.BoldBlue(roleID),
 							printer.BoldBlue(flags.readOnlyReplica),
@@ -95,7 +95,7 @@ func GetCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "Return connection details for a branch replica.")
-	cmd.Flags().StringVar(&flags.readOnlyReplica, "read-only-replica", "", "Return connection details for a regional read-only replica (region slug).")
+	cmd.Flags().StringVar(&flags.readOnlyReplica, "read-only-replica", "", "Return connection details for a read-only replica (name).")
 	cmd.Flags().StringVar(&flags.bouncer, "bouncer", "", "Return connection details for a PgBouncer (name).")
 	cmd.MarkFlagsMutuallyExclusive("replica", "read-only-replica", "bouncer")
 

--- a/internal/cmd/role/get_test.go
+++ b/internal/cmd/role/get_test.go
@@ -88,13 +88,13 @@ func TestRole_GetCmdConnectionTargets(t *testing.T) {
 		},
 		{
 			name: "read-only replica",
-			args: []string{"mydb", "main", "role-id", "--read-only-replica", "us-west"},
+			args: []string{"mydb", "main", "role-id", "--read-only-replica", "analytics"},
 			request: ps.GetPostgresRoleRequest{
-				ReadOnlyReplica: "us-west",
+				ReadOnlyReplica: "analytics",
 			},
 			username:      "app.read-only|replica",
-			accessHostURL: "us-west.pg.psdb.cloud",
-			databaseURL:   "postgresql://app.read-only%7Creplica:@us-west.pg.psdb.cloud:5432/postgres?sslmode=verify-full",
+			accessHostURL: "analytics.pg.psdb.cloud",
+			databaseURL:   "postgresql://app.read-only%7Creplica:@analytics.pg.psdb.cloud:5432/postgres?sslmode=verify-full",
 		},
 		{
 			name: "bouncer",
@@ -188,9 +188,9 @@ func TestRole_GetCmdConnectionTargetNotFound(t *testing.T) {
 	}{
 		{
 			name:       "read-only replica",
-			args:       []string{"mydb", "main", "role-id", "--read-only-replica", "missing-region"},
-			targetType: "read-only replica in region",
-			target:     "missing-region",
+			args:       []string{"mydb", "main", "role-id", "--read-only-replica", "missing-replica"},
+			targetType: "read-only replica",
+			target:     "missing-replica",
 		},
 		{
 			name:       "bouncer",

--- a/internal/planetscale/postgres_roles_test.go
+++ b/internal/planetscale/postgres_roles_test.go
@@ -339,10 +339,10 @@ func TestPostgresRoles_GetConnectionTargets(t *testing.T) {
 		},
 		{
 			name:       "read-only replica",
-			request:    GetPostgresRoleRequest{ReadOnlyReplica: "us-west"},
-			query:      url.Values{"read_only_replica": []string{"us-west"}},
+			request:    GetPostgresRoleRequest{ReadOnlyReplica: "analytics"},
+			query:      url.Values{"read_only_replica": []string{"analytics"}},
 			username:   "test-user.replica-id|replica",
-			accessHost: "us-west.planetscale.com",
+			accessHost: "analytics.planetscale.com",
 		},
 		{
 			name:       "bouncer",


### PR DESCRIPTION
`pscale role get --read-only-replica` now accepts a read-only replica name instead of a region slug. The command help and errors use the same terminology so customers can target multiple read-only replicas in one region without ambiguity.