### PR TITLE
Stop the config file from overwriting an explicit --org

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -493,8 +493,10 @@ func initConfig() {
 
 // targetCommand returns the command cobra is about to run, falling back to the
 // root command when the arguments don't resolve (unknown command, no args).
+// Execute uses Traverse because TraverseChildren is enabled, so use the same
+// resolution path here to handle flags interleaved with subcommands.
 func targetCommand(root *cobra.Command, args []string) *cobra.Command {
-	cmd, _, err := root.Find(args)
+	cmd, _, err := root.Traverse(args)
 	if err != nil || cmd == nil {
 		return root
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -488,20 +488,25 @@ func initConfig() {
 		}
 	}
 
-	postInitCommands(rootCmd.Commands())
+	presetRequiredFlags(targetCommand(rootCmd, os.Args[1:]))
+}
+
+// targetCommand returns the command cobra is about to run, falling back to the
+// root command when the arguments don't resolve (unknown command, no args).
+func targetCommand(root *cobra.Command, args []string) *cobra.Command {
+	cmd, _, err := root.Find(args)
+	if err != nil || cmd == nil {
+		return root
+	}
+	return cmd
 }
 
 // Hacky fix for getting Cobra required flags and Viper playing well together.
 // See: https://github.com/spf13/viper/issues/397
-func postInitCommands(commands []*cobra.Command) {
-	for _, cmd := range commands {
-		presetRequiredFlags(cmd)
-		if cmd.HasSubCommands() {
-			postInitCommands(cmd.Commands())
-		}
-	}
-}
-
+//
+// Only the command being run is preset. Commands bind flags such as --org to
+// shared config fields, so presetting an unrelated command's flags overwrites
+// the value the user passed on the command line.
 func presetRequiredFlags(cmd *cobra.Command) {
 	err := viper.BindPFlags(cmd.Flags())
 	if err != nil {
@@ -509,6 +514,9 @@ func presetRequiredFlags(cmd *cobra.Command) {
 	}
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			return
+		}
 		if viper.IsSet(f.Name) && viper.GetString(f.Name) != "" {
 			err = cmd.Flags().Set(f.Name, viper.GetString(f.Name))
 			if err != nil {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/planetscale/cli/internal/cmd/agentguide"
 	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
 )
 
 const rootCLIHelperEnv = "PSCALE_ROOT_CLI_HELPER"
@@ -79,6 +81,71 @@ func TestRootSkillFlagIsNotInheritedBySubcommands(t *testing.T) {
 	}
 }
 
+func TestFlagValueWinsOverConfigFile(t *testing.T) {
+	home := writeHomeConfig(t, "org: config-org\n")
+
+	result := runRootCLIWithHome(t, home,
+		"database", "list",
+		"--org", "flag-org",
+		"--format", "json",
+		"--api-url", "http://127.0.0.1:1/",
+		"--service-token-id", "id",
+		"--service-token", "secret",
+	)
+
+	if !strings.Contains(result.stdout, "organizations/flag-org") {
+		t.Fatalf("--org did not reach the API request, stdout = %q, stderr = %q", result.stdout, result.stderr)
+	}
+}
+
+func TestConfigFileFillsUnsetFlag(t *testing.T) {
+	home := writeHomeConfig(t, "org: config-org\n")
+
+	result := runRootCLIWithHome(t, home,
+		"database", "list",
+		"--format", "json",
+		"--api-url", "http://127.0.0.1:1/",
+		"--service-token-id", "id",
+		"--service-token", "secret",
+	)
+
+	if !strings.Contains(result.stdout, "organizations/config-org") {
+		t.Fatalf("config org was not used, stdout = %q, stderr = %q", result.stdout, result.stderr)
+	}
+}
+
+func writeHomeConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".config", "planetscale")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "pscale.yml"), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestTargetCommand(t *testing.T) {
+	root := &cobra.Command{Use: "pscale"}
+	parent := &cobra.Command{Use: "database"}
+	child := &cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}}
+	parent.AddCommand(child)
+	root.AddCommand(parent)
+
+	if got := targetCommand(root, []string{"database", "list", "--org", "acme"}); got != child {
+		t.Fatalf("target = %q, want database list", got.Name())
+	}
+	if got := targetCommand(root, nil); got != root {
+		t.Fatalf("target = %q, want root", got.Name())
+	}
+	if got := targetCommand(root, []string{"nope"}); got != root {
+		t.Fatalf("target = %q, want root for an unknown command", got.Name())
+	}
+}
+
 func TestRootCLIHelperProcess(t *testing.T) {
 	if os.Getenv(rootCLIHelperEnv) != "1" {
 		return
@@ -106,7 +173,16 @@ type rootCLIResult struct {
 	stderr   string
 }
 
+// runRootCLI runs the CLI against an empty home directory, so the developer's
+// own config and credentials stay out of the test.
 func runRootCLI(t *testing.T, args ...string) rootCLIResult {
+	t.Helper()
+	return runRootCLIWithHome(t, t.TempDir(), args...)
+}
+
+// runRootCLIWithHome runs the CLI with $HOME pointed at dir, so a test can
+// control the config file the CLI reads.
+func runRootCLIWithHome(t *testing.T, home string, args ...string) rootCLIResult {
 	t.Helper()
 
 	testArgs := append([]string{"-test.run=^TestRootCLIHelperProcess$", "--"}, args...)
@@ -117,6 +193,9 @@ func runRootCLI(t *testing.T, args ...string) rootCLIResult {
 		"PSCALE_NO_UPDATE_NOTIFIER=1",
 		"XDG_CONFIG_HOME="+t.TempDir(),
 	)
+	if home != "" {
+		command.Env = append(command.Env, "HOME="+home)
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -98,6 +98,24 @@ func TestFlagValueWinsOverConfigFile(t *testing.T) {
 	}
 }
 
+func TestInterleavedFlagValueWinsOverConfigFile(t *testing.T) {
+	home := writeHomeConfig(t, "org: config-org\n")
+
+	result := runRootCLIWithHome(t, home,
+		"database",
+		"--org", "flag-org",
+		"list",
+		"--format", "json",
+		"--api-url", "http://127.0.0.1:1/",
+		"--service-token-id", "id",
+		"--service-token", "secret",
+	)
+
+	if !strings.Contains(result.stdout, "organizations/flag-org") {
+		t.Fatalf("interleaved --org did not reach the API request, stdout = %q, stderr = %q", result.stdout, result.stderr)
+	}
+}
+
 func TestConfigFileFillsUnsetFlag(t *testing.T) {
 	home := writeHomeConfig(t, "org: config-org\n")
 
@@ -131,12 +149,16 @@ func writeHomeConfig(t *testing.T, contents string) string {
 func TestTargetCommand(t *testing.T) {
 	root := &cobra.Command{Use: "pscale"}
 	parent := &cobra.Command{Use: "database"}
+	parent.PersistentFlags().String("org", "", "")
 	child := &cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}}
 	parent.AddCommand(child)
 	root.AddCommand(parent)
 
 	if got := targetCommand(root, []string{"database", "list", "--org", "acme"}); got != child {
 		t.Fatalf("target = %q, want database list", got.Name())
+	}
+	if got := targetCommand(root, []string{"database", "--org", "acme", "list"}); got != child {
+		t.Fatalf("target with interleaved flag = %q, want database list", got.Name())
 	}
 	if got := targetCommand(root, nil); got != root {
 		t.Fatalf("target = %q, want root", got.Name())


### PR DESCRIPTION
## Summary

`pscale <anything> --org <org>` silently ignored `--org` when `~/.config/planetscale/pscale.yml` set an org, running against the configured organization instead. It is on `main` today, so agents and scripts that pass `--org` on every command (as `AGENTS.md` instructs) would read and write the wrong organization without any warning.

Cause: `initConfig` walked the whole command tree and preset every command's flags from viper. Commands bind `--org` to the same `ch.Config.Organization` field, so presetting an unrelated command's unset `--org` wrote the config value over the one parsed from the command line. This surfaced once a command declared `--org` as a local (not persistent) flag, since only local flags are in `cmd.Flags()` for commands cobra never merges persistent flags into.

Fix: preset only the command being run, and skip flags that were set on the command line.

Also points the CLI tests at an empty home directory. They were reading the developer's real config and credentials, which made `TestRootSkillFlagDoesNotInterceptSubcommandValues` fail locally (it reached the API instead of `NO_AUTH`).

## Test plan

- [x] `go test ./...`
- [x] New tests: `--org` reaches the API request, config still fills an unset `--org`, and `targetCommand` resolves subcommands and falls back to root
- [x] Verified against production with a local build:
  - `pscale database list --org does-not-exist-xyz --format json` errors instead of listing the configured org's databases
  - `pscale database list --format json` still uses the org from the config file
  - `pscale database list --org example --format json` lists that org
  - `pscale org update --billing-email ... --api-url http://127.0.0.1:1/` still fills its required `--org` from the config file (request path is `/v1/organizations/<config org>`)