### PR TITLE
Harden team and read-only region output

### DIFF
--- a/internal/cmd/database/read_only_regions.go
+++ b/internal/cmd/database/read_only_regions.go
@@ -39,6 +39,9 @@ func ReadOnlyRegionsListCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := requireVitessDatabase(cmd.Context(), ch, client, database, "read-only regions"); err != nil {
+				return err
+			}
 
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching read-only regions for database %s...", printer.BoldBlue(database)))
 			defer end()

--- a/internal/cmd/database/regions_test.go
+++ b/internal/cmd/database/regions_test.go
@@ -80,6 +80,11 @@ func TestDatabase_RegionsListCmdHuman(t *testing.T) {
 func TestDatabase_ReadOnlyRegionsListCmd(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
+	databases := &mock.DatabaseService{
+		GetFn: func(context.Context, *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: "app", Kind: ps.DatabaseEngineMySQL}, nil
+		},
+	}
 	regions := []*ps.ReadOnlyRegion{{
 		ID:          "ror123",
 		DisplayName: "Europe West",
@@ -105,7 +110,7 @@ func TestDatabase_ReadOnlyRegionsListCmd(t *testing.T) {
 		},
 	}
 
-	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.JSON, &out, nil, svc))
+	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.JSON, &out, databases, svc))
 	cmd.SetArgs([]string{"app", "--page", "3", "--per-page", "10"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.ListFnInvoked, qt.IsTrue)
@@ -116,6 +121,11 @@ func TestDatabase_ReadOnlyRegionsListCmd(t *testing.T) {
 func TestDatabase_ReadOnlyRegionsListCmdHuman(t *testing.T) {
 	c := qt.New(t)
 	var out bytes.Buffer
+	databases := &mock.DatabaseService{
+		GetFn: func(context.Context, *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: "app", Kind: ps.DatabaseEngineMySQL}, nil
+		},
+	}
 	svc := &mock.ReadOnlyRegionsService{
 		ListFn: func(context.Context, *ps.ListReadOnlyRegionsRequest, ...ps.ListOption) ([]*ps.ReadOnlyRegion, error) {
 			return []*ps.ReadOnlyRegion{{
@@ -130,12 +140,28 @@ func TestDatabase_ReadOnlyRegionsListCmdHuman(t *testing.T) {
 		},
 	}
 
-	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.Human, &out, nil, svc))
+	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.Human, &out, databases, svc))
 	cmd.SetArgs([]string{"app"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(out.String(), qt.Contains, "ror123")
 	c.Assert(out.String(), qt.Contains, "eu-west")
 	c.Assert(out.String(), qt.Contains, "Europe West")
+}
+
+func TestDatabase_ReadOnlyRegionsListCmdRejectsPostgres(t *testing.T) {
+	c := qt.New(t)
+	databases := &mock.DatabaseService{
+		GetFn: func(context.Context, *ps.GetDatabaseRequest) (*ps.Database, error) {
+			return &ps.Database{Name: "app", Kind: ps.DatabaseEnginePostgres}, nil
+		},
+	}
+	regions := &mock.ReadOnlyRegionsService{}
+
+	cmd := ReadOnlyRegionsListCmd(databaseRegionsTestHelper(printer.JSON, &bytes.Buffer{}, databases, regions))
+	cmd.SetArgs([]string{"app"})
+
+	c.Assert(cmd.Execute(), qt.ErrorMatches, `.*only available for Vitess .* databases; app is postgresql`)
+	c.Assert(regions.ListFnInvoked, qt.IsFalse)
 }
 
 func TestDatabase_RegionCommandsRegistered(t *testing.T) {

--- a/internal/cmd/org/team.go
+++ b/internal/cmd/org/team.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	ps "github.com/planetscale/cli/internal/planetscale"
@@ -101,7 +102,19 @@ func toOrganizationTeamMembers(members []*ps.OrganizationTeamMembership) []*orga
 }
 
 func (m *organizationTeamMember) MarshalJSON() ([]byte, error) {
-	return json.MarshalIndent(m.orig, "", "  ")
+	return json.MarshalIndent(struct {
+		ID        string                   `json:"id"`
+		User      ps.OrganizationTeamUser  `json:"user"`
+		Actor     ps.OrganizationTeamActor `json:"actor"`
+		CreatedAt time.Time                `json:"created_at"`
+		UpdatedAt time.Time                `json:"updated_at"`
+	}{
+		ID:        m.orig.ID,
+		User:      m.orig.User,
+		Actor:     m.orig.Actor,
+		CreatedAt: m.orig.CreatedAt,
+		UpdatedAt: m.orig.UpdatedAt,
+	}, "", "  ")
 }
 
 func (m *organizationTeamMember) MarshalCSVValue() interface{} {

--- a/internal/cmd/org/team_test.go
+++ b/internal/cmd/org/team_test.go
@@ -3,6 +3,7 @@ package org
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/url"
 	"testing"
 
@@ -35,6 +36,7 @@ func testTeamMember() *ps.OrganizationTeamMembership {
 			Name:        "Ada",
 			Email:       "ada@example.com",
 		},
+		Passwords: []json.RawMessage{json.RawMessage(`{"id":"password-1","name":"production"}`)},
 	}
 }
 
@@ -184,6 +186,8 @@ func TestOrg_TeamMemberListCmd(t *testing.T) {
 	cmd.SetArgs([]string{"platform", "--page", "3", "--per-page", "50"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(buf.String(), qt.Contains, `"email": "ada@example.com"`)
+	c.Assert(buf.String(), qt.Not(qt.Contains), `"passwords"`)
+	c.Assert(buf.String(), qt.Not(qt.Contains), `"password-1"`)
 }
 
 func TestOrg_TeamMemberListCmd_EmptyPage(t *testing.T) {


### PR DESCRIPTION
## Summary
- serialize team memberships through a safe JSON projection that omits password metadata
- check the database engine before listing Vitess read-only regions
- return a clear error for PostgreSQL without calling the read-only-region endpoint

## Test plan
- [x] `go test ./internal/cmd/org ./internal/cmd/database -count=1`