### PR TITLE
Add billing invoice list, show, and line-items commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -571,7 +571,7 @@ pscale billing invoice show <invoice-id> --org <org> --format json
 pscale billing invoice line-items <invoice-id> --org <org> --format json
 ```
 
-- `list` and `line-items` walk every page by default. Pass `--page` to fetch one page. `--per-page` defaults to 100. Invoice ids come from `list`.
+- `list` and `line-items` are paginated and return **one page per call**: `--page` (default 1) and `--per-page` (default 25). Invoices with thousands of line items are common, so walk pages deliberately. Human output prints the next page number; in JSON compare the row count to `--per-page` to decide whether to fetch again.
 - JSON preserves the API objects. Line items include the billed database and nested resource (usually a branch).
 - Requires `read_invoices` on a service token.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,6 +561,20 @@ pscale billing payment-method status <setup-id> --org <org> --format json
 | `NOT_FOUND` | No current card. Next step is `pscale billing payment-method update --org <org> --format json`. |
 | `UNPAID_INVOICES` | `delete` rejected because the organization has unpaid invoices. Pay them, then retry. |
 
+## Billing invoices
+
+Read-only invoice history for an organization. `--org` is required.
+
+```bash
+pscale billing invoice list --org <org> --format json
+pscale billing invoice show <invoice-id> --org <org> --format json
+pscale billing invoice line-items <invoice-id> --org <org> --format json
+```
+
+- `list` and `line-items` walk every page by default. Pass `--page` to fetch one page. `--per-page` defaults to 100. Invoice ids come from `list`.
+- JSON preserves the API objects. Line items include the billed database and nested resource (usually a branch).
+- Requires `read_invoices` on a service token.
+
 ## Imports (Cloudflare D1) — Postgres only
 
 `pscale import d1` migrates a Cloudflare D1 (SQLite) export into a PlanetScale Postgres branch. Every subcommand supports `--format json` and returns `status`, `issues`, and `next_steps`; stateful steps return a `migration_id` — pass it back with `--migration-id` to resume.

--- a/internal/cmd/billing/billing.go
+++ b/internal/cmd/billing/billing.go
@@ -17,6 +17,7 @@ func BillingCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 
 	cmd.AddCommand(PaymentMethodCmd(ch))
+	cmd.AddCommand(InvoiceCmd(ch))
 	return cmd
 }
 

--- a/internal/cmd/billing/invoice.go
+++ b/internal/cmd/billing/invoice.go
@@ -62,13 +62,13 @@ func toInvoice(inv *ps.Invoice) *invoice {
 }
 
 type invoiceLineItem struct {
-	ID               string  `header:"id" json:"id"`
-	Description      string  `header:"description" json:"description"`
-	MetricName       string  `header:"metric_name" json:"metric_name"`
-	Subtotal         float64 `header:"subtotal" json:"subtotal"`
-	DatabaseName     string  `header:"database" json:"database_name"`
-	ResourceName     string  `header:"resource" json:"resource_name"`
-	CloudflareBilled bool    `header:"cloudflare_billed" json:"cloudflare_billed"`
+	ID               string `header:"id" json:"id"`
+	Description      string `header:"description" json:"description"`
+	MetricName       string `header:"metric_name" json:"metric_name"`
+	Subtotal         string `header:"subtotal" json:"subtotal"`
+	DatabaseName     string `header:"database" json:"database_name"`
+	ResourceName     string `header:"resource" json:"resource_name"`
+	CloudflareBilled bool   `header:"cloudflare_billed" json:"cloudflare_billed"`
 
 	orig *ps.InvoiceLineItem
 }
@@ -94,7 +94,7 @@ func toInvoiceLineItem(item *ps.InvoiceLineItem) *invoiceLineItem {
 		ID:               item.ID,
 		Description:      item.Description,
 		MetricName:       item.MetricName,
-		Subtotal:         item.Subtotal,
+		Subtotal:         string(item.Subtotal),
 		DatabaseName:     item.DatabaseName,
 		ResourceName:     item.Resource.Name,
 		CloudflareBilled: item.CloudflareBilled,

--- a/internal/cmd/billing/invoice.go
+++ b/internal/cmd/billing/invoice.go
@@ -1,7 +1,6 @@
 package billing
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -123,7 +122,9 @@ func ListInvoicesCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching invoices for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			invoices, err := listAllInvoices(cmd.Context(), client.Invoices, org, flags.page, flags.perPage)
+			page, err := client.Invoices.List(cmd.Context(), &ps.ListInvoicesRequest{
+				Organization: org,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
@@ -134,21 +135,21 @@ func ListInvoicesCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			if len(invoices) == 0 && ch.Printer.Format() == printer.Human {
-				if flags.page > 0 {
-					ch.Printer.Println("No invoices found on this page.")
-				} else {
-					ch.Printer.Printf("No invoices in %s.\n", printer.BoldBlue(org))
-				}
+			if len(page.Data) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Println("No invoices found on this page.")
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toInvoices(invoices))
+			if err := ch.Printer.PrintResource(toInvoices(page.Data)); err != nil {
+				return err
+			}
+			printNextPageHint(ch, page.NextPage)
+			return nil
 		},
 	}
 
-	cmd.Flags().IntVar(&flags.page, "page", 0, "Fetch a single page instead of walking every page")
-	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	cmd.Flags().IntVar(&flags.page, "page", 1, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 25, "Number of results per page")
 	return cmd
 }
 
@@ -210,7 +211,10 @@ func InvoiceLineItemsCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching line items for invoice %s in %s...", printer.BoldBlue(id), printer.BoldBlue(org)))
 			defer end()
 
-			items, err := listAllInvoiceLineItems(cmd.Context(), client.Invoices, org, id, flags.page, flags.perPage)
+			page, err := client.Invoices.ListLineItems(cmd.Context(), &ps.ListInvoiceLineItemsRequest{
+				Organization: org,
+				Invoice:      id,
+			}, ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
 			if err != nil {
 				switch cmdutil.ErrCode(err) {
 				case ps.ErrNotFound:
@@ -221,66 +225,29 @@ func InvoiceLineItemsCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			if len(items) == 0 && ch.Printer.Format() == printer.Human {
-				if flags.page > 0 {
-					ch.Printer.Println("No line items found on this page.")
-				} else {
-					ch.Printer.Printf("No line items for invoice %s.\n", printer.BoldBlue(id))
-				}
+			if len(page.Data) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Println("No line items found on this page.")
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toInvoiceLineItems(items))
+			if err := ch.Printer.PrintResource(toInvoiceLineItems(page.Data)); err != nil {
+				return err
+			}
+			printNextPageHint(ch, page.NextPage)
+			return nil
 		},
 	}
 
-	cmd.Flags().IntVar(&flags.page, "page", 0, "Fetch a single page instead of walking every page")
-	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	cmd.Flags().IntVar(&flags.page, "page", 1, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 25, "Number of results per page")
 	return cmd
 }
 
-func listAllInvoices(ctx context.Context, svc ps.InvoicesService, org string, page, perPage int) ([]*ps.Invoice, error) {
-	req := &ps.ListInvoicesRequest{Organization: org}
-	if page > 0 {
-		result, err := svc.List(ctx, req, ps.WithPage(page), ps.WithPerPage(perPage))
-		if err != nil {
-			return nil, err
-		}
-		return result.Data, nil
+// printNextPageHint tells a human there is another page. JSON and CSV output
+// stay machine-readable, so callers there compare the row count to --per-page.
+func printNextPageHint(ch *cmdutil.Helper, nextPage *int) {
+	if nextPage == nil || ch.Printer.Format() != printer.Human {
+		return
 	}
-
-	var all []*ps.Invoice
-	for p := 1; ; p++ {
-		result, err := svc.List(ctx, req, ps.WithPage(p), ps.WithPerPage(perPage))
-		if err != nil {
-			return nil, err
-		}
-		all = append(all, result.Data...)
-		if result.NextPage == nil {
-			return all, nil
-		}
-	}
-}
-
-func listAllInvoiceLineItems(ctx context.Context, svc ps.InvoicesService, org, invoice string, page, perPage int) ([]*ps.InvoiceLineItem, error) {
-	req := &ps.ListInvoiceLineItemsRequest{Organization: org, Invoice: invoice}
-	if page > 0 {
-		result, err := svc.ListLineItems(ctx, req, ps.WithPage(page), ps.WithPerPage(perPage))
-		if err != nil {
-			return nil, err
-		}
-		return result.Data, nil
-	}
-
-	var all []*ps.InvoiceLineItem
-	for p := 1; ; p++ {
-		result, err := svc.ListLineItems(ctx, req, ps.WithPage(p), ps.WithPerPage(perPage))
-		if err != nil {
-			return nil, err
-		}
-		all = append(all, result.Data...)
-		if result.NextPage == nil {
-			return all, nil
-		}
-	}
+	ch.Printer.Printf("\nMore results available. Fetch the next page with --page %d.\n", *nextPage)
 }

--- a/internal/cmd/billing/invoice.go
+++ b/internal/cmd/billing/invoice.go
@@ -1,0 +1,286 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func InvoiceCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invoice <command>",
+		Short: "List and show organization invoices",
+	}
+	cmd.AddCommand(ListInvoicesCmd(ch))
+	cmd.AddCommand(ShowInvoiceCmd(ch))
+	cmd.AddCommand(InvoiceLineItemsCmd(ch))
+	return cmd
+}
+
+type invoice struct {
+	ID                 string `header:"id" json:"id"`
+	Total              string `header:"total" json:"total"`
+	BillingPeriodStart string `header:"billing_period_start" json:"billing_period_start"`
+	BillingPeriodEnd   string `header:"billing_period_end" json:"billing_period_end"`
+	Paid               bool   `header:"paid" json:"paid"`
+	Overdue            bool   `header:"overdue" json:"overdue"`
+
+	orig *ps.Invoice
+}
+
+func (i *invoice) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(i.orig, "", "  ")
+}
+
+func (i *invoice) MarshalCSVValue() interface{} {
+	return []*invoice{i}
+}
+
+func toInvoices(invoices []*ps.Invoice) []*invoice {
+	out := make([]*invoice, 0, len(invoices))
+	for _, inv := range invoices {
+		out = append(out, toInvoice(inv))
+	}
+	return out
+}
+
+func toInvoice(inv *ps.Invoice) *invoice {
+	return &invoice{
+		ID:                 inv.ID,
+		Total:              inv.Total,
+		BillingPeriodStart: inv.BillingPeriodStart,
+		BillingPeriodEnd:   inv.BillingPeriodEnd,
+		Paid:               inv.Paid,
+		Overdue:            inv.Overdue,
+		orig:               inv,
+	}
+}
+
+type invoiceLineItem struct {
+	ID               string  `header:"id" json:"id"`
+	Description      string  `header:"description" json:"description"`
+	MetricName       string  `header:"metric_name" json:"metric_name"`
+	Subtotal         float64 `header:"subtotal" json:"subtotal"`
+	DatabaseName     string  `header:"database" json:"database_name"`
+	ResourceName     string  `header:"resource" json:"resource_name"`
+	CloudflareBilled bool    `header:"cloudflare_billed" json:"cloudflare_billed"`
+
+	orig *ps.InvoiceLineItem
+}
+
+func (i *invoiceLineItem) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(i.orig, "", "  ")
+}
+
+func (i *invoiceLineItem) MarshalCSVValue() interface{} {
+	return []*invoiceLineItem{i}
+}
+
+func toInvoiceLineItems(items []*ps.InvoiceLineItem) []*invoiceLineItem {
+	out := make([]*invoiceLineItem, 0, len(items))
+	for _, item := range items {
+		out = append(out, toInvoiceLineItem(item))
+	}
+	return out
+}
+
+func toInvoiceLineItem(item *ps.InvoiceLineItem) *invoiceLineItem {
+	return &invoiceLineItem{
+		ID:               item.ID,
+		Description:      item.Description,
+		MetricName:       item.MetricName,
+		Subtotal:         item.Subtotal,
+		DatabaseName:     item.DatabaseName,
+		ResourceName:     item.Resource.Name,
+		CloudflareBilled: item.CloudflareBilled,
+		orig:             item,
+	}
+}
+
+func ListInvoicesCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List invoices for an organization",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := ch.Config.Organization
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching invoices for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			invoices, err := listAllInvoices(cmd.Context(), client.Invoices, org, flags.page, flags.perPage)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("organization %s does not exist", printer.BoldBlue(org))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(invoices) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page > 0 {
+					ch.Printer.Println("No invoices found on this page.")
+				} else {
+					ch.Printer.Printf("No invoices in %s.\n", printer.BoldBlue(org))
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toInvoices(invoices))
+		},
+	}
+
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Fetch a single page instead of walking every page")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+func ShowInvoiceCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <invoice-id>",
+		Short: "Show an invoice",
+		Args:  cmdutil.RequiredArgs("invoice-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := ch.Config.Organization
+			id := args[0]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching invoice %s in %s...", printer.BoldBlue(id), printer.BoldBlue(org)))
+			defer end()
+
+			invoice, err := client.Invoices.Get(cmd.Context(), &ps.GetInvoiceRequest{
+				Organization: org,
+				Invoice:      id,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("invoice %s does not exist in organization %s", printer.BoldBlue(id), printer.BoldBlue(org))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			return ch.Printer.PrintResource(toInvoice(invoice))
+		},
+	}
+
+	return cmd
+}
+
+func InvoiceLineItemsCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		page    int
+		perPage int
+	}
+
+	cmd := &cobra.Command{
+		Use:   "line-items <invoice-id>",
+		Short: "List line items for an invoice",
+		Args:  cmdutil.RequiredArgs("invoice-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			org := ch.Config.Organization
+			id := args[0]
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching line items for invoice %s in %s...", printer.BoldBlue(id), printer.BoldBlue(org)))
+			defer end()
+
+			items, err := listAllInvoiceLineItems(cmd.Context(), client.Invoices, org, id, flags.page, flags.perPage)
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("invoice %s does not exist in organization %s", printer.BoldBlue(id), printer.BoldBlue(org))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if len(items) == 0 && ch.Printer.Format() == printer.Human {
+				if flags.page > 0 {
+					ch.Printer.Println("No line items found on this page.")
+				} else {
+					ch.Printer.Printf("No line items for invoice %s.\n", printer.BoldBlue(id))
+				}
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toInvoiceLineItems(items))
+		},
+	}
+
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Fetch a single page instead of walking every page")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 100, "Number of results per page")
+	return cmd
+}
+
+func listAllInvoices(ctx context.Context, svc ps.InvoicesService, org string, page, perPage int) ([]*ps.Invoice, error) {
+	req := &ps.ListInvoicesRequest{Organization: org}
+	if page > 0 {
+		result, err := svc.List(ctx, req, ps.WithPage(page), ps.WithPerPage(perPage))
+		if err != nil {
+			return nil, err
+		}
+		return result.Data, nil
+	}
+
+	var all []*ps.Invoice
+	for p := 1; ; p++ {
+		result, err := svc.List(ctx, req, ps.WithPage(p), ps.WithPerPage(perPage))
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, result.Data...)
+		if result.NextPage == nil {
+			return all, nil
+		}
+	}
+}
+
+func listAllInvoiceLineItems(ctx context.Context, svc ps.InvoicesService, org, invoice string, page, perPage int) ([]*ps.InvoiceLineItem, error) {
+	req := &ps.ListInvoiceLineItemsRequest{Organization: org, Invoice: invoice}
+	if page > 0 {
+		result, err := svc.ListLineItems(ctx, req, ps.WithPage(page), ps.WithPerPage(perPage))
+		if err != nil {
+			return nil, err
+		}
+		return result.Data, nil
+	}
+
+	var all []*ps.InvoiceLineItem
+	for p := 1; ; p++ {
+		result, err := svc.ListLineItems(ctx, req, ps.WithPage(p), ps.WithPerPage(perPage))
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, result.Data...)
+		if result.NextPage == nil {
+			return all, nil
+		}
+	}
+}

--- a/internal/cmd/billing/invoice_test.go
+++ b/internal/cmd/billing/invoice_test.go
@@ -38,37 +38,33 @@ func testInvoiceLineItem() *ps.InvoiceLineItem {
 	}
 }
 
-func TestInvoiceListCmd_WalksPages(t *testing.T) {
+func TestInvoiceListCmd_FetchesOnePage(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
-	pages := []string{}
+	calls := 0
 	next2 := 2
 	svc := &mock.InvoicesService{
 		ListFn: func(ctx context.Context, req *ps.ListInvoicesRequest, opts ...ps.ListOption) (*ps.InvoicePage, error) {
+			calls++
 			c.Assert(req.Organization, qt.Equals, "my-org")
 			page, perPage := listOpts(c, opts)
-			pages = append(pages, page)
-			c.Assert(perPage, qt.Equals, "100")
-			if page == "1" {
-				return &ps.InvoicePage{
-					Data:     []*ps.Invoice{{ID: "inv_1", Total: "1.00"}},
-					NextPage: &next2,
-				}, nil
-			}
-			c.Assert(page, qt.Equals, "2")
-			return &ps.InvoicePage{Data: []*ps.Invoice{testInvoice()}}, nil
+			c.Assert(page, qt.Equals, "1")
+			c.Assert(perPage, qt.Equals, "25")
+			return &ps.InvoicePage{
+				Data:     []*ps.Invoice{testInvoice()},
+				NextPage: &next2,
+			}, nil
 		},
 	}
 
 	cmd := ListInvoicesCmd(invoiceTestHelper(&buf, printer.JSON, svc))
 	c.Assert(cmd.Execute(), qt.IsNil)
-	c.Assert(pages, qt.DeepEquals, []string{"1", "2"})
-	c.Assert(buf.String(), qt.Contains, "inv_1")
+	c.Assert(calls, qt.Equals, 1)
 	c.Assert(buf.String(), qt.Contains, "inv_123")
 }
 
-func TestInvoiceListCmd_SinglePage(t *testing.T) {
+func TestInvoiceListCmd_HonorsPageFlags(t *testing.T) {
 	c := qt.New(t)
 
 	calls := 0
@@ -107,38 +103,36 @@ func TestInvoiceShowCmd(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, "inv_123")
 }
 
-func TestInvoiceLineItemsCmd_WalksPages(t *testing.T) {
+func TestInvoiceLineItemsCmd_FetchesOnePage(t *testing.T) {
 	c := qt.New(t)
 
 	var buf bytes.Buffer
-	pages := []string{}
+	calls := 0
 	next2 := 2
 	svc := &mock.InvoicesService{
 		ListLineItemsFn: func(ctx context.Context, req *ps.ListInvoiceLineItemsRequest, opts ...ps.ListOption) (*ps.InvoiceLineItemPage, error) {
+			calls++
 			c.Assert(req.Organization, qt.Equals, "my-org")
 			c.Assert(req.Invoice, qt.Equals, "inv_123")
 			page, perPage := listOpts(c, opts)
-			pages = append(pages, page)
-			c.Assert(perPage, qt.Equals, "100")
-			if page == "1" {
-				return &ps.InvoiceLineItemPage{
-					Data:     []*ps.InvoiceLineItem{{ID: "li_0", DatabaseName: "other"}},
-					NextPage: &next2,
-				}, nil
-			}
-			return &ps.InvoiceLineItemPage{Data: []*ps.InvoiceLineItem{testInvoiceLineItem()}}, nil
+			c.Assert(page, qt.Equals, "1")
+			c.Assert(perPage, qt.Equals, "25")
+			return &ps.InvoiceLineItemPage{
+				Data:     []*ps.InvoiceLineItem{testInvoiceLineItem()},
+				NextPage: &next2,
+			}, nil
 		},
 	}
 
 	cmd := InvoiceLineItemsCmd(invoiceTestHelper(&buf, printer.JSON, svc))
 	cmd.SetArgs([]string{"inv_123"})
 	c.Assert(cmd.Execute(), qt.IsNil)
-	c.Assert(pages, qt.DeepEquals, []string{"1", "2"})
-	c.Assert(buf.String(), qt.Contains, "li_0")
+	c.Assert(calls, qt.Equals, 1)
 	c.Assert(buf.String(), qt.Contains, "li_1")
+	c.Assert(buf.String(), qt.Contains, "mydb")
 }
 
-func TestInvoiceLineItemsCmd_SinglePage(t *testing.T) {
+func TestInvoiceLineItemsCmd_HonorsPageFlags(t *testing.T) {
 	c := qt.New(t)
 
 	calls := 0
@@ -147,15 +141,37 @@ func TestInvoiceLineItemsCmd_SinglePage(t *testing.T) {
 			calls++
 			page, perPage := listOpts(c, opts)
 			c.Assert(page, qt.Equals, "3")
-			c.Assert(perPage, qt.Equals, "25")
+			c.Assert(perPage, qt.Equals, "100")
 			return &ps.InvoiceLineItemPage{Data: []*ps.InvoiceLineItem{testInvoiceLineItem()}}, nil
 		},
 	}
 
 	cmd := InvoiceLineItemsCmd(invoiceTestHelper(&bytes.Buffer{}, printer.JSON, svc))
-	cmd.SetArgs([]string{"inv_123", "--page", "3", "--per-page", "25"})
+	cmd.SetArgs([]string{"inv_123", "--page", "3", "--per-page", "100"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(calls, qt.Equals, 1)
+}
+
+func TestInvoiceLineItemsCmd_HumanPrintsNextPage(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	next7 := 7
+	svc := &mock.InvoicesService{
+		ListLineItemsFn: func(ctx context.Context, req *ps.ListInvoiceLineItemsRequest, opts ...ps.ListOption) (*ps.InvoiceLineItemPage, error) {
+			return &ps.InvoiceLineItemPage{
+				Data:     []*ps.InvoiceLineItem{testInvoiceLineItem()},
+				NextPage: &next7,
+			}, nil
+		},
+	}
+
+	ch := invoiceTestHelper(&buf, printer.Human, svc)
+	ch.Printer.SetHumanOutput(&buf)
+	cmd := InvoiceLineItemsCmd(ch)
+	cmd.SetArgs([]string{"inv_123"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "--page 7")
 }
 
 func listOpts(c *qt.C, opts []ps.ListOption) (page, perPage string) {

--- a/internal/cmd/billing/invoice_test.go
+++ b/internal/cmd/billing/invoice_test.go
@@ -28,7 +28,7 @@ func testInvoice() *ps.Invoice {
 func testInvoiceLineItem() *ps.InvoiceLineItem {
 	return &ps.InvoiceLineItem{
 		ID:               "li_1",
-		Subtotal:         12.34,
+		Subtotal:         "12.34",
 		Description:      "PS_10",
 		MetricName:       "ps_10",
 		CloudflareBilled: false,

--- a/internal/cmd/billing/invoice_test.go
+++ b/internal/cmd/billing/invoice_test.go
@@ -1,0 +1,179 @@
+package billing
+
+import (
+	"bytes"
+	"context"
+	"net/url"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func testInvoice() *ps.Invoice {
+	return &ps.Invoice{
+		ID:                 "inv_123",
+		Total:              "12.34",
+		BillingPeriodStart: "2026-07-01",
+		BillingPeriodEnd:   "2026-07-31",
+		Paid:               true,
+		Overdue:            false,
+	}
+}
+
+func testInvoiceLineItem() *ps.InvoiceLineItem {
+	return &ps.InvoiceLineItem{
+		ID:               "li_1",
+		Subtotal:         12.34,
+		Description:      "PS_10",
+		MetricName:       "ps_10",
+		CloudflareBilled: false,
+		DatabaseID:       "db_1",
+		DatabaseName:     "mydb",
+		Resource:         ps.InvoiceLineItemResource{ID: "branch_1", Name: "main"},
+	}
+}
+
+func TestInvoiceListCmd_WalksPages(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	pages := []string{}
+	next2 := 2
+	svc := &mock.InvoicesService{
+		ListFn: func(ctx context.Context, req *ps.ListInvoicesRequest, opts ...ps.ListOption) (*ps.InvoicePage, error) {
+			c.Assert(req.Organization, qt.Equals, "my-org")
+			page, perPage := listOpts(c, opts)
+			pages = append(pages, page)
+			c.Assert(perPage, qt.Equals, "100")
+			if page == "1" {
+				return &ps.InvoicePage{
+					Data:     []*ps.Invoice{{ID: "inv_1", Total: "1.00"}},
+					NextPage: &next2,
+				}, nil
+			}
+			c.Assert(page, qt.Equals, "2")
+			return &ps.InvoicePage{Data: []*ps.Invoice{testInvoice()}}, nil
+		},
+	}
+
+	cmd := ListInvoicesCmd(invoiceTestHelper(&buf, printer.JSON, svc))
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(pages, qt.DeepEquals, []string{"1", "2"})
+	c.Assert(buf.String(), qt.Contains, "inv_1")
+	c.Assert(buf.String(), qt.Contains, "inv_123")
+}
+
+func TestInvoiceListCmd_SinglePage(t *testing.T) {
+	c := qt.New(t)
+
+	calls := 0
+	svc := &mock.InvoicesService{
+		ListFn: func(ctx context.Context, req *ps.ListInvoicesRequest, opts ...ps.ListOption) (*ps.InvoicePage, error) {
+			calls++
+			page, perPage := listOpts(c, opts)
+			c.Assert(page, qt.Equals, "2")
+			c.Assert(perPage, qt.Equals, "10")
+			return &ps.InvoicePage{Data: []*ps.Invoice{testInvoice()}}, nil
+		},
+	}
+
+	cmd := ListInvoicesCmd(invoiceTestHelper(&bytes.Buffer{}, printer.JSON, svc))
+	cmd.SetArgs([]string{"--page", "2", "--per-page", "10"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(calls, qt.Equals, 1)
+}
+
+func TestInvoiceShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	svc := &mock.InvoicesService{
+		GetFn: func(ctx context.Context, req *ps.GetInvoiceRequest) (*ps.Invoice, error) {
+			c.Assert(req.Organization, qt.Equals, "my-org")
+			c.Assert(req.Invoice, qt.Equals, "inv_123")
+			return testInvoice(), nil
+		},
+	}
+
+	cmd := ShowInvoiceCmd(invoiceTestHelper(&buf, printer.JSON, svc))
+	cmd.SetArgs([]string{"inv_123"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, "inv_123")
+}
+
+func TestInvoiceLineItemsCmd_WalksPages(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	pages := []string{}
+	next2 := 2
+	svc := &mock.InvoicesService{
+		ListLineItemsFn: func(ctx context.Context, req *ps.ListInvoiceLineItemsRequest, opts ...ps.ListOption) (*ps.InvoiceLineItemPage, error) {
+			c.Assert(req.Organization, qt.Equals, "my-org")
+			c.Assert(req.Invoice, qt.Equals, "inv_123")
+			page, perPage := listOpts(c, opts)
+			pages = append(pages, page)
+			c.Assert(perPage, qt.Equals, "100")
+			if page == "1" {
+				return &ps.InvoiceLineItemPage{
+					Data:     []*ps.InvoiceLineItem{{ID: "li_0", DatabaseName: "other"}},
+					NextPage: &next2,
+				}, nil
+			}
+			return &ps.InvoiceLineItemPage{Data: []*ps.InvoiceLineItem{testInvoiceLineItem()}}, nil
+		},
+	}
+
+	cmd := InvoiceLineItemsCmd(invoiceTestHelper(&buf, printer.JSON, svc))
+	cmd.SetArgs([]string{"inv_123"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(pages, qt.DeepEquals, []string{"1", "2"})
+	c.Assert(buf.String(), qt.Contains, "li_0")
+	c.Assert(buf.String(), qt.Contains, "li_1")
+}
+
+func TestInvoiceLineItemsCmd_SinglePage(t *testing.T) {
+	c := qt.New(t)
+
+	calls := 0
+	svc := &mock.InvoicesService{
+		ListLineItemsFn: func(ctx context.Context, req *ps.ListInvoiceLineItemsRequest, opts ...ps.ListOption) (*ps.InvoiceLineItemPage, error) {
+			calls++
+			page, perPage := listOpts(c, opts)
+			c.Assert(page, qt.Equals, "3")
+			c.Assert(perPage, qt.Equals, "25")
+			return &ps.InvoiceLineItemPage{Data: []*ps.InvoiceLineItem{testInvoiceLineItem()}}, nil
+		},
+	}
+
+	cmd := InvoiceLineItemsCmd(invoiceTestHelper(&bytes.Buffer{}, printer.JSON, svc))
+	cmd.SetArgs([]string{"inv_123", "--page", "3", "--per-page", "25"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(calls, qt.Equals, 1)
+}
+
+func listOpts(c *qt.C, opts []ps.ListOption) (page, perPage string) {
+	listOpts := &ps.ListOptions{URLValues: &url.Values{}}
+	for _, opt := range opts {
+		c.Assert(opt(listOpts), qt.IsNil)
+	}
+	return listOpts.URLValues.Get("page"), listOpts.URLValues.Get("per_page")
+}
+
+func invoiceTestHelper(buf *bytes.Buffer, format printer.Format, svc *mock.InvoicesService) *cmdutil.Helper {
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(buf)
+	return &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "my-org"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Invoices: svc}, nil
+		},
+	}
+}

--- a/internal/mock/invoices.go
+++ b/internal/mock/invoices.go
@@ -1,0 +1,31 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+type InvoicesService struct {
+	ListFn                 func(context.Context, *ps.ListInvoicesRequest, ...ps.ListOption) (*ps.InvoicePage, error)
+	ListFnInvoked          bool
+	GetFn                  func(context.Context, *ps.GetInvoiceRequest) (*ps.Invoice, error)
+	GetFnInvoked           bool
+	ListLineItemsFn        func(context.Context, *ps.ListInvoiceLineItemsRequest, ...ps.ListOption) (*ps.InvoiceLineItemPage, error)
+	ListLineItemsFnInvoked bool
+}
+
+func (s *InvoicesService) List(ctx context.Context, req *ps.ListInvoicesRequest, opts ...ps.ListOption) (*ps.InvoicePage, error) {
+	s.ListFnInvoked = true
+	return s.ListFn(ctx, req, opts...)
+}
+
+func (s *InvoicesService) Get(ctx context.Context, req *ps.GetInvoiceRequest) (*ps.Invoice, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
+}
+
+func (s *InvoicesService) ListLineItems(ctx context.Context, req *ps.ListInvoiceLineItemsRequest, opts ...ps.ListOption) (*ps.InvoiceLineItemPage, error) {
+	s.ListLineItemsFnInvoked = true
+	return s.ListLineItemsFn(ctx, req, opts...)
+}

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -53,9 +53,6 @@ type Client struct {
 	AuthAttemptExports    AuthAttemptExportsService
 	BackupPolicies        BackupPoliciesService
 	Backups               BackupsService
-	PaymentMethods        BillingPaymentMethodsService
-	PaymentMethodSetups   BillingPaymentMethodSetupsService
-	Invoices              InvoicesService
 	BranchInfrastructure  BranchInfrastructureService
 	BranchMaintenance     BranchMaintenanceService
 	D1ImportNotifications D1ImportNotificationsService
@@ -63,6 +60,7 @@ type Client struct {
 	Databases             DatabasesService
 	DataImports           DataImportsService
 	DeployRequests        DeployRequestsService
+	Invoices              InvoicesService
 	Keyspaces             KeyspacesService
 	LookupVindex          LookupVindexService
 	MaintenanceSchedules  MaintenanceSchedulesService
@@ -71,6 +69,8 @@ type Client struct {
 	MoveTables            MoveTablesService
 	Organizations         OrganizationsService
 	Passwords             PasswordsService
+	PaymentMethods        BillingPaymentMethodsService
+	PaymentMethodSetups   BillingPaymentMethodSetupsService
 	PlannedReparentShard  PlannedReparentShardService
 	PostgresBranches      PostgresBranchesService
 	PostgresBouncers      PostgresBouncersService
@@ -333,9 +333,6 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.AuthAttemptExports = &authAttemptExportsService{client: c}
 	c.BackupPolicies = &backupPoliciesService{client: c}
 	c.Backups = &backupsService{client: c}
-	c.PaymentMethods = &billingPaymentMethodsService{client: c}
-	c.PaymentMethodSetups = &billingPaymentMethodSetupsService{client: c}
-	c.Invoices = &invoicesService{client: c}
 	c.BranchInfrastructure = &branchInfrastructureService{client: c}
 	c.BranchMaintenance = &branchMaintenanceService{client: c}
 	c.D1ImportNotifications = &d1ImportNotificationsService{client: c}
@@ -343,6 +340,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.Databases = &databasesService{client: c}
 	c.DataImports = &dataImportsService{client: c}
 	c.DeployRequests = &deployRequestsService{client: c}
+	c.Invoices = &invoicesService{client: c}
 	c.Keyspaces = &keyspacesService{client: c}
 	c.LookupVindex = &lookupVindexService{client: c}
 	c.MaintenanceSchedules = &maintenanceSchedulesService{client: c}
@@ -351,13 +349,15 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.MoveTables = &moveTablesService{client: c}
 	c.Organizations = &organizationsService{client: c}
 	c.Passwords = &passwordsService{client: c}
+	c.PaymentMethods = &billingPaymentMethodsService{client: c}
+	c.PaymentMethodSetups = &billingPaymentMethodSetupsService{client: c}
 	c.PlannedReparentShard = &plannedReparentShardService{client: c}
-	c.Processlist = &processlistService{client: c}
 	c.PostgresBranches = &postgresBranchesService{client: c}
 	c.PostgresBouncers = &postgresBouncersService{client: c}
 	c.PostgresCIDRs = &postgresCIDRsService{client: c}
 	c.PostgresRoles = &postgresRolesService{client: c}
 	c.PostgresSwitchovers = &postgresSwitchoversService{client: c}
+	c.Processlist = &processlistService{client: c}
 	c.QueryInsights = &queryInsightsService{client: c}
 	c.QueryPatterns = &queryPatternsService{client: c}
 	c.ReadOnlyRegions = &readOnlyRegionsService{client: c}

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -55,6 +55,7 @@ type Client struct {
 	Backups               BackupsService
 	PaymentMethods        BillingPaymentMethodsService
 	PaymentMethodSetups   BillingPaymentMethodSetupsService
+	Invoices              InvoicesService
 	BranchInfrastructure  BranchInfrastructureService
 	BranchMaintenance     BranchMaintenanceService
 	D1ImportNotifications D1ImportNotificationsService
@@ -334,6 +335,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.Backups = &backupsService{client: c}
 	c.PaymentMethods = &billingPaymentMethodsService{client: c}
 	c.PaymentMethodSetups = &billingPaymentMethodSetupsService{client: c}
+	c.Invoices = &invoicesService{client: c}
 	c.BranchInfrastructure = &branchInfrastructureService{client: c}
 	c.BranchMaintenance = &branchMaintenanceService{client: c}
 	c.D1ImportNotifications = &d1ImportNotificationsService{client: c}

--- a/internal/planetscale/invoices.go
+++ b/internal/planetscale/invoices.go
@@ -1,0 +1,135 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+)
+
+type Invoice struct {
+	ID                 string `json:"id"`
+	Total              string `json:"total"`
+	BillingPeriodStart string `json:"billing_period_start"`
+	BillingPeriodEnd   string `json:"billing_period_end"`
+	Paid               bool   `json:"paid"`
+	Overdue            bool   `json:"overdue"`
+}
+
+type InvoiceLineItemResource struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	CreatedAt string  `json:"created_at"`
+	UpdatedAt string  `json:"updated_at"`
+	DeletedAt *string `json:"deleted_at"`
+}
+
+type InvoiceLineItem struct {
+	ID               string                  `json:"id"`
+	Subtotal         float64                 `json:"subtotal"`
+	Description      string                  `json:"description"`
+	MetricName       string                  `json:"metric_name"`
+	CloudflareBilled bool                    `json:"cloudflare_billed"`
+	DatabaseID       string                  `json:"database_id"`
+	DatabaseName     string                  `json:"database_name"`
+	Resource         InvoiceLineItemResource `json:"resource"`
+}
+
+type invoicesResponse struct {
+	Data     []*Invoice `json:"data"`
+	NextPage *int       `json:"next_page"`
+}
+
+type invoiceLineItemsResponse struct {
+	Data     []*InvoiceLineItem `json:"data"`
+	NextPage *int               `json:"next_page"`
+}
+
+type InvoicePage struct {
+	Data     []*Invoice
+	NextPage *int
+}
+
+type InvoiceLineItemPage struct {
+	Data     []*InvoiceLineItem
+	NextPage *int
+}
+
+type ListInvoicesRequest struct {
+	Organization string
+}
+
+type GetInvoiceRequest struct {
+	Organization string
+	Invoice      string
+}
+
+type ListInvoiceLineItemsRequest struct {
+	Organization string
+	Invoice      string
+}
+
+type InvoicesService interface {
+	List(context.Context, *ListInvoicesRequest, ...ListOption) (*InvoicePage, error)
+	Get(context.Context, *GetInvoiceRequest) (*Invoice, error)
+	ListLineItems(context.Context, *ListInvoiceLineItemsRequest, ...ListOption) (*InvoiceLineItemPage, error)
+}
+
+type invoicesService struct {
+	client *Client
+}
+
+var _ InvoicesService = &invoicesService{}
+
+func invoicesAPIPath(org string) string {
+	return path.Join("v1/organizations", org, "invoices")
+}
+
+func invoiceAPIPath(org, invoice string) string {
+	return path.Join(invoicesAPIPath(org), invoice)
+}
+
+func invoiceLineItemsAPIPath(org, invoice string) string {
+	return path.Join(invoiceAPIPath(org, invoice), "line-items")
+}
+
+func (s *invoicesService) List(ctx context.Context, listReq *ListInvoicesRequest, opts ...ListOption) (*InvoicePage, error) {
+	listOpts := defaultListOptions(opts...)
+	req, err := s.client.newRequest(http.MethodGet, invoicesAPIPath(listReq.Organization), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list invoices: %w", err)
+	}
+
+	resp := &invoicesResponse{}
+	if err := s.client.do(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return &InvoicePage{Data: resp.Data, NextPage: resp.NextPage}, nil
+}
+
+func (s *invoicesService) Get(ctx context.Context, getReq *GetInvoiceRequest) (*Invoice, error) {
+	req, err := s.client.newRequest(http.MethodGet, invoiceAPIPath(getReq.Organization, getReq.Invoice), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get invoice: %w", err)
+	}
+
+	invoice := &Invoice{}
+	if err := s.client.do(ctx, req, invoice); err != nil {
+		return nil, err
+	}
+	return invoice, nil
+}
+
+func (s *invoicesService) ListLineItems(ctx context.Context, listReq *ListInvoiceLineItemsRequest, opts ...ListOption) (*InvoiceLineItemPage, error) {
+	listOpts := defaultListOptions(opts...)
+	req, err := s.client.newRequest(http.MethodGet, invoiceLineItemsAPIPath(listReq.Organization, listReq.Invoice), nil, WithQueryParams(*listOpts.URLValues))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list invoice line items: %w", err)
+	}
+
+	resp := &invoiceLineItemsResponse{}
+	if err := s.client.do(ctx, req, resp); err != nil {
+		return nil, err
+	}
+	return &InvoiceLineItemPage{Data: resp.Data, NextPage: resp.NextPage}, nil
+}

--- a/internal/planetscale/invoices.go
+++ b/internal/planetscale/invoices.go
@@ -2,10 +2,33 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path"
 )
+
+type InvoiceAmount string
+
+func (a *InvoiceAmount) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		*a = ""
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*a = InvoiceAmount(s)
+		return nil
+	}
+
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*a = InvoiceAmount(n.String())
+	return nil
+}
 
 type Invoice struct {
 	ID                 string `json:"id"`
@@ -26,7 +49,7 @@ type InvoiceLineItemResource struct {
 
 type InvoiceLineItem struct {
 	ID               string                  `json:"id"`
-	Subtotal         float64                 `json:"subtotal"`
+	Subtotal         InvoiceAmount           `json:"subtotal"`
 	Description      string                  `json:"description"`
 	MetricName       string                  `json:"metric_name"`
 	CloudflareBilled bool                    `json:"cloudflare_billed"`

--- a/internal/planetscale/invoices_test.go
+++ b/internal/planetscale/invoices_test.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,7 +50,7 @@ func TestInvoices_ListGetAndLineItems(t *testing.T) {
 				"next_page": 4,
 				"data": [{
 					"id": "li_1",
-					"subtotal": 12.34,
+					"subtotal": "12.34",
 					"description": "PS_10",
 					"metric_name": "ps_10",
 					"cloudflare_billed": false,
@@ -98,8 +99,20 @@ func TestInvoices_ListGetAndLineItems(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(items.Data, qt.HasLen, 1)
 	c.Assert(items.Data[0].ID, qt.Equals, "li_1")
-	c.Assert(items.Data[0].Subtotal, qt.Equals, 12.34)
+	c.Assert(items.Data[0].Subtotal, qt.Equals, InvoiceAmount("12.34"))
 	c.Assert(items.Data[0].DatabaseName, qt.Equals, "mydb")
 	c.Assert(items.Data[0].Resource.Name, qt.Equals, "main")
 	c.Assert(*items.NextPage, qt.Equals, 4)
+}
+
+func TestInvoiceAmount_UnmarshalJSON(t *testing.T) {
+	c := qt.New(t)
+
+	var fromString InvoiceAmount
+	c.Assert(json.Unmarshal([]byte(`"12.34"`), &fromString), qt.IsNil)
+	c.Assert(fromString, qt.Equals, InvoiceAmount("12.34"))
+
+	var fromNumber InvoiceAmount
+	c.Assert(json.Unmarshal([]byte(`12.34`), &fromNumber), qt.IsNil)
+	c.Assert(fromNumber, qt.Equals, InvoiceAmount("12.34"))
 }

--- a/internal/planetscale/invoices_test.go
+++ b/internal/planetscale/invoices_test.go
@@ -1,0 +1,105 @@
+package planetscale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestInvoices_ListGetAndLineItems(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		switch r.URL.Path {
+		case "/v1/organizations/my-org/invoices":
+			c.Assert(r.URL.Query().Get("page"), qt.Equals, "2")
+			c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "10")
+			_, err := w.Write([]byte(`{
+				"type": "list",
+				"next_page": null,
+				"data": [{
+					"id": "inv_123",
+					"total": "12.34",
+					"billing_period_start": "2026-07-01",
+					"billing_period_end": "2026-07-31",
+					"paid": true,
+					"overdue": false
+				}]
+			}`))
+			c.Assert(err, qt.IsNil)
+		case "/v1/organizations/my-org/invoices/inv_123":
+			_, err := w.Write([]byte(`{
+				"id": "inv_123",
+				"total": "12.34",
+				"billing_period_start": "2026-07-01",
+				"billing_period_end": "2026-07-31",
+				"paid": true,
+				"overdue": false
+			}`))
+			c.Assert(err, qt.IsNil)
+		case "/v1/organizations/my-org/invoices/inv_123/line-items":
+			c.Assert(r.URL.Query().Get("page"), qt.Equals, "3")
+			c.Assert(r.URL.Query().Get("per_page"), qt.Equals, "25")
+			_, err := w.Write([]byte(`{
+				"type": "list",
+				"next_page": 4,
+				"data": [{
+					"id": "li_1",
+					"subtotal": 12.34,
+					"description": "PS_10",
+					"metric_name": "ps_10",
+					"cloudflare_billed": false,
+					"database_id": "db_1",
+					"database_name": "mydb",
+					"resource": {
+						"id": "branch_1",
+						"name": "main",
+						"created_at": "2026-07-01T00:00:00.000Z",
+						"updated_at": "2026-07-01T00:00:00.000Z",
+						"deleted_at": null
+					}
+				}]
+			}`))
+			c.Assert(err, qt.IsNil)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	page, err := client.Invoices.List(context.Background(), &ListInvoicesRequest{
+		Organization: "my-org",
+	}, WithPage(2), WithPerPage(10))
+	c.Assert(err, qt.IsNil)
+	c.Assert(page.Data, qt.HasLen, 1)
+	c.Assert(page.Data[0].ID, qt.Equals, "inv_123")
+	c.Assert(page.Data[0].Total, qt.Equals, "12.34")
+	c.Assert(page.Data[0].Paid, qt.IsTrue)
+	c.Assert(page.NextPage, qt.IsNil)
+
+	invoice, err := client.Invoices.Get(context.Background(), &GetInvoiceRequest{
+		Organization: "my-org",
+		Invoice:      "inv_123",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(invoice.BillingPeriodStart, qt.Equals, "2026-07-01")
+
+	items, err := client.Invoices.ListLineItems(context.Background(), &ListInvoiceLineItemsRequest{
+		Organization: "my-org",
+		Invoice:      "inv_123",
+	}, WithPage(3), WithPerPage(25))
+	c.Assert(err, qt.IsNil)
+	c.Assert(items.Data, qt.HasLen, 1)
+	c.Assert(items.Data[0].ID, qt.Equals, "li_1")
+	c.Assert(items.Data[0].Subtotal, qt.Equals, 12.34)
+	c.Assert(items.Data[0].DatabaseName, qt.Equals, "mydb")
+	c.Assert(items.Data[0].Resource.Name, qt.Equals, "main")
+	c.Assert(*items.NextPage, qt.Equals, 4)
+}


### PR DESCRIPTION
## Summary
- Add `pscale billing invoice list`, `show`, and `line-items` for the organization invoice APIs.
- `list` and `line-items` return one page per call: `--page` (default 1) and `--per-page` (default 25). Invoices routinely carry thousands of line items, so the commands never walk pages on their own. Human output prints the next page number; JSON and CSV stay unchanged, so callers compare the row count to `--per-page`.
- JSON output preserves the API objects. Line-item subtotals decode from either a string or a number. Service tokens need `read_invoices`.

## Test plan
- [x] `go test ./internal/planetscale ./internal/cmd/billing`
- [x] `pscale billing invoice list --org <org> --format json --per-page 2` returns exactly one page
- [x] `pscale billing invoice show <invoice-id> --org <org> --format json`
- [x] `pscale billing invoice line-items <invoice-id> --org <org> --format json`
- [x] Human output prints the next page hint; a page past the end reports no results