### PR TITLE
Fix query Insights errors and pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,7 @@ Two complementary read-only surfaces. When diagnosing database health or perform
 ```bash
 pscale insights queries <database> <branch> --org <org> --format json --sort totalTime   # top queries; sorts: totalTime, count, p99Latency, rowsRead, rowsReadPerReturned, errorCount, ...
 pscale insights queries samples <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # recent executions; keyspace from queries list
-pscale insights queries traffic-budgets <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # traffic budgets affecting a query fingerprint
+pscale insights queries traffic-budgets <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace> --page <n> --per-page <n>  # traffic budgets affecting a query fingerprint
 pscale insights queries show <database> <branch> <query-id> --org <org> --format json     # one execution; query-id comes from the samples list
 pscale insights queries summary <database> <branch> <fingerprint> --org <org> --format json --keyspace <keyspace>  # aggregate stats for one query pattern
 pscale insights errors <database> <branch> --org <org> --format json                     # failing queries with error messages

--- a/internal/cmd/insights/queries_test.go
+++ b/internal/cmd/insights/queries_test.go
@@ -351,6 +351,21 @@ func TestInsights_QueryShowCmd_Human(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, "select 1")
 }
 
+func TestInsights_QueryShowCmd_NotFoundNamesQueryExecution(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{
+		GetQueryFn: func(context.Context, *ps.GetQueryRequest) (*ps.Query, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	cmd := QueryShowCmd(testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{QueryInsights: svc}))
+	cmd.SetArgs([]string{"mydb", "main", "missing-execution"})
+
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, "query execution missing-execution does not exist on branch main in database mydb .*")
+}
+
 func TestInsights_QuerySummaryCmd(t *testing.T) {
 	c := qt.New(t)
 	lastRunAt := time.Date(2026, 8, 25, 18, 0, 0, 0, time.UTC)
@@ -424,6 +439,21 @@ func TestInsights_QuerySummaryCmd_Human(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, "b129e8fa")
 	c.Assert(buf.String(), qt.Contains, "20")
 	c.Assert(buf.String(), qt.Contains, "select 1")
+}
+
+func TestInsights_QuerySummaryCmd_NotFoundNamesFingerprint(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{
+		GetQuerySummaryFn: func(context.Context, *ps.GetQuerySummaryRequest, ...ps.ListOption) (*ps.QuerySummary, error) {
+			return nil, &ps.Error{Code: ps.ErrNotFound}
+		},
+	}
+
+	cmd := QuerySummaryCmd(testHelper(&bytes.Buffer{}, printer.JSON, &ps.Client{QueryInsights: svc}))
+	cmd.SetArgs([]string{"mydb", "main", "missing-fingerprint", "--keyspace", "commerce"})
+
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, "query fingerprint missing-fingerprint does not exist in keyspace commerce on branch main in database mydb .*")
 }
 
 func TestInsights_QuerySummaryCmd_RequiresKeyspace(t *testing.T) {

--- a/internal/cmd/insights/query_show.go
+++ b/internal/cmd/insights/query_show.go
@@ -57,6 +57,10 @@ not the fingerprint used by the samples and summary commands.`,
 				QueryID:      queryID,
 			})
 			if err != nil {
+				if cmdutil.ErrCode(err) == ps.ErrNotFound {
+					return fmt.Errorf("query execution %s does not exist on branch %s in database %s (organization: %s)",
+						printer.BoldBlue(queryID), printer.BoldBlue(branch), printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				}
 				return notFoundError(ch, err, database, branch)
 			}
 			end()

--- a/internal/cmd/insights/query_summary.go
+++ b/internal/cmd/insights/query_summary.go
@@ -73,6 +73,11 @@ The fingerprint identifies a query pattern; it is not an execution/sample ID.`,
 				Fingerprint:  fingerprint,
 			}, ps.WithKeyspace(flags.keyspace), ps.WithPeriod(flags.period), ps.WithTimeRange(flags.from, flags.to))
 			if err != nil {
+				if cmdutil.ErrCode(err) == ps.ErrNotFound {
+					return fmt.Errorf("query fingerprint %s does not exist in keyspace %s on branch %s in database %s (organization: %s)",
+						printer.BoldBlue(fingerprint), printer.BoldBlue(flags.keyspace), printer.BoldBlue(branch),
+						printer.BoldBlue(database), printer.BoldBlue(ch.Config.Organization))
+				}
 				return notFoundError(ch, err, database, branch)
 			}
 			end()

--- a/internal/cmd/insights/query_traffic_budgets.go
+++ b/internal/cmd/insights/query_traffic_budgets.go
@@ -12,13 +12,16 @@ import (
 )
 
 func QueryTrafficBudgetsCmd(ch *cmdutil.Helper) *cobra.Command {
-	var keyspace string
+	var flags struct {
+		keyspace string
+		page     int
+		perPage  int
+	}
 
 	cmd := &cobra.Command{
-		Use:     "traffic-budgets <database> <branch> <fingerprint>",
-		Short:   "List traffic budgets affecting a query fingerprint",
-		Aliases: []string{"ls"},
-		Args:    cmdutil.RequiredArgs("database", "branch", "fingerprint"),
+		Use:   "traffic-budgets <database> <branch> <fingerprint>",
+		Short: "List traffic budgets affecting a query fingerprint",
+		Args:  cmdutil.RequiredArgs("database", "branch", "fingerprint"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			database, branch, fingerprint := args[0], args[1], args[2]
@@ -37,7 +40,7 @@ func QueryTrafficBudgetsCmd(ch *cmdutil.Helper) *cobra.Command {
 				Database:     database,
 				Branch:       branch,
 				Fingerprint:  fingerprint,
-			}, ps.WithKeyspace(keyspace))
+			}, ps.WithKeyspace(flags.keyspace), ps.WithPage(flags.page), ps.WithPerPage(flags.perPage))
 			if err != nil {
 				return notFoundError(ch, err, database, branch)
 			}
@@ -53,7 +56,9 @@ func QueryTrafficBudgetsCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&keyspace, "keyspace", "", "Keyspace for the fingerprint")
+	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the fingerprint")
+	cmd.Flags().IntVar(&flags.page, "page", 1, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.perPage, "per-page", 25, "Number of results per page")
 
 	return cmd
 }

--- a/internal/cmd/insights/query_traffic_budgets.go
+++ b/internal/cmd/insights/query_traffic_budgets.go
@@ -47,8 +47,12 @@ func QueryTrafficBudgetsCmd(ch *cmdutil.Helper) *cobra.Command {
 			end()
 
 			if len(budgets) == 0 && ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("No traffic budgets affect fingerprint %s on %s/%s.\n",
-					printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch))
+				if flags.page > 0 {
+					ch.Printer.Println("No traffic budgets found on this page.")
+				} else {
+					ch.Printer.Printf("No traffic budgets affect fingerprint %s on %s/%s.\n",
+						printer.BoldBlue(fingerprint), printer.BoldBlue(database), printer.BoldBlue(branch))
+				}
 				return nil
 			}
 
@@ -57,7 +61,7 @@ func QueryTrafficBudgetsCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&flags.keyspace, "keyspace", "", "Keyspace for the fingerprint")
-	cmd.Flags().IntVar(&flags.page, "page", 1, "Page number to fetch")
+	cmd.Flags().IntVar(&flags.page, "page", 0, "Page number to fetch")
 	cmd.Flags().IntVar(&flags.perPage, "per-page", 25, "Number of results per page")
 
 	return cmd

--- a/internal/cmd/insights/query_traffic_budgets_test.go
+++ b/internal/cmd/insights/query_traffic_budgets_test.go
@@ -62,3 +62,41 @@ func TestQueryTrafficBudgetsCmd(t *testing.T) {
 	c.Assert(out[0]["id"], qt.Equals, "budget-1")
 	c.Assert(out[0]["name"], qt.Equals, "App queries")
 }
+
+func TestQueryTrafficBudgetsCmd_EmptyFirstPage(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{
+		ListQueryTrafficBudgetsFn: func(context.Context, *ps.ListQueryTrafficBudgetsRequest, ...ps.ListOption) ([]*ps.TrafficBudget, error) {
+			return nil, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.Human, &ps.Client{QueryInsights: svc})
+	ch.Printer.SetHumanOutput(&buf)
+
+	cmd := QueryTrafficBudgetsCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "No traffic budgets affect fingerprint")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "on this page")
+}
+
+func TestQueryTrafficBudgetsCmd_EmptyLaterPage(t *testing.T) {
+	c := qt.New(t)
+	svc := &mock.QueryInsightsService{
+		ListQueryTrafficBudgetsFn: func(context.Context, *ps.ListQueryTrafficBudgetsRequest, ...ps.ListOption) ([]*ps.TrafficBudget, error) {
+			return nil, nil
+		},
+	}
+
+	var buf bytes.Buffer
+	ch := testHelper(&buf, printer.Human, &ps.Client{QueryInsights: svc})
+	ch.Printer.SetHumanOutput(&buf)
+
+	cmd := QueryTrafficBudgetsCmd(ch)
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--page", "4"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "No traffic budgets found on this page.")
+	c.Assert(buf.String(), qt.Not(qt.Contains), "No traffic budgets affect fingerprint")
+}

--- a/internal/cmd/insights/query_traffic_budgets_test.go
+++ b/internal/cmd/insights/query_traffic_budgets_test.go
@@ -38,6 +38,8 @@ func TestQueryTrafficBudgetsCmd(t *testing.T) {
 				c.Assert(opt(listOpts), qt.IsNil)
 			}
 			c.Assert(values.Get("keyspace"), qt.Equals, "mydb")
+			c.Assert(values.Get("page"), qt.Equals, "3")
+			c.Assert(values.Get("per_page"), qt.Equals, "50")
 
 			return budgets, nil
 		},
@@ -47,12 +49,12 @@ func TestQueryTrafficBudgetsCmd(t *testing.T) {
 	ch := testHelper(&buf, printer.JSON, &ps.Client{QueryInsights: svc})
 
 	cmd := QueryTrafficBudgetsCmd(ch)
-	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--keyspace", "mydb"})
+	cmd.SetArgs([]string{"mydb", "main", "b129e8fa", "--keyspace", "mydb", "--page", "3", "--per-page", "50"})
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(svc.ListQueryTrafficBudgetsFnInvoked, qt.IsTrue)
-	c.Assert(cmd.Aliases, qt.DeepEquals, []string{"ls"})
+	c.Assert(cmd.Aliases, qt.HasLen, 0)
 
 	var out []map[string]any
 	c.Assert(json.Unmarshal(buf.Bytes(), &out), qt.IsNil)


### PR DESCRIPTION
## Summary
- report missing query executions and fingerprints instead of claiming the branch is missing
- add `--page` and `--per-page` to query traffic-budget results without walking all pages
- remove the nested `ls` alias that intercepted `insights queries ls`

## Test plan
- [x] `go test ./internal/cmd/insights ./internal/planetscale -count=1`