### PR TITLE
Add pscale org sso commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ pscale --org <org> database list --format json
 
    Only org admins can change another member's role or remove someone else. Nobody can change their own role. `--role` is `admin`, `member`, or `analyst`.
 
-   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Success JSON includes `next_steps`. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present. `--idp-sso-managed-roles` is for SSO profile roles; `--idp-managed-roles` is for directory sync roles. They cannot both be enabled.
+   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Success JSON includes `next_steps`. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present. `--idp-sso-managed-roles` is for SSO profile roles; `--idp-managed-roles` is for directory sync roles. They are mutually exclusive: enabling one turns the other off, and enabling both in one call is rejected.
 
    ```bash
    pscale org sso show --org <org> --format json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ pscale --org <org> database list --format json
    ```bash
    pscale org update --org <org> --format json --billing-email billing@example.com
    pscale org update --org <org> --format json --idp-managed-roles=false
+   pscale org update --org <org> --format json --idp-sso-managed-roles=true
    pscale org update --org <org> --format json --spend-alert=true --spend-alert-amount 2500
    pscale org update --org <org> --format json --spend-alert=false
    ```
@@ -107,7 +108,7 @@ pscale --org <org> database list --format json
 
    Only org admins can change another member's role or remove someone else. Nobody can change their own role. `--role` is `admin`, `member`, or `analyst`.
 
-   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present.
+   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Success JSON includes `next_steps`. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present. `--idp-sso-managed-roles` is for SSO profile roles; `--idp-managed-roles` is for directory sync roles. They cannot both be enabled.
 
    ```bash
    pscale org sso show --org <org> --format json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ pscale --org <org> database list --format json
 
    Only org admins can change another member's role or remove someone else. Nobody can change their own role. `--role` is `admin`, `member`, or `analyst`.
 
-   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Success JSON includes `next_steps`. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present. `--idp-sso-managed-roles` is for SSO profile roles; `--idp-managed-roles` is for directory sync roles. They are mutually exclusive: enabling one turns the other off, and enabling both in one call is rejected.
+   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Success JSON includes `next_steps`. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present. `domain verify` does not return a domain id. Prefer `domain verify --wait`: it prints the portal URL, polls `domain list` until a new domain id appears, then polls `domain show` until that domain is verified or failed. Without `--wait`, open `portal_url`, then `domain list` and `domain show <domain-id>` to check state. `--idp-sso-managed-roles` is for SSO profile roles; `--idp-managed-roles` is for directory sync roles. They are mutually exclusive: enabling one turns the other off, and enabling both in one call is rejected.
 
    ```bash
    pscale org sso show --org <org> --format json
@@ -118,7 +118,9 @@ pscale --org <org> database list --format json
    pscale org sso directory enable --org <org> --format json
    pscale org sso directory disable --org <org> --format json --force
    pscale org sso domain list --org <org> --format json
+   pscale org sso domain show <domain-id> --org <org> --format json
    pscale org sso domain verify --org <org> --format json
+   pscale org sso domain verify --org <org> --format json --wait
    pscale org sso domain delete <domain-id> --org <org> --format json --force
    ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ pscale --org <org> database list --format json
 
    Only org admins can change another member's role or remove someone else. Nobody can change their own role. `--role` is `admin`, `member`, or `analyst`.
 
-   Organization SSO (admin session, or a token with `manage_sso`). Enable, configure, and domain verify return setup URLs and try to open them. Destructive commands need `--force` in JSON:
+   Organization SSO (admin session, or a token with `manage_sso`). Disable, directory disable, and domain delete need `--force` in JSON. Configure, directory enable, and domain verify return `portal_url` and `browser_opened`; if `browser_opened` is false, open `portal_url`. `enable` JSON includes `domain_verification_url` when present.
 
    ```bash
    pscale org sso show --org <org> --format json
@@ -120,8 +120,6 @@ pscale --org <org> database list --format json
    pscale org sso domain verify --org <org> --format json
    pscale org sso domain delete <domain-id> --org <org> --format json --force
    ```
-
-   `show` reports `enabled`, `configured`, `directory`, `has_verified_domain`, and `domains`. Portal commands return `portal_url` and `browser_opened`; if `browser_opened` is false, tell the user to open `portal_url`. `enable` JSON is the SSO object and includes `domain_verification_url` when present.
 
 Organization teams and team members:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,22 @@ pscale --org <org> database list --format json
 
    Only org admins can change another member's role or remove someone else. Nobody can change their own role. `--role` is `admin`, `member`, or `analyst`.
 
+   Organization SSO (admin session, or a token with `manage_sso`). Enable, configure, and domain verify return setup URLs and try to open them. Destructive commands need `--force` in JSON:
+
+   ```bash
+   pscale org sso show --org <org> --format json
+   pscale org sso enable --org <org> --format json
+   pscale org sso configure --org <org> --format json
+   pscale org sso disable --org <org> --format json --force
+   pscale org sso directory enable --org <org> --format json
+   pscale org sso directory disable --org <org> --format json --force
+   pscale org sso domain list --org <org> --format json
+   pscale org sso domain verify --org <org> --format json
+   pscale org sso domain delete <domain-id> --org <org> --format json --force
+   ```
+
+   `show` reports `enabled`, `configured`, `directory`, `has_verified_domain`, and `domains`. Portal commands return `portal_url` and `browser_opened`; if `browser_opened` is false, tell the user to open `portal_url`. `enable` JSON is the SSO object and includes `domain_verification_url` when present.
+
 Organization teams and team members:
 
 ```bash

--- a/internal/cmd/org/org.go
+++ b/internal/cmd/org/org.go
@@ -20,6 +20,7 @@ func OrgCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.AddCommand(ListCmd(ch))
 	cmd.AddCommand(UpdateCmd(ch))
 	cmd.AddCommand(MemberCmd(ch))
+	cmd.AddCommand(SSOCmd(ch))
 	cmd.AddCommand(TeamCmd(ch))
 
 	return cmd

--- a/internal/cmd/org/sso.go
+++ b/internal/cmd/org/sso.go
@@ -1,0 +1,284 @@
+package org
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+var openSSOBrowser = cmdutil.TryOpenBrowser
+
+func SSOCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sso <command>",
+		Short: "Enable, configure, and disable organization SSO",
+		Long: `Manage organization single sign-on.
+
+Enabling SSO returns a URL for verifying an email domain. Configuring SSO and
+directory sync opens a setup URL. Requires an org admin session, or a token
+with the manage_sso grant.`,
+	}
+
+	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
+	cmd.MarkPersistentFlagRequired("org")
+
+	cmd.AddCommand(SSOShowCmd(ch))
+	cmd.AddCommand(SSOEnableCmd(ch))
+	cmd.AddCommand(SSODisableCmd(ch))
+	cmd.AddCommand(SSOConfigureCmd(ch))
+	cmd.AddCommand(SSODirectoryCmd(ch))
+	cmd.AddCommand(SSODomainCmd(ch))
+
+	return cmd
+}
+
+type organizationSSO struct {
+	ID                string `header:"id" json:"id"`
+	Enabled           bool   `header:"enabled" json:"enabled"`
+	Configured        bool   `header:"configured" json:"configured"`
+	Directory         bool   `header:"directory" json:"directory"`
+	HasVerifiedDomain bool   `header:"has_verified_domain" json:"has_verified_domain"`
+
+	orig *ps.OrganizationSSO
+}
+
+func (s *organizationSSO) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(s.orig, "", "  ")
+}
+
+func (s *organizationSSO) MarshalCSVValue() interface{} {
+	return []*organizationSSO{s}
+}
+
+func toOrganizationSSO(sso *ps.OrganizationSSO) *organizationSSO {
+	return &organizationSSO{
+		ID:                sso.ID,
+		Enabled:           sso.Enabled,
+		Configured:        sso.Configured,
+		Directory:         sso.Directory,
+		HasVerifiedDomain: sso.HasVerifiedDomain,
+		orig:              sso,
+	}
+}
+
+type ssoPortal struct {
+	PortalURL     string `header:"portal_url" json:"portal_url"`
+	BrowserOpened bool   `header:"browser_opened" json:"browser_opened"`
+}
+
+func (p *ssoPortal) MarshalCSVValue() interface{} {
+	return []*ssoPortal{p}
+}
+
+type organizationDomain struct {
+	ID     string `header:"id" json:"id"`
+	Domain string `header:"domain" json:"domain"`
+	State  string `header:"state" json:"state"`
+
+	orig *ps.OrganizationDomain
+}
+
+func (d *organizationDomain) MarshalJSON() ([]byte, error) {
+	return json.MarshalIndent(d.orig, "", "  ")
+}
+
+func (d *organizationDomain) MarshalCSVValue() interface{} {
+	return []*organizationDomain{d}
+}
+
+func toOrganizationDomains(domains []*ps.OrganizationDomain) []*organizationDomain {
+	out := make([]*organizationDomain, 0, len(domains))
+	for _, domain := range domains {
+		out = append(out, &organizationDomain{
+			ID:     domain.ID,
+			Domain: domain.Domain,
+			State:  domain.State,
+			orig:   domain,
+		})
+	}
+	return out
+}
+
+func handleSSOError(org string, err error) error {
+	switch cmdutil.ErrCode(err) {
+	case ps.ErrNotFound:
+		return fmt.Errorf("organization %s does not exist", printer.BoldBlue(org))
+	default:
+		return cmdutil.HandleError(err)
+	}
+}
+
+func printSSOPortal(ch *cmdutil.Helper, url, action string) error {
+	if url == "" {
+		return fmt.Errorf("no %s URL was returned", action)
+	}
+
+	browserOpened := openSSOBrowser(runtime.GOOS, url) == nil
+	if ch.Printer.Format() == printer.Human {
+		if browserOpened {
+			ch.Printer.Printf("Opened the %s URL in your browser.\n", action)
+			ch.Printer.Printf("%s\n", printer.BoldBlue(url))
+		} else {
+			ch.Printer.Printf("Open this URL to %s: %s\n", action, printer.BoldBlue(url))
+		}
+		return nil
+	}
+
+	return ch.Printer.PrintResource(&ssoPortal{
+		PortalURL:     url,
+		BrowserOpened: browserOpened,
+	})
+}
+
+func SSOShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show organization SSO status",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching SSO status for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			sso, err := client.OrganizationSSO.Get(ctx, &ps.GetOrganizationSSORequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+		},
+	}
+
+	return cmd
+}
+
+func SSOEnableCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable organization SSO",
+		Long:  "Enable the SSO add-on and return a URL for verifying an email domain.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Enabling SSO for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			sso, err := client.OrganizationSSO.Enable(ctx, &ps.EnableOrganizationSSORequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			if sso.DomainVerificationURL != nil && *sso.DomainVerificationURL != "" {
+				if ch.Printer.Format() == printer.Human {
+					ch.Printer.Printf("SSO is enabled for %s.\n", printer.BoldBlue(org))
+					return printSSOPortal(ch, *sso.DomainVerificationURL, "verify an email domain")
+				}
+				_ = openSSOBrowser(runtime.GOOS, *sso.DomainVerificationURL)
+			} else if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("SSO is enabled for %s.\n", printer.BoldBlue(org))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+		},
+	}
+
+	return cmd
+}
+
+func SSODisableCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "disable",
+		Short: "Disable organization SSO",
+		Long:  "Disable SSO and directory sync for the organization.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			if !force {
+				if err := ch.Printer.ConfirmCommand(org, "disable SSO", "disabling SSO"); err != nil {
+					return err
+				}
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Disabling SSO for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			sso, err := client.OrganizationSSO.Disable(ctx, &ps.DisableOrganizationSSORequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("SSO is disabled for %s.\n", printer.BoldBlue(org))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable SSO without confirmation")
+	return cmd
+}
+
+func SSOConfigureCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Open the identity provider setup portal",
+		Long:  "Return a URL for configuring the identity provider. Requires SSO to be enabled and at least one verified domain.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating an SSO configuration URL for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			portal, err := client.OrganizationSSO.Configure(ctx, &ps.ConfigureOrganizationSSORequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			return printSSOPortal(ch, portal.PortalURL, "configure SSO")
+		},
+	}
+
+	return cmd
+}

--- a/internal/cmd/org/sso.go
+++ b/internal/cmd/org/sso.go
@@ -39,35 +39,103 @@ type organizationSSO struct {
 	Directory         bool   `header:"directory" json:"directory"`
 	HasVerifiedDomain bool   `header:"has_verified_domain" json:"has_verified_domain"`
 
-	orig *ps.OrganizationSSO
+	nextSteps []string
+	orig      *ps.OrganizationSSO
 }
 
 func (s *organizationSSO) MarshalJSON() ([]byte, error) {
-	return json.MarshalIndent(s.orig, "", "  ")
+	type payload struct {
+		*ps.OrganizationSSO
+		NextSteps []string `json:"next_steps"`
+	}
+	return json.MarshalIndent(payload{OrganizationSSO: s.orig, NextSteps: s.nextSteps}, "", "  ")
 }
 
 func (s *organizationSSO) MarshalCSVValue() interface{} {
 	return []*organizationSSO{s}
 }
 
-func toOrganizationSSO(sso *ps.OrganizationSSO) *organizationSSO {
+func toOrganizationSSO(org string, sso *ps.OrganizationSSO) *organizationSSO {
 	return &organizationSSO{
 		ID:                sso.ID,
 		Enabled:           sso.Enabled,
 		Configured:        sso.Configured,
 		Directory:         sso.Directory,
 		HasVerifiedDomain: sso.HasVerifiedDomain,
+		nextSteps:         ssoResourceNextSteps(org, sso),
 		orig:              sso,
 	}
 }
 
 type ssoPortal struct {
-	PortalURL     string `header:"portal_url" json:"portal_url"`
-	BrowserOpened bool   `header:"browser_opened" json:"browser_opened"`
+	PortalURL     string   `header:"portal_url" json:"portal_url"`
+	BrowserOpened bool     `header:"browser_opened" json:"browser_opened"`
+	NextSteps     []string `json:"next_steps"`
 }
 
 func (p *ssoPortal) MarshalCSVValue() interface{} {
 	return []*ssoPortal{p}
+}
+
+type ssoDomainDeleted struct {
+	Result    string   `json:"result"`
+	Org       string   `json:"org"`
+	ID        string   `json:"id"`
+	NextSteps []string `json:"next_steps"`
+}
+
+func jsonSSOCmd(org, rest string) string {
+	return fmt.Sprintf("pscale org sso %s --org %s --format json", rest, org)
+}
+
+func jsonOrgUpdateCmd(org, flag string) string {
+	return fmt.Sprintf("pscale org update --org %s --format json %s", org, flag)
+}
+
+func ssoResourceNextSteps(org string, sso *ps.OrganizationSSO) []string {
+	if sso == nil || !sso.Enabled {
+		return []string{jsonSSOCmd(org, "enable")}
+	}
+	if !sso.HasVerifiedDomain {
+		return []string{jsonSSOCmd(org, "domain verify")}
+	}
+	if !sso.Configured {
+		return []string{jsonSSOCmd(org, "configure")}
+	}
+	if !sso.Directory {
+		return []string{
+			jsonSSOCmd(org, "directory enable"),
+			jsonOrgUpdateCmd(org, "--idp-sso-managed-roles=true"),
+		}
+	}
+	return []string{jsonOrgUpdateCmd(org, "--idp-managed-roles=true")}
+}
+
+func ssoPortalNextSteps(org, kind string, browserOpened bool) []string {
+	steps := make([]string, 0, 3)
+	if !browserOpened {
+		steps = append(steps, "Open portal_url in a browser")
+	}
+	steps = append(steps, jsonSSOCmd(org, "show"))
+	switch kind {
+	case "configure":
+		steps = append(steps, jsonOrgUpdateCmd(org, "--idp-sso-managed-roles=true"))
+	case "directory":
+		steps = append(steps, jsonOrgUpdateCmd(org, "--idp-managed-roles=true"))
+	case "verify":
+		steps = append(steps, jsonSSOCmd(org, "configure"))
+	}
+	return steps
+}
+
+func printHumanNextSteps(ch *cmdutil.Helper, steps []string) {
+	if ch.Printer.Format() != printer.Human || len(steps) == 0 {
+		return
+	}
+	ch.Printer.Println("Next:")
+	for _, step := range steps {
+		ch.Printer.Printf("  %s\n", step)
+	}
 }
 
 type organizationDomain struct {
@@ -108,12 +176,14 @@ func handleSSOError(org string, err error) error {
 	}
 }
 
-func printSSOPortal(ch *cmdutil.Helper, url, action string) error {
+func printSSOPortal(ch *cmdutil.Helper, url, kind, action string) error {
 	if url == "" {
 		return fmt.Errorf("no %s URL was returned", action)
 	}
 
+	org := ch.Config.Organization
 	browserOpened := openSSOBrowser(runtime.GOOS, url) == nil
+	steps := ssoPortalNextSteps(org, kind, browserOpened)
 	if ch.Printer.Format() == printer.Human {
 		if browserOpened {
 			ch.Printer.Printf("Opened the %s URL in your browser.\n", action)
@@ -121,12 +191,14 @@ func printSSOPortal(ch *cmdutil.Helper, url, action string) error {
 		} else {
 			ch.Printer.Printf("Open this URL to %s: %s\n", action, printer.BoldBlue(url))
 		}
+		printHumanNextSteps(ch, steps)
 		return nil
 	}
 
 	return ch.Printer.PrintResource(&ssoPortal{
 		PortalURL:     url,
 		BrowserOpened: browserOpened,
+		NextSteps:     steps,
 	})
 }
 
@@ -153,7 +225,7 @@ func SSOShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+			return ch.Printer.PrintResource(toOrganizationSSO(org, sso))
 		},
 	}
 
@@ -186,12 +258,13 @@ func SSOEnableCmd(ch *cmdutil.Helper) *cobra.Command {
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("SSO is enabled for %s.\n", printer.BoldBlue(org))
 				if sso.DomainVerificationURL != nil && *sso.DomainVerificationURL != "" {
-					return printSSOPortal(ch, *sso.DomainVerificationURL, "verify an email domain")
+					return printSSOPortal(ch, *sso.DomainVerificationURL, "verify", "verify an email domain")
 				}
+				printHumanNextSteps(ch, ssoResourceNextSteps(org, sso))
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+			return ch.Printer.PrintResource(toOrganizationSSO(org, sso))
 		},
 	}
 
@@ -231,10 +304,11 @@ func SSODisableCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("SSO is disabled for %s.\n", printer.BoldBlue(org))
+				printHumanNextSteps(ch, ssoResourceNextSteps(org, sso))
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+			return ch.Printer.PrintResource(toOrganizationSSO(org, sso))
 		},
 	}
 
@@ -266,7 +340,7 @@ func SSOConfigureCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			return printSSOPortal(ch, portal.PortalURL, "configure SSO")
+			return printSSOPortal(ch, portal.PortalURL, "configure", "configure SSO")
 		},
 	}
 

--- a/internal/cmd/org/sso.go
+++ b/internal/cmd/org/sso.go
@@ -16,12 +16,7 @@ var openSSOBrowser = cmdutil.TryOpenBrowser
 func SSOCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sso <command>",
-		Short: "Enable, configure, and disable organization SSO",
-		Long: `Manage organization single sign-on.
-
-Enabling SSO returns a URL for verifying an email domain. Configuring SSO and
-directory sync opens a setup URL. Requires an org admin session, or a token
-with the manage_sso grant.`,
+		Short: "Manage organization SSO",
 	}
 
 	cmd.PersistentFlags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
@@ -152,7 +147,7 @@ func SSOShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching SSO status for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			sso, err := client.OrganizationSSO.Get(ctx, &ps.GetOrganizationSSORequest{Organization: org})
+			sso, err := client.OrganizationSSO.Get(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}
@@ -169,7 +164,6 @@ func SSOEnableCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Enable organization SSO",
-		Long:  "Enable the SSO add-on and return a URL for verifying an email domain.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -183,20 +177,17 @@ func SSOEnableCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Enabling SSO for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			sso, err := client.OrganizationSSO.Enable(ctx, &ps.EnableOrganizationSSORequest{Organization: org})
+			sso, err := client.OrganizationSSO.Enable(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}
 			end()
 
-			if sso.DomainVerificationURL != nil && *sso.DomainVerificationURL != "" {
-				if ch.Printer.Format() == printer.Human {
-					ch.Printer.Printf("SSO is enabled for %s.\n", printer.BoldBlue(org))
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("SSO is enabled for %s.\n", printer.BoldBlue(org))
+				if sso.DomainVerificationURL != nil && *sso.DomainVerificationURL != "" {
 					return printSSOPortal(ch, *sso.DomainVerificationURL, "verify an email domain")
 				}
-				_ = openSSOBrowser(runtime.GOOS, *sso.DomainVerificationURL)
-			} else if ch.Printer.Format() == printer.Human {
-				ch.Printer.Printf("SSO is enabled for %s.\n", printer.BoldBlue(org))
 				return nil
 			}
 
@@ -213,7 +204,6 @@ func SSODisableCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Disable organization SSO",
-		Long:  "Disable SSO and directory sync for the organization.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -233,7 +223,7 @@ func SSODisableCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Disabling SSO for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			sso, err := client.OrganizationSSO.Disable(ctx, &ps.DisableOrganizationSSORequest{Organization: org})
+			sso, err := client.OrganizationSSO.Disable(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}
@@ -270,7 +260,7 @@ func SSOConfigureCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating an SSO configuration URL for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			portal, err := client.OrganizationSSO.Configure(ctx, &ps.ConfigureOrganizationSSORequest{Organization: org})
+			portal, err := client.OrganizationSSO.Configure(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}

--- a/internal/cmd/org/sso.go
+++ b/internal/cmd/org/sso.go
@@ -97,7 +97,7 @@ func ssoResourceNextSteps(org string, sso *ps.OrganizationSSO) []string {
 		return []string{jsonSSOCmd(org, "enable")}
 	}
 	if !sso.HasVerifiedDomain {
-		return []string{jsonSSOCmd(org, "domain verify")}
+		return []string{jsonSSOCmd(org, "domain verify") + " --wait"}
 	}
 	if !sso.Configured {
 		return []string{jsonSSOCmd(org, "configure")}
@@ -123,7 +123,8 @@ func ssoPortalNextSteps(org, kind string, browserOpened bool) []string {
 	case "directory":
 		steps = append(steps, jsonOrgUpdateCmd(org, "--idp-managed-roles=true"))
 	case "verify":
-		steps = append(steps, jsonSSOCmd(org, "configure"))
+		steps = append(steps, jsonSSOCmd(org, "domain list"))
+		steps = append(steps, jsonSSODomainShow(org, "<domain-id>"))
 	}
 	return steps
 }
@@ -143,28 +144,53 @@ type organizationDomain struct {
 	Domain string `header:"domain" json:"domain"`
 	State  string `header:"state" json:"state"`
 
-	orig *ps.OrganizationDomain
+	nextSteps []string
+	orig      *ps.OrganizationDomain
 }
 
 func (d *organizationDomain) MarshalJSON() ([]byte, error) {
-	return json.MarshalIndent(d.orig, "", "  ")
+	type payload struct {
+		*ps.OrganizationDomain
+		NextSteps []string `json:"next_steps"`
+	}
+	return json.MarshalIndent(payload{OrganizationDomain: d.orig, NextSteps: d.nextSteps}, "", "  ")
 }
 
 func (d *organizationDomain) MarshalCSVValue() interface{} {
 	return []*organizationDomain{d}
 }
 
-func toOrganizationDomains(domains []*ps.OrganizationDomain) []*organizationDomain {
+func toOrganizationDomain(org string, domain *ps.OrganizationDomain) *organizationDomain {
+	return &organizationDomain{
+		ID:        domain.ID,
+		Domain:    domain.Domain,
+		State:     domain.State,
+		nextSteps: domainNextSteps(org, domain),
+		orig:      domain,
+	}
+}
+
+func toOrganizationDomains(org string, domains []*ps.OrganizationDomain) []*organizationDomain {
 	out := make([]*organizationDomain, 0, len(domains))
 	for _, domain := range domains {
-		out = append(out, &organizationDomain{
-			ID:     domain.ID,
-			Domain: domain.Domain,
-			State:  domain.State,
-			orig:   domain,
-		})
+		out = append(out, toOrganizationDomain(org, domain))
 	}
 	return out
+}
+
+func jsonSSODomainShow(org, domainID string) string {
+	return fmt.Sprintf("pscale org sso domain show %s --org %s --format json", domainID, org)
+}
+
+func domainNextSteps(org string, domain *ps.OrganizationDomain) []string {
+	switch domain.State {
+	case "verified":
+		return []string{jsonSSOCmd(org, "configure")}
+	case "failed":
+		return []string{jsonSSOCmd(org, "domain verify") + " --wait"}
+	default:
+		return []string{jsonSSODomainShow(org, domain.ID)}
+	}
 }
 
 func handleSSOError(org string, err error) error {

--- a/internal/cmd/org/sso_directory.go
+++ b/internal/cmd/org/sso_directory.go
@@ -1,0 +1,97 @@
+package org
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func SSODirectoryCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "directory <command>",
+		Short: "Enable or disable directory sync",
+	}
+
+	cmd.AddCommand(SSODirectoryEnableCmd(ch))
+	cmd.AddCommand(SSODirectoryDisableCmd(ch))
+	return cmd
+}
+
+func SSODirectoryEnableCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Open the directory sync setup portal",
+		Long:  "Return a URL for configuring directory sync. Requires SSO to be enabled.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating a directory sync URL for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			portal, err := client.OrganizationSSO.EnableDirectory(ctx, &ps.EnableOrganizationSSODirectoryRequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			return printSSOPortal(ch, portal.PortalURL, "configure directory sync")
+		},
+	}
+
+	return cmd
+}
+
+func SSODirectoryDisableCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "disable",
+		Short: "Disable directory sync",
+		Long:  "Disable directory sync for the organization. Non-admin directory members are removed.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			if !force {
+				if err := ch.Printer.ConfirmCommand(org, "disable directory sync", "disabling directory sync"); err != nil {
+					return err
+				}
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Disabling directory sync for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			sso, err := client.OrganizationSSO.DisableDirectory(ctx, &ps.DisableOrganizationSSODirectoryRequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Directory sync is disabled for %s.\n", printer.BoldBlue(org))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Disable directory sync without confirmation")
+	return cmd
+}

--- a/internal/cmd/org/sso_directory.go
+++ b/internal/cmd/org/sso_directory.go
@@ -24,7 +24,6 @@ func SSODirectoryEnableCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Open the directory sync setup portal",
-		Long:  "Return a URL for configuring directory sync. Requires SSO to be enabled.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -38,7 +37,7 @@ func SSODirectoryEnableCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating a directory sync URL for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			portal, err := client.OrganizationSSO.EnableDirectory(ctx, &ps.EnableOrganizationSSODirectoryRequest{Organization: org})
+			portal, err := client.OrganizationSSO.EnableDirectory(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}
@@ -77,7 +76,7 @@ func SSODirectoryDisableCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Disabling directory sync for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			sso, err := client.OrganizationSSO.DisableDirectory(ctx, &ps.DisableOrganizationSSODirectoryRequest{Organization: org})
+			sso, err := client.OrganizationSSO.DisableDirectory(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}

--- a/internal/cmd/org/sso_directory.go
+++ b/internal/cmd/org/sso_directory.go
@@ -43,7 +43,7 @@ func SSODirectoryEnableCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			return printSSOPortal(ch, portal.PortalURL, "configure directory sync")
+			return printSSOPortal(ch, portal.PortalURL, "directory", "configure directory sync")
 		},
 	}
 
@@ -84,10 +84,11 @@ func SSODirectoryDisableCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Directory sync is disabled for %s.\n", printer.BoldBlue(org))
+				printHumanNextSteps(ch, ssoResourceNextSteps(org, sso))
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toOrganizationSSO(sso))
+			return ch.Printer.PrintResource(toOrganizationSSO(org, sso))
 		},
 	}
 

--- a/internal/cmd/org/sso_domain.go
+++ b/internal/cmd/org/sso_domain.go
@@ -1,0 +1,149 @@
+package org
+
+import (
+	"fmt"
+
+	"github.com/planetscale/cli/internal/cmdutil"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+	"github.com/spf13/cobra"
+)
+
+func SSODomainCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "domain <command>",
+		Short: "List, verify, and delete SSO email domains",
+	}
+
+	cmd.AddCommand(SSODomainListCmd(ch))
+	cmd.AddCommand(SSODomainVerifyCmd(ch))
+	cmd.AddCommand(SSODomainDeleteCmd(ch))
+	return cmd
+}
+
+func SSODomainListCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List SSO email domains",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching SSO domains for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			domains, err := client.OrganizationSSO.ListDomains(ctx, &ps.ListOrganizationSSODomainsRequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			if len(domains) == 0 && ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("No SSO domains in %s.\n", printer.BoldBlue(org))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(toOrganizationDomains(domains))
+		},
+	}
+
+	return cmd
+}
+
+func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Open the domain verification portal",
+		Long:  "Enable SSO if needed and return a URL for verifying an email domain.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating a domain verification URL for %s...", printer.BoldBlue(org)))
+			defer end()
+
+			portal, err := client.OrganizationSSO.VerifyDomain(ctx, &ps.VerifyOrganizationSSODomainRequest{Organization: org})
+			if err != nil {
+				return handleSSOError(org, err)
+			}
+			end()
+
+			return printSSOPortal(ch, portal.PortalURL, "verify an email domain")
+		},
+	}
+
+	return cmd
+}
+
+func SSODomainDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <domain-id>",
+		Short:   "Delete an SSO email domain",
+		Aliases: []string{"rm"},
+		Args:    cmdutil.RequiredArgs("domain-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+			domainID := args[0]
+
+			if !force {
+				if err := ch.Printer.ConfirmCommand(domainID, "delete SSO domain", "deletion of SSO domain"); err != nil {
+					return err
+				}
+			}
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting SSO domain %s from %s...", printer.BoldBlue(domainID), printer.BoldBlue(org)))
+			defer end()
+
+			err = client.OrganizationSSO.DeleteDomain(ctx, &ps.DeleteOrganizationSSODomainRequest{
+				Organization: org,
+				DomainID:     domainID,
+			})
+			if err != nil {
+				switch cmdutil.ErrCode(err) {
+				case ps.ErrNotFound:
+					return fmt.Errorf("SSO domain %s does not exist in organization %s",
+						printer.BoldBlue(domainID), printer.BoldBlue(org))
+				default:
+					return cmdutil.HandleError(err)
+				}
+			}
+			end()
+
+			if ch.Printer.Format() == printer.Human {
+				ch.Printer.Printf("Deleted SSO domain %s from %s.\n",
+					printer.BoldBlue(domainID), printer.BoldBlue(org))
+				return nil
+			}
+
+			return ch.Printer.PrintResource(map[string]string{
+				"result": "domain deleted",
+				"org":    org,
+				"id":     domainID,
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&force, "force", false, "Delete the domain without confirmation")
+	return cmd
+}

--- a/internal/cmd/org/sso_domain.go
+++ b/internal/cmd/org/sso_domain.go
@@ -47,6 +47,7 @@ func SSODomainListCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if len(domains) == 0 && ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("No SSO domains in %s.\n", printer.BoldBlue(org))
+				printHumanNextSteps(ch, []string{jsonSSOCmd(org, "domain verify")})
 				return nil
 			}
 
@@ -80,7 +81,7 @@ func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			return printSSOPortal(ch, portal.PortalURL, "verify an email domain")
+			return printSSOPortal(ch, portal.PortalURL, "verify", "verify an email domain")
 		},
 	}
 
@@ -132,13 +133,15 @@ func SSODomainDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			if ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("Deleted SSO domain %s from %s.\n",
 					printer.BoldBlue(domainID), printer.BoldBlue(org))
+				printHumanNextSteps(ch, []string{jsonSSOCmd(org, "domain list"), jsonSSOCmd(org, "show")})
 				return nil
 			}
 
-			return ch.Printer.PrintResource(map[string]string{
-				"result": "domain deleted",
-				"org":    org,
-				"id":     domainID,
+			return ch.Printer.PrintResource(&ssoDomainDeleted{
+				Result:    "domain deleted",
+				Org:       org,
+				ID:        domainID,
+				NextSteps: []string{jsonSSOCmd(org, "domain list"), jsonSSOCmd(org, "show")},
 			})
 		},
 	}

--- a/internal/cmd/org/sso_domain.go
+++ b/internal/cmd/org/sso_domain.go
@@ -1,7 +1,12 @@
 package org
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"runtime"
+	"time"
 
 	"github.com/planetscale/cli/internal/cmdutil"
 	ps "github.com/planetscale/cli/internal/planetscale"
@@ -9,13 +14,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var ssoDomainPollInterval = 2 * time.Second
+
 func SSODomainCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "domain <command>",
-		Short: "List, verify, and delete SSO email domains",
+		Short: "List, show, verify, and delete SSO email domains",
 	}
 
 	cmd.AddCommand(SSODomainListCmd(ch))
+	cmd.AddCommand(SSODomainShowCmd(ch))
 	cmd.AddCommand(SSODomainVerifyCmd(ch))
 	cmd.AddCommand(SSODomainDeleteCmd(ch))
 	return cmd
@@ -47,11 +55,45 @@ func SSODomainListCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			if len(domains) == 0 && ch.Printer.Format() == printer.Human {
 				ch.Printer.Printf("No SSO domains in %s.\n", printer.BoldBlue(org))
-				printHumanNextSteps(ch, []string{jsonSSOCmd(org, "domain verify")})
+				printHumanNextSteps(ch, []string{jsonSSOCmd(org, "domain verify") + " --wait"})
 				return nil
 			}
 
-			return ch.Printer.PrintResource(toOrganizationDomains(domains))
+			return ch.Printer.PrintResource(toOrganizationDomains(org, domains))
+		},
+	}
+
+	return cmd
+}
+
+func SSODomainShowCmd(ch *cmdutil.Helper) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <domain-id>",
+		Short: "Show an SSO email domain",
+		Args:  cmdutil.RequiredArgs("domain-id"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			org := ch.Config.Organization
+			domainID := args[0]
+
+			client, err := ch.Client()
+			if err != nil {
+				return err
+			}
+
+			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching SSO domain %s...", printer.BoldBlue(domainID)))
+			defer end()
+
+			domain, err := client.OrganizationSSO.GetDomain(ctx, &ps.OrganizationSSODomainRequest{
+				Organization: org,
+				DomainID:     domainID,
+			})
+			if err != nil {
+				return handleSSODomainError(org, domainID, err)
+			}
+			end()
+
+			return printSSODomain(ch, org, domain)
 		},
 	}
 
@@ -59,6 +101,11 @@ func SSODomainListCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
+	var flags struct {
+		wait        bool
+		waitTimeout time.Duration
+	}
+
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Open the domain verification portal",
@@ -72,8 +119,16 @@ func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
+			var existing []*ps.OrganizationDomain
+			if flags.wait {
+				existing, err = client.OrganizationSSO.ListDomains(ctx, &ps.OrganizationSSORequest{Organization: org})
+				if err != nil {
+					return handleSSOError(org, err)
+				}
+			}
+
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating a domain verification URL for %s...", printer.BoldBlue(org)))
-			defer end()
+			defer func() { end() }()
 
 			portal, err := client.OrganizationSSO.VerifyDomain(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
@@ -81,10 +136,28 @@ func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 			end()
 
-			return printSSOPortal(ch, portal.PortalURL, "verify", "verify an email domain")
+			if !flags.wait {
+				return printSSOPortal(ch, portal.PortalURL, "verify", "verify an email domain")
+			}
+
+			if err := printSSOPortalPending(cmd, ch, portal.PortalURL, "verify an email domain"); err != nil {
+				return err
+			}
+
+			end = ch.Printer.PrintProgress(fmt.Sprintf("Waiting for an SSO domain to verify in %s...", printer.BoldBlue(org)))
+			waitCtx, cancel := context.WithTimeout(ctx, flags.waitTimeout)
+			defer cancel()
+			domain, err := waitForSSODomainVerification(waitCtx, client, org, existing)
+			if err != nil {
+				return err
+			}
+
+			return printSSODomain(ch, org, domain)
 		},
 	}
 
+	cmd.Flags().BoolVar(&flags.wait, "wait", false, "After opening the portal, wait until a domain is verified")
+	cmd.Flags().DurationVar(&flags.waitTimeout, "wait-timeout", 10*time.Minute, "Maximum time to wait with --wait")
 	return cmd
 }
 
@@ -115,18 +188,12 @@ func SSODomainDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Deleting SSO domain %s from %s...", printer.BoldBlue(domainID), printer.BoldBlue(org)))
 			defer end()
 
-			err = client.OrganizationSSO.DeleteDomain(ctx, &ps.DeleteOrganizationSSODomainRequest{
+			err = client.OrganizationSSO.DeleteDomain(ctx, &ps.OrganizationSSODomainRequest{
 				Organization: org,
 				DomainID:     domainID,
 			})
 			if err != nil {
-				switch cmdutil.ErrCode(err) {
-				case ps.ErrNotFound:
-					return fmt.Errorf("SSO domain %s does not exist in organization %s",
-						printer.BoldBlue(domainID), printer.BoldBlue(org))
-				default:
-					return cmdutil.HandleError(err)
-				}
+				return handleSSODomainError(org, domainID, err)
 			}
 			end()
 
@@ -148,4 +215,143 @@ func SSODomainDeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	cmd.Flags().BoolVar(&force, "force", false, "Delete the domain without confirmation")
 	return cmd
+}
+
+func printSSODomain(ch *cmdutil.Helper, org string, domain *ps.OrganizationDomain) error {
+	return ch.Printer.PrintResource(toOrganizationDomain(org, domain))
+}
+
+func printSSOPortalPending(cmd *cobra.Command, ch *cmdutil.Helper, url, action string) error {
+	if url == "" {
+		return fmt.Errorf("no %s URL was returned", action)
+	}
+
+	browserOpened := openSSOBrowser(runtime.GOOS, url) == nil
+	if ch.Printer.Format() == printer.JSON {
+		pending := &ssoPortal{
+			PortalURL:     url,
+			BrowserOpened: browserOpened,
+			NextSteps:     ssoPortalNextSteps(ch.Config.Organization, "verify", browserOpened),
+		}
+		return json.NewEncoder(cmd.ErrOrStderr()).Encode(pending)
+	}
+
+	if browserOpened {
+		ch.Printer.Printf("Opened the %s URL in your browser.\n", action)
+		ch.Printer.Printf("%s\n", printer.BoldBlue(url))
+	} else {
+		ch.Printer.Printf("Open this URL to %s: %s\n", action, printer.BoldBlue(url))
+	}
+	return nil
+}
+
+func waitUntilSSODomainReady(ctx context.Context, client *ps.Client, org, domainID string) (*ps.OrganizationDomain, error) {
+	ticker := time.NewTicker(ssoDomainPollInterval)
+	defer ticker.Stop()
+
+	for {
+		domain, err := client.OrganizationSSO.GetDomain(ctx, &ps.OrganizationSSODomainRequest{
+			Organization: org,
+			DomainID:     domainID,
+		})
+		if err != nil {
+			if timedOut(err, ctx) {
+				return nil, fmt.Errorf("timed out waiting for SSO domain %s", domainID)
+			}
+			if !retryableSSOPollError(err) {
+				return nil, handleSSODomainError(org, domainID, err)
+			}
+		} else {
+			switch domain.State {
+			case "verified":
+				return domain, nil
+			case "failed":
+				return domain, ssoDomainFailedError(domain)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for SSO domain %s", domainID)
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForSSODomainVerification(ctx context.Context, client *ps.Client, org string, existing []*ps.OrganizationDomain) (*ps.OrganizationDomain, error) {
+	ticker := time.NewTicker(ssoDomainPollInterval)
+	defer ticker.Stop()
+
+	known := make(map[string]struct{}, len(existing))
+	for _, domain := range existing {
+		known[domain.ID] = struct{}{}
+	}
+
+	current := existing
+	for {
+		if domain := latestNewDomain(known, current); domain != nil {
+			return waitUntilSSODomainReady(ctx, client, org, domain.ID)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for an SSO domain in %s", org)
+		case <-ticker.C:
+		}
+
+		domains, err := client.OrganizationSSO.ListDomains(ctx, &ps.OrganizationSSORequest{Organization: org})
+		if err != nil {
+			if timedOut(err, ctx) {
+				return nil, fmt.Errorf("timed out waiting for an SSO domain in %s", org)
+			}
+			if !retryableSSOPollError(err) {
+				return nil, handleSSOError(org, err)
+			}
+			continue
+		}
+		current = domains
+	}
+}
+
+func timedOut(err error, ctx context.Context) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil
+}
+
+func retryableSSOPollError(err error) bool {
+	switch cmdutil.ErrCode(err) {
+	case ps.ErrPermission, ps.ErrInvalid, ps.ErrResponseMalformed:
+		return false
+	default:
+		return true
+	}
+}
+
+func latestNewDomain(known map[string]struct{}, current []*ps.OrganizationDomain) *ps.OrganizationDomain {
+	var latest *ps.OrganizationDomain
+	for _, domain := range current {
+		if _, ok := known[domain.ID]; ok {
+			continue
+		}
+		if latest == nil || domain.CreatedAt.After(latest.CreatedAt) {
+			latest = domain
+		}
+	}
+	return latest
+}
+
+func ssoDomainFailedError(domain *ps.OrganizationDomain) error {
+	if domain.FailureReason != nil && *domain.FailureReason != "" {
+		return fmt.Errorf("SSO domain %s failed: %s", domain.ID, *domain.FailureReason)
+	}
+	return fmt.Errorf("SSO domain %s failed verification", domain.ID)
+}
+
+func handleSSODomainError(org, domainID string, err error) error {
+	switch cmdutil.ErrCode(err) {
+	case ps.ErrNotFound:
+		return fmt.Errorf("SSO domain %s does not exist in organization %s",
+			printer.BoldBlue(domainID), printer.BoldBlue(org))
+	default:
+		return cmdutil.HandleError(err)
+	}
 }

--- a/internal/cmd/org/sso_domain.go
+++ b/internal/cmd/org/sso_domain.go
@@ -151,6 +151,7 @@ func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			end()
 
 			return printSSODomain(ch, org, domain)
 		},

--- a/internal/cmd/org/sso_domain.go
+++ b/internal/cmd/org/sso_domain.go
@@ -39,7 +39,7 @@ func SSODomainListCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Fetching SSO domains for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			domains, err := client.OrganizationSSO.ListDomains(ctx, &ps.ListOrganizationSSODomainsRequest{Organization: org})
+			domains, err := client.OrganizationSSO.ListDomains(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}
@@ -61,7 +61,6 @@ func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Open the domain verification portal",
-		Long:  "Enable SSO if needed and return a URL for verifying an email domain.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -75,7 +74,7 @@ func SSODomainVerifyCmd(ch *cmdutil.Helper) *cobra.Command {
 			end := ch.Printer.PrintProgress(fmt.Sprintf("Creating a domain verification URL for %s...", printer.BoldBlue(org)))
 			defer end()
 
-			portal, err := client.OrganizationSSO.VerifyDomain(ctx, &ps.VerifyOrganizationSSODomainRequest{Organization: org})
+			portal, err := client.OrganizationSSO.VerifyDomain(ctx, &ps.OrganizationSSORequest{Organization: org})
 			if err != nil {
 				return handleSSOError(org, err)
 			}

--- a/internal/cmd/org/sso_test.go
+++ b/internal/cmd/org/sso_test.go
@@ -42,7 +42,7 @@ func TestOrg_SSOShowCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		GetFn: func(ctx context.Context, req *ps.GetOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+		GetFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 			c.Assert(req.Organization, qt.Equals, "planetscale")
 			return testSSO(), nil
 		},
@@ -68,9 +68,8 @@ func TestOrg_SSOEnableCmd(t *testing.T) {
 
 	oldOpen := openSSOBrowser
 	c.Cleanup(func() { openSSOBrowser = oldOpen })
-	var opened string
 	openSSOBrowser = func(_ string, url string) error {
-		opened = url
+		t.Fatalf("unexpected browser open in JSON mode: %s", url)
 		return nil
 	}
 
@@ -80,7 +79,7 @@ func TestOrg_SSOEnableCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		EnableFn: func(ctx context.Context, req *ps.EnableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+		EnableFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 			c.Assert(req.Organization, qt.Equals, "planetscale")
 			return testSSO(), nil
 		},
@@ -97,7 +96,6 @@ func TestOrg_SSOEnableCmd(t *testing.T) {
 	cmd := SSOEnableCmd(ch)
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.EnableFnInvoked, qt.IsTrue)
-	c.Assert(opened, qt.Equals, "https://portal.example/verify")
 	c.Assert(buf.String(), qt.Contains, "domain_verification_url")
 }
 
@@ -110,7 +108,7 @@ func TestOrg_SSODisableCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		DisableFn: func(ctx context.Context, req *ps.DisableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+		DisableFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 			c.Assert(req.Organization, qt.Equals, "planetscale")
 			sso := testSSO()
 			sso.Enabled = false
@@ -170,7 +168,7 @@ func TestOrg_SSOConfigureCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		ConfigureFn: func(ctx context.Context, req *ps.ConfigureOrganizationSSORequest) (*ps.SSOPortal, error) {
+		ConfigureFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
 			c.Assert(req.Organization, qt.Equals, "planetscale")
 			return &ps.SSOPortal{PortalURL: "https://portal.example/sso"}, nil
 		},
@@ -205,7 +203,7 @@ func TestOrg_SSODirectoryEnableCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		EnableDirectoryFn: func(ctx context.Context, req *ps.EnableOrganizationSSODirectoryRequest) (*ps.SSOPortal, error) {
+		EnableDirectoryFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
 			return &ps.SSOPortal{PortalURL: "https://portal.example/dsync"}, nil
 		},
 	}
@@ -233,7 +231,7 @@ func TestOrg_SSODirectoryDisableCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		DisableDirectoryFn: func(ctx context.Context, req *ps.DisableOrganizationSSODirectoryRequest) (*ps.OrganizationSSO, error) {
+		DisableDirectoryFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 			sso := testSSO()
 			sso.Directory = false
 			return sso, nil
@@ -264,7 +262,7 @@ func TestOrg_SSODomainListCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		ListDomainsFn: func(ctx context.Context, req *ps.ListOrganizationSSODomainsRequest) ([]*ps.OrganizationDomain, error) {
+		ListDomainsFn: func(ctx context.Context, req *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error) {
 			return testSSO().Domains, nil
 		},
 	}
@@ -281,6 +279,39 @@ func TestOrg_SSODomainListCmd(t *testing.T) {
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.ListDomainsFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.Contains, "example.com")
+}
+
+func TestOrg_SSODomainVerifyCmd(t *testing.T) {
+	c := qt.New(t)
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	openSSOBrowser = func(_ string, url string) error { return nil }
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		VerifyDomainFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			return &ps.SSOPortal{PortalURL: "https://portal.example/verify"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainVerifyCmd(ch)
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.VerifyDomainFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"portal_url": "https://portal.example/verify"`)
 }
 
 func TestOrg_SSODomainDeleteCmd(t *testing.T) {

--- a/internal/cmd/org/sso_test.go
+++ b/internal/cmd/org/sso_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 	"github.com/planetscale/cli/internal/cmdutil"
@@ -314,7 +315,243 @@ func TestOrg_SSODomainVerifyCmd(t *testing.T) {
 	cmd := SSODomainVerifyCmd(ch)
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.VerifyDomainFnInvoked, qt.IsTrue)
+	c.Assert(svc.ListDomainsFnInvoked, qt.IsFalse)
 	c.Assert(buf.String(), qt.Contains, `"portal_url": "https://portal.example/verify"`)
+	c.Assert(buf.String(), qt.Contains, "domain show <domain-id>")
+}
+
+func TestOrg_SSODomainShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		GetDomainFn: func(ctx context.Context, req *ps.OrganizationSSODomainRequest) (*ps.OrganizationDomain, error) {
+			c.Assert(req.DomainID, qt.Equals, "dom_1")
+			return &ps.OrganizationDomain{ID: "dom_1", Domain: "example.com", State: "pending"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainShowCmd(ch)
+	cmd.SetArgs([]string{"dom_1"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetDomainFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"state": "pending"`)
+	c.Assert(buf.String(), qt.Contains, "domain show dom_1")
+}
+
+func TestOrg_SSODomainVerifyCmdWait(t *testing.T) {
+	c := qt.New(t)
+
+	oldInterval := ssoDomainPollInterval
+	ssoDomainPollInterval = time.Millisecond
+	c.Cleanup(func() { ssoDomainPollInterval = oldInterval })
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	openSSOBrowser = func(_ string, url string) error { return nil }
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	listCalls := 0
+	svc := &mock.OrganizationSSOService{
+		ListDomainsFn: func(ctx context.Context, req *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error) {
+			listCalls++
+			if listCalls == 1 {
+				return nil, nil
+			}
+			return []*ps.OrganizationDomain{{ID: "dom_1", Domain: "example.com", State: "pending"}}, nil
+		},
+		VerifyDomainFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
+			return &ps.SSOPortal{PortalURL: "https://portal.example/verify"}, nil
+		},
+		GetDomainFn: func(ctx context.Context, req *ps.OrganizationSSODomainRequest) (*ps.OrganizationDomain, error) {
+			c.Assert(req.DomainID, qt.Equals, "dom_1")
+			return &ps.OrganizationDomain{ID: "dom_1", Domain: "example.com", State: "verified"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainVerifyCmd(ch)
+	cmd.SetArgs([]string{"--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.VerifyDomainFnInvoked, qt.IsTrue)
+	c.Assert(svc.GetDomainFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"state": "verified"`)
+	c.Assert(buf.String(), qt.Contains, "example.com")
+}
+
+func TestOrg_SSODomainVerifyCmdWaitUsesLatestNewDomain(t *testing.T) {
+	c := qt.New(t)
+
+	oldInterval := ssoDomainPollInterval
+	ssoDomainPollInterval = time.Millisecond
+	c.Cleanup(func() { ssoDomainPollInterval = oldInterval })
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	openSSOBrowser = func(_ string, url string) error { return nil }
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	old := &ps.OrganizationDomain{ID: "dom_old", Domain: "old.com", State: "pending"}
+	newer := &ps.OrganizationDomain{
+		ID:        "dom_new",
+		Domain:    "new.com",
+		State:     "pending",
+		CreatedAt: time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC),
+	}
+	oldestNew := &ps.OrganizationDomain{
+		ID:        "dom_mid",
+		Domain:    "mid.com",
+		State:     "pending",
+		CreatedAt: time.Date(2026, 8, 28, 11, 0, 0, 0, time.UTC),
+	}
+
+	listCalls := 0
+	svc := &mock.OrganizationSSOService{
+		ListDomainsFn: func(ctx context.Context, req *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error) {
+			listCalls++
+			if listCalls == 1 {
+				return []*ps.OrganizationDomain{old}, nil
+			}
+			return []*ps.OrganizationDomain{old, oldestNew, newer}, nil
+		},
+		VerifyDomainFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
+			return &ps.SSOPortal{PortalURL: "https://portal.example/verify"}, nil
+		},
+		GetDomainFn: func(ctx context.Context, req *ps.OrganizationSSODomainRequest) (*ps.OrganizationDomain, error) {
+			c.Assert(req.DomainID, qt.Equals, "dom_new")
+			return &ps.OrganizationDomain{ID: "dom_new", Domain: "new.com", State: "verified"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainVerifyCmd(ch)
+	cmd.SetArgs([]string{"--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(buf.String(), qt.Contains, "new.com")
+}
+
+func TestOrg_SSODomainVerifyCmdWaitPollsShowForNewID(t *testing.T) {
+	c := qt.New(t)
+
+	oldInterval := ssoDomainPollInterval
+	ssoDomainPollInterval = time.Millisecond
+	c.Cleanup(func() { ssoDomainPollInterval = oldInterval })
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	openSSOBrowser = func(_ string, url string) error { return nil }
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	listCalls := 0
+	svc := &mock.OrganizationSSOService{
+		ListDomainsFn: func(ctx context.Context, req *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error) {
+			listCalls++
+			if listCalls == 1 {
+				return nil, nil
+			}
+			return []*ps.OrganizationDomain{{ID: "dom_1", Domain: "example.com", State: "bogus"}}, nil
+		},
+		VerifyDomainFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
+			return &ps.SSOPortal{PortalURL: "https://portal.example/verify"}, nil
+		},
+		GetDomainFn: func(ctx context.Context, req *ps.OrganizationSSODomainRequest) (*ps.OrganizationDomain, error) {
+			c.Assert(req.DomainID, qt.Equals, "dom_1")
+			return &ps.OrganizationDomain{ID: "dom_1", Domain: "example.com", State: "verified"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainVerifyCmd(ch)
+	cmd.SetArgs([]string{"--wait"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetDomainFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"state": "verified"`)
+}
+
+func TestOrg_SSODomainVerifyCmdWaitStopsOnPermissionError(t *testing.T) {
+	c := qt.New(t)
+
+	oldInterval := ssoDomainPollInterval
+	ssoDomainPollInterval = time.Millisecond
+	c.Cleanup(func() { ssoDomainPollInterval = oldInterval })
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	openSSOBrowser = func(_ string, url string) error { return nil }
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	listCalls := 0
+	svc := &mock.OrganizationSSOService{
+		ListDomainsFn: func(ctx context.Context, req *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error) {
+			listCalls++
+			if listCalls == 1 {
+				return nil, nil
+			}
+			return nil, &ps.Error{Code: ps.ErrPermission}
+		},
+		VerifyDomainFn: func(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
+			return &ps.SSOPortal{PortalURL: "https://portal.example/verify"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainVerifyCmd(ch)
+	cmd.SetArgs([]string{"--wait", "--wait-timeout", "2s"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, ".*")
 }
 
 func TestOrg_SSODomainDeleteCmd(t *testing.T) {
@@ -326,7 +563,7 @@ func TestOrg_SSODomainDeleteCmd(t *testing.T) {
 	p.SetResourceOutput(&buf)
 
 	svc := &mock.OrganizationSSOService{
-		DeleteDomainFn: func(ctx context.Context, req *ps.DeleteOrganizationSSODomainRequest) error {
+		DeleteDomainFn: func(ctx context.Context, req *ps.OrganizationSSODomainRequest) error {
 			c.Assert(req.DomainID, qt.Equals, "dom_1")
 			return nil
 		},
@@ -356,7 +593,7 @@ func TestSSOResourceNextSteps(t *testing.T) {
 		"pscale org sso enable --org acme --format json",
 	})
 	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{Enabled: true}), qt.DeepEquals, []string{
-		"pscale org sso domain verify --org acme --format json",
+		"pscale org sso domain verify --org acme --format json --wait",
 	})
 	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{Enabled: true, HasVerifiedDomain: true}), qt.DeepEquals, []string{
 		"pscale org sso configure --org acme --format json",

--- a/internal/cmd/org/sso_test.go
+++ b/internal/cmd/org/sso_test.go
@@ -61,6 +61,7 @@ func TestOrg_SSOShowCmd(t *testing.T) {
 	c.Assert(svc.GetFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.Contains, `"enabled": true`)
 	c.Assert(buf.String(), qt.Contains, "example.com")
+	c.Assert(buf.String(), qt.Contains, "pscale org sso configure --org planetscale --format json")
 }
 
 func TestOrg_SSOEnableCmd(t *testing.T) {
@@ -188,6 +189,7 @@ func TestOrg_SSOConfigureCmd(t *testing.T) {
 	c.Assert(opened, qt.Equals, "https://portal.example/sso")
 	c.Assert(buf.String(), qt.Contains, `"portal_url": "https://portal.example/sso"`)
 	c.Assert(buf.String(), qt.Contains, `"browser_opened": true`)
+	c.Assert(buf.String(), qt.Contains, "--idp-sso-managed-roles=true")
 }
 
 func TestOrg_SSODirectoryEnableCmd(t *testing.T) {
@@ -220,6 +222,7 @@ func TestOrg_SSODirectoryEnableCmd(t *testing.T) {
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.EnableDirectoryFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.Contains, `"browser_opened": false`)
+	c.Assert(buf.String(), qt.Contains, "--idp-managed-roles=true")
 }
 
 func TestOrg_SSODirectoryDisableCmd(t *testing.T) {
@@ -342,4 +345,27 @@ func TestOrg_SSODomainDeleteCmd(t *testing.T) {
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.DeleteDomainFnInvoked, qt.IsTrue)
 	c.Assert(buf.String(), qt.Contains, "domain deleted")
+	c.Assert(buf.String(), qt.Contains, "pscale org sso domain list --org planetscale --format json")
+}
+
+func TestSSOResourceNextSteps(t *testing.T) {
+	c := qt.New(t)
+	org := "acme"
+
+	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{}), qt.DeepEquals, []string{
+		"pscale org sso enable --org acme --format json",
+	})
+	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{Enabled: true}), qt.DeepEquals, []string{
+		"pscale org sso domain verify --org acme --format json",
+	})
+	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{Enabled: true, HasVerifiedDomain: true}), qt.DeepEquals, []string{
+		"pscale org sso configure --org acme --format json",
+	})
+	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{Enabled: true, HasVerifiedDomain: true, Configured: true}), qt.DeepEquals, []string{
+		"pscale org sso directory enable --org acme --format json",
+		"pscale org update --org acme --format json --idp-sso-managed-roles=true",
+	})
+	c.Assert(ssoResourceNextSteps(org, &ps.OrganizationSSO{Enabled: true, HasVerifiedDomain: true, Configured: true, Directory: true}), qt.DeepEquals, []string{
+		"pscale org update --org acme --format json --idp-managed-roles=true",
+	})
 }

--- a/internal/cmd/org/sso_test.go
+++ b/internal/cmd/org/sso_test.go
@@ -1,0 +1,314 @@
+package org
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/planetscale/cli/internal/cmdutil"
+	"github.com/planetscale/cli/internal/config"
+	"github.com/planetscale/cli/internal/mock"
+	ps "github.com/planetscale/cli/internal/planetscale"
+	"github.com/planetscale/cli/internal/printer"
+)
+
+func testSSO() *ps.OrganizationSSO {
+	url := "https://portal.example/verify"
+	return &ps.OrganizationSSO{
+		ID:                    "org_1",
+		Type:                  "OrganizationSSO",
+		Enabled:               true,
+		Configured:            false,
+		Directory:             false,
+		HasVerifiedDomain:     true,
+		DomainVerificationURL: &url,
+		Domains: []*ps.OrganizationDomain{{
+			ID:     "dom_1",
+			Type:   "OrganizationDomain",
+			Domain: "example.com",
+			State:  "verified",
+		}},
+	}
+}
+
+func TestOrg_SSOShowCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		GetFn: func(ctx context.Context, req *ps.GetOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			return testSSO(), nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSOShowCmd(ch)
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.GetFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"enabled": true`)
+	c.Assert(buf.String(), qt.Contains, "example.com")
+}
+
+func TestOrg_SSOEnableCmd(t *testing.T) {
+	c := qt.New(t)
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	var opened string
+	openSSOBrowser = func(_ string, url string) error {
+		opened = url
+		return nil
+	}
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		EnableFn: func(ctx context.Context, req *ps.EnableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			return testSSO(), nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSOEnableCmd(ch)
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.EnableFnInvoked, qt.IsTrue)
+	c.Assert(opened, qt.Equals, "https://portal.example/verify")
+	c.Assert(buf.String(), qt.Contains, "domain_verification_url")
+}
+
+func TestOrg_SSODisableCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		DisableFn: func(ctx context.Context, req *ps.DisableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			sso := testSSO()
+			sso.Enabled = false
+			sso.DomainVerificationURL = nil
+			return sso, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODisableCmd(ch)
+	cmd.SetArgs([]string{"--force"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.DisableFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"enabled": false`)
+}
+
+func TestOrg_SSODisableCmd_RequiresForce(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: &mock.OrganizationSSOService{}}, nil
+		},
+	}
+
+	cmd := SSODisableCmd(ch)
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--force")
+}
+
+func TestOrg_SSOConfigureCmd(t *testing.T) {
+	c := qt.New(t)
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	var opened string
+	openSSOBrowser = func(_ string, url string) error {
+		opened = url
+		return nil
+	}
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		ConfigureFn: func(ctx context.Context, req *ps.ConfigureOrganizationSSORequest) (*ps.SSOPortal, error) {
+			c.Assert(req.Organization, qt.Equals, "planetscale")
+			return &ps.SSOPortal{PortalURL: "https://portal.example/sso"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSOConfigureCmd(ch)
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.ConfigureFnInvoked, qt.IsTrue)
+	c.Assert(opened, qt.Equals, "https://portal.example/sso")
+	c.Assert(buf.String(), qt.Contains, `"portal_url": "https://portal.example/sso"`)
+	c.Assert(buf.String(), qt.Contains, `"browser_opened": true`)
+}
+
+func TestOrg_SSODirectoryEnableCmd(t *testing.T) {
+	c := qt.New(t)
+
+	oldOpen := openSSOBrowser
+	c.Cleanup(func() { openSSOBrowser = oldOpen })
+	openSSOBrowser = func(_ string, url string) error { return errors.New("no browser") }
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		EnableDirectoryFn: func(ctx context.Context, req *ps.EnableOrganizationSSODirectoryRequest) (*ps.SSOPortal, error) {
+			return &ps.SSOPortal{PortalURL: "https://portal.example/dsync"}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODirectoryEnableCmd(ch)
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.EnableDirectoryFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"browser_opened": false`)
+}
+
+func TestOrg_SSODirectoryDisableCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		DisableDirectoryFn: func(ctx context.Context, req *ps.DisableOrganizationSSODirectoryRequest) (*ps.OrganizationSSO, error) {
+			sso := testSSO()
+			sso.Directory = false
+			return sso, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODirectoryDisableCmd(ch)
+	cmd.SetArgs([]string{"--force"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.DisableDirectoryFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, `"directory": false`)
+}
+
+func TestOrg_SSODomainListCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		ListDomainsFn: func(ctx context.Context, req *ps.ListOrganizationSSODomainsRequest) ([]*ps.OrganizationDomain, error) {
+			return testSSO().Domains, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainListCmd(ch)
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.ListDomainsFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, "example.com")
+}
+
+func TestOrg_SSODomainDeleteCmd(t *testing.T) {
+	c := qt.New(t)
+
+	var buf bytes.Buffer
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+	p.SetResourceOutput(&buf)
+
+	svc := &mock.OrganizationSSOService{
+		DeleteDomainFn: func(ctx context.Context, req *ps.DeleteOrganizationSSODomainRequest) error {
+			c.Assert(req.DomainID, qt.Equals, "dom_1")
+			return nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{Organization: "planetscale"},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{OrganizationSSO: svc}, nil
+		},
+	}
+
+	cmd := SSODomainDeleteCmd(ch)
+	cmd.SetArgs([]string{"dom_1", "--force"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.DeleteDomainFnInvoked, qt.IsTrue)
+	c.Assert(buf.String(), qt.Contains, "domain deleted")
+}

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -35,18 +35,27 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				req.BillingEmail = &flags.billingEmail
 				changed = true
 			}
-			if cmd.Flags().Changed("idp-managed-roles") {
-				req.IDPManagedRoles = &flags.idpManagedRoles
+			directoryRoles := cmd.Flags().Changed("idp-managed-roles")
+			ssoRoles := cmd.Flags().Changed("idp-sso-managed-roles")
+			if directoryRoles || ssoRoles {
+				if directoryRoles && ssoRoles && flags.idpManagedRoles && flags.idpSSOManagedRoles {
+					return fmt.Errorf("cannot enable both --idp-managed-roles and --idp-sso-managed-roles")
+				}
+				if directoryRoles {
+					req.IDPManagedRoles = &flags.idpManagedRoles
+				}
+				if ssoRoles {
+					req.IDPSSOManagedRoles = &flags.idpSSOManagedRoles
+				}
+				// The two are mutually exclusive server-side, so enabling one turns
+				// the other off rather than leaving a stale setting behind.
+				if flags.idpManagedRoles && directoryRoles && !ssoRoles {
+					req.IDPSSOManagedRoles = boolPtr(false)
+				}
+				if flags.idpSSOManagedRoles && ssoRoles && !directoryRoles {
+					req.IDPManagedRoles = boolPtr(false)
+				}
 				changed = true
-			}
-			if cmd.Flags().Changed("idp-sso-managed-roles") {
-				req.IDPSSOManagedRoles = &flags.idpSSOManagedRoles
-				changed = true
-			}
-
-			if cmd.Flags().Changed("idp-managed-roles") && cmd.Flags().Changed("idp-sso-managed-roles") &&
-				flags.idpManagedRoles && flags.idpSSOManagedRoles {
-				return fmt.Errorf("cannot enable both --idp-managed-roles and --idp-sso-managed-roles")
 			}
 
 			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {

--- a/internal/cmd/org/update.go
+++ b/internal/cmd/org/update.go
@@ -14,10 +14,11 @@ import (
 
 func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	var flags struct {
-		billingEmail     string
-		idpManagedRoles  bool
-		spendAlert       bool
-		spendAlertAmount int64
+		billingEmail       string
+		idpManagedRoles    bool
+		idpSSOManagedRoles bool
+		spendAlert         bool
+		spendAlertAmount   int64
 	}
 
 	cmd := &cobra.Command{
@@ -38,12 +39,21 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 				req.IDPManagedRoles = &flags.idpManagedRoles
 				changed = true
 			}
+			if cmd.Flags().Changed("idp-sso-managed-roles") {
+				req.IDPSSOManagedRoles = &flags.idpSSOManagedRoles
+				changed = true
+			}
+
+			if cmd.Flags().Changed("idp-managed-roles") && cmd.Flags().Changed("idp-sso-managed-roles") &&
+				flags.idpManagedRoles && flags.idpSSOManagedRoles {
+				return fmt.Errorf("cannot enable both --idp-managed-roles and --idp-sso-managed-roles")
+			}
 
 			if cmd.Flags().Changed("spend-alert") || cmd.Flags().Changed("spend-alert-amount") {
 				changed = true
 			}
 			if !changed {
-				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
+				return fmt.Errorf("at least one of --billing-email, --idp-managed-roles, --idp-sso-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
 			}
 
 			client, err := ch.Client()
@@ -78,7 +88,8 @@ func UpdateCmd(ch *cmdutil.Helper) *cobra.Command {
 	cmd.Flags().StringVar(&ch.Config.Organization, "org", ch.Config.Organization, "The organization for the current user")
 	cmd.MarkFlagRequired("org")
 	cmd.Flags().StringVar(&flags.billingEmail, "billing-email", "", "The billing email for the organization")
-	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles")
+	cmd.Flags().BoolVar(&flags.idpManagedRoles, "idp-managed-roles", false, "Whether the identity provider manages organization roles through directory sync")
+	cmd.Flags().BoolVar(&flags.idpSSOManagedRoles, "idp-sso-managed-roles", false, "Whether the identity provider manages organization roles through SSO")
 	cmd.Flags().BoolVar(&flags.spendAlert, "spend-alert", false, "Enable or disable billing spend alerts")
 	cmd.Flags().Int64Var(&flags.spendAlertAmount, "spend-alert-amount", 0, "Monthly spend amount that triggers spend alerts")
 
@@ -140,23 +151,25 @@ func spendAlertAmount(org *ps.Organization) (int64, error) {
 }
 
 type organizationUpdate struct {
-	Name             string `header:"name" json:"name"`
-	BillingEmail     string `header:"billing_email" json:"billing_email"`
-	IDPManagedRoles  bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
-	SpendAlert       bool   `header:"spend_alert" json:"spend_alert"`
-	SpendAlertAmount string `header:"spend_alert_amount" json:"spend_alert_amount"`
+	Name               string `header:"name" json:"name"`
+	BillingEmail       string `header:"billing_email" json:"billing_email"`
+	IDPManagedRoles    bool   `header:"idp_managed_roles" json:"idp_managed_roles"`
+	IDPSSOManagedRoles bool   `header:"idp_sso_managed_roles" json:"idp_sso_managed_roles"`
+	SpendAlert         bool   `header:"spend_alert" json:"spend_alert"`
+	SpendAlertAmount   string `header:"spend_alert_amount" json:"spend_alert_amount"`
 
 	orig *ps.Organization
 }
 
 func toOrganizationUpdate(org *ps.Organization) *organizationUpdate {
 	return &organizationUpdate{
-		Name:             org.Name,
-		BillingEmail:     org.BillingEmail,
-		IDPManagedRoles:  org.IDPManagedRoles,
-		SpendAlert:       org.InvoiceBudgetAlerts,
-		SpendAlertAmount: string(org.InvoiceBudgetAmount),
-		orig:             org,
+		Name:               org.Name,
+		BillingEmail:       org.BillingEmail,
+		IDPManagedRoles:    org.IDPManagedRoles,
+		IDPSSOManagedRoles: org.IDPSSOManagedRoles,
+		SpendAlert:         org.InvoiceBudgetAlerts,
+		SpendAlertAmount:   string(org.InvoiceBudgetAmount),
+		orig:               org,
 	}
 }
 

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -151,7 +151,7 @@ func TestOrganization_UpdateCmdRequiresUpdateFlag(t *testing.T) {
 
 	cmd := UpdateCmd(ch)
 	cmd.SetArgs([]string{"--org", "planetscale"})
-	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "at least one of --billing-email, --idp-managed-roles, --idp-sso-managed-roles, --spend-alert, or --spend-alert-amount must be provided")
 }
 
 func TestOrganization_UpdateCmdRejectsAmountWithDisabledSpendAlert(t *testing.T) {
@@ -251,4 +251,32 @@ func TestOrganization_UpdateCmdHuman(t *testing.T) {
 	c.Assert(buf.String(), qt.Contains, "IDP MANAGED ROLES")
 	c.Assert(buf.String(), qt.Contains, "SPEND ALERT")
 	c.Assert(buf.String(), qt.Contains, "billing@example.com")
+}
+
+func TestOrganization_UpdateCmdIDPSSOManagedRoles(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.IDPSSOManagedRoles, qt.IsNotNil)
+			c.Assert(*req.IDPSSOManagedRoles, qt.IsTrue)
+			return &ps.Organization{Name: req.Organization, IDPSSOManagedRoles: true}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--idp-sso-managed-roles=true"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
 }

--- a/internal/cmd/org/update_test.go
+++ b/internal/cmd/org/update_test.go
@@ -263,6 +263,8 @@ func TestOrganization_UpdateCmdIDPSSOManagedRoles(t *testing.T) {
 		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
 			c.Assert(req.IDPSSOManagedRoles, qt.IsNotNil)
 			c.Assert(*req.IDPSSOManagedRoles, qt.IsTrue)
+			c.Assert(req.IDPManagedRoles, qt.IsNotNil)
+			c.Assert(*req.IDPManagedRoles, qt.IsFalse)
 			return &ps.Organization{Name: req.Organization, IDPSSOManagedRoles: true}, nil
 		},
 	}
@@ -279,4 +281,77 @@ func TestOrganization_UpdateCmdIDPSSOManagedRoles(t *testing.T) {
 	cmd.SetArgs([]string{"--org", "planetscale", "--idp-sso-managed-roles=true"})
 	c.Assert(cmd.Execute(), qt.IsNil)
 	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestOrganization_UpdateCmdIDPManagedRolesDisablesSSORoles(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.IDPManagedRoles, qt.IsNotNil)
+			c.Assert(*req.IDPManagedRoles, qt.IsTrue)
+			c.Assert(req.IDPSSOManagedRoles, qt.IsNotNil)
+			c.Assert(*req.IDPSSOManagedRoles, qt.IsFalse)
+			return &ps.Organization{Name: req.Organization, IDPManagedRoles: true}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--idp-managed-roles=true"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestOrganization_UpdateCmdDisablingRoleFlagLeavesOtherAlone(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	p := printer.NewPrinter(&format)
+
+	svc := &mock.OrganizationsService{
+		UpdateFn: func(ctx context.Context, req *ps.UpdateOrganizationRequest) (*ps.Organization, error) {
+			c.Assert(req.IDPManagedRoles, qt.IsNotNil)
+			c.Assert(*req.IDPManagedRoles, qt.IsFalse)
+			c.Assert(req.IDPSSOManagedRoles, qt.IsNil)
+			return &ps.Organization{Name: req.Organization}, nil
+		},
+	}
+
+	ch := &cmdutil.Helper{
+		Printer: p,
+		Config:  &config.Config{},
+		Client: func() (*ps.Client, error) {
+			return &ps.Client{Organizations: svc}, nil
+		},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--idp-managed-roles=false"})
+	c.Assert(cmd.Execute(), qt.IsNil)
+	c.Assert(svc.UpdateFnInvoked, qt.IsTrue)
+}
+
+func TestOrganization_UpdateCmdRejectsBothRoleFlagsEnabled(t *testing.T) {
+	c := qt.New(t)
+
+	format := printer.JSON
+	ch := &cmdutil.Helper{
+		Printer: printer.NewPrinter(&format),
+		Config:  &config.Config{},
+	}
+
+	cmd := UpdateCmd(ch)
+	cmd.SetArgs([]string{"--org", "planetscale", "--idp-managed-roles=true", "--idp-sso-managed-roles=true"})
+	c.Assert(cmd.Execute(), qt.ErrorMatches, "cannot enable both --idp-managed-roles and --idp-sso-managed-roles")
 }

--- a/internal/mock/organization_sso.go
+++ b/internal/mock/organization_sso.go
@@ -1,0 +1,81 @@
+package mock
+
+import (
+	"context"
+
+	ps "github.com/planetscale/cli/internal/planetscale"
+)
+
+type OrganizationSSOService struct {
+	GetFn        func(context.Context, *ps.GetOrganizationSSORequest) (*ps.OrganizationSSO, error)
+	GetFnInvoked bool
+
+	EnableFn        func(context.Context, *ps.EnableOrganizationSSORequest) (*ps.OrganizationSSO, error)
+	EnableFnInvoked bool
+
+	DisableFn        func(context.Context, *ps.DisableOrganizationSSORequest) (*ps.OrganizationSSO, error)
+	DisableFnInvoked bool
+
+	ConfigureFn        func(context.Context, *ps.ConfigureOrganizationSSORequest) (*ps.SSOPortal, error)
+	ConfigureFnInvoked bool
+
+	EnableDirectoryFn        func(context.Context, *ps.EnableOrganizationSSODirectoryRequest) (*ps.SSOPortal, error)
+	EnableDirectoryFnInvoked bool
+
+	DisableDirectoryFn        func(context.Context, *ps.DisableOrganizationSSODirectoryRequest) (*ps.OrganizationSSO, error)
+	DisableDirectoryFnInvoked bool
+
+	ListDomainsFn        func(context.Context, *ps.ListOrganizationSSODomainsRequest) ([]*ps.OrganizationDomain, error)
+	ListDomainsFnInvoked bool
+
+	VerifyDomainFn        func(context.Context, *ps.VerifyOrganizationSSODomainRequest) (*ps.SSOPortal, error)
+	VerifyDomainFnInvoked bool
+
+	DeleteDomainFn        func(context.Context, *ps.DeleteOrganizationSSODomainRequest) error
+	DeleteDomainFnInvoked bool
+}
+
+func (s *OrganizationSSOService) Get(ctx context.Context, req *ps.GetOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+	s.GetFnInvoked = true
+	return s.GetFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) Enable(ctx context.Context, req *ps.EnableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+	s.EnableFnInvoked = true
+	return s.EnableFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) Disable(ctx context.Context, req *ps.DisableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+	s.DisableFnInvoked = true
+	return s.DisableFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) Configure(ctx context.Context, req *ps.ConfigureOrganizationSSORequest) (*ps.SSOPortal, error) {
+	s.ConfigureFnInvoked = true
+	return s.ConfigureFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) EnableDirectory(ctx context.Context, req *ps.EnableOrganizationSSODirectoryRequest) (*ps.SSOPortal, error) {
+	s.EnableDirectoryFnInvoked = true
+	return s.EnableDirectoryFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) DisableDirectory(ctx context.Context, req *ps.DisableOrganizationSSODirectoryRequest) (*ps.OrganizationSSO, error) {
+	s.DisableDirectoryFnInvoked = true
+	return s.DisableDirectoryFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) ListDomains(ctx context.Context, req *ps.ListOrganizationSSODomainsRequest) ([]*ps.OrganizationDomain, error) {
+	s.ListDomainsFnInvoked = true
+	return s.ListDomainsFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) VerifyDomain(ctx context.Context, req *ps.VerifyOrganizationSSODomainRequest) (*ps.SSOPortal, error) {
+	s.VerifyDomainFnInvoked = true
+	return s.VerifyDomainFn(ctx, req)
+}
+
+func (s *OrganizationSSOService) DeleteDomain(ctx context.Context, req *ps.DeleteOrganizationSSODomainRequest) error {
+	s.DeleteDomainFnInvoked = true
+	return s.DeleteDomainFn(ctx, req)
+}

--- a/internal/mock/organization_sso.go
+++ b/internal/mock/organization_sso.go
@@ -28,10 +28,13 @@ type OrganizationSSOService struct {
 	ListDomainsFn        func(context.Context, *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error)
 	ListDomainsFnInvoked bool
 
+	GetDomainFn        func(context.Context, *ps.OrganizationSSODomainRequest) (*ps.OrganizationDomain, error)
+	GetDomainFnInvoked bool
+
 	VerifyDomainFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.SSOPortal, error)
 	VerifyDomainFnInvoked bool
 
-	DeleteDomainFn        func(context.Context, *ps.DeleteOrganizationSSODomainRequest) error
+	DeleteDomainFn        func(context.Context, *ps.OrganizationSSODomainRequest) error
 	DeleteDomainFnInvoked bool
 }
 
@@ -70,12 +73,17 @@ func (s *OrganizationSSOService) ListDomains(ctx context.Context, req *ps.Organi
 	return s.ListDomainsFn(ctx, req)
 }
 
+func (s *OrganizationSSOService) GetDomain(ctx context.Context, req *ps.OrganizationSSODomainRequest) (*ps.OrganizationDomain, error) {
+	s.GetDomainFnInvoked = true
+	return s.GetDomainFn(ctx, req)
+}
+
 func (s *OrganizationSSOService) VerifyDomain(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
 	s.VerifyDomainFnInvoked = true
 	return s.VerifyDomainFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) DeleteDomain(ctx context.Context, req *ps.DeleteOrganizationSSODomainRequest) error {
+func (s *OrganizationSSOService) DeleteDomain(ctx context.Context, req *ps.OrganizationSSODomainRequest) error {
 	s.DeleteDomainFnInvoked = true
 	return s.DeleteDomainFn(ctx, req)
 }

--- a/internal/mock/organization_sso.go
+++ b/internal/mock/organization_sso.go
@@ -7,70 +7,70 @@ import (
 )
 
 type OrganizationSSOService struct {
-	GetFn        func(context.Context, *ps.GetOrganizationSSORequest) (*ps.OrganizationSSO, error)
+	GetFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error)
 	GetFnInvoked bool
 
-	EnableFn        func(context.Context, *ps.EnableOrganizationSSORequest) (*ps.OrganizationSSO, error)
+	EnableFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error)
 	EnableFnInvoked bool
 
-	DisableFn        func(context.Context, *ps.DisableOrganizationSSORequest) (*ps.OrganizationSSO, error)
+	DisableFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error)
 	DisableFnInvoked bool
 
-	ConfigureFn        func(context.Context, *ps.ConfigureOrganizationSSORequest) (*ps.SSOPortal, error)
+	ConfigureFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.SSOPortal, error)
 	ConfigureFnInvoked bool
 
-	EnableDirectoryFn        func(context.Context, *ps.EnableOrganizationSSODirectoryRequest) (*ps.SSOPortal, error)
+	EnableDirectoryFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.SSOPortal, error)
 	EnableDirectoryFnInvoked bool
 
-	DisableDirectoryFn        func(context.Context, *ps.DisableOrganizationSSODirectoryRequest) (*ps.OrganizationSSO, error)
+	DisableDirectoryFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error)
 	DisableDirectoryFnInvoked bool
 
-	ListDomainsFn        func(context.Context, *ps.ListOrganizationSSODomainsRequest) ([]*ps.OrganizationDomain, error)
+	ListDomainsFn        func(context.Context, *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error)
 	ListDomainsFnInvoked bool
 
-	VerifyDomainFn        func(context.Context, *ps.VerifyOrganizationSSODomainRequest) (*ps.SSOPortal, error)
+	VerifyDomainFn        func(context.Context, *ps.OrganizationSSORequest) (*ps.SSOPortal, error)
 	VerifyDomainFnInvoked bool
 
 	DeleteDomainFn        func(context.Context, *ps.DeleteOrganizationSSODomainRequest) error
 	DeleteDomainFnInvoked bool
 }
 
-func (s *OrganizationSSOService) Get(ctx context.Context, req *ps.GetOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+func (s *OrganizationSSOService) Get(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 	s.GetFnInvoked = true
 	return s.GetFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) Enable(ctx context.Context, req *ps.EnableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+func (s *OrganizationSSOService) Enable(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 	s.EnableFnInvoked = true
 	return s.EnableFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) Disable(ctx context.Context, req *ps.DisableOrganizationSSORequest) (*ps.OrganizationSSO, error) {
+func (s *OrganizationSSOService) Disable(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 	s.DisableFnInvoked = true
 	return s.DisableFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) Configure(ctx context.Context, req *ps.ConfigureOrganizationSSORequest) (*ps.SSOPortal, error) {
+func (s *OrganizationSSOService) Configure(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
 	s.ConfigureFnInvoked = true
 	return s.ConfigureFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) EnableDirectory(ctx context.Context, req *ps.EnableOrganizationSSODirectoryRequest) (*ps.SSOPortal, error) {
+func (s *OrganizationSSOService) EnableDirectory(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
 	s.EnableDirectoryFnInvoked = true
 	return s.EnableDirectoryFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) DisableDirectory(ctx context.Context, req *ps.DisableOrganizationSSODirectoryRequest) (*ps.OrganizationSSO, error) {
+func (s *OrganizationSSOService) DisableDirectory(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.OrganizationSSO, error) {
 	s.DisableDirectoryFnInvoked = true
 	return s.DisableDirectoryFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) ListDomains(ctx context.Context, req *ps.ListOrganizationSSODomainsRequest) ([]*ps.OrganizationDomain, error) {
+func (s *OrganizationSSOService) ListDomains(ctx context.Context, req *ps.OrganizationSSORequest) ([]*ps.OrganizationDomain, error) {
 	s.ListDomainsFnInvoked = true
 	return s.ListDomainsFn(ctx, req)
 }
 
-func (s *OrganizationSSOService) VerifyDomain(ctx context.Context, req *ps.VerifyOrganizationSSODomainRequest) (*ps.SSOPortal, error) {
+func (s *OrganizationSSOService) VerifyDomain(ctx context.Context, req *ps.OrganizationSSORequest) (*ps.SSOPortal, error) {
 	s.VerifyDomainFnInvoked = true
 	return s.VerifyDomainFn(ctx, req)
 }

--- a/internal/planetscale/client.go
+++ b/internal/planetscale/client.go
@@ -68,6 +68,7 @@ type Client struct {
 	Metrics               MetricsService
 	MoveTables            MoveTablesService
 	Organizations         OrganizationsService
+	OrganizationSSO       OrganizationSSOService
 	Passwords             PasswordsService
 	PaymentMethods        BillingPaymentMethodsService
 	PaymentMethodSetups   BillingPaymentMethodSetupsService
@@ -348,6 +349,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	c.Metrics = &metricsService{client: c}
 	c.MoveTables = &moveTablesService{client: c}
 	c.Organizations = &organizationsService{client: c}
+	c.OrganizationSSO = &organizationSSOService{client: c}
 	c.Passwords = &passwordsService{client: c}
 	c.PaymentMethods = &billingPaymentMethodsService{client: c}
 	c.PaymentMethodSetups = &billingPaymentMethodSetupsService{client: c}

--- a/internal/planetscale/organization_sso.go
+++ b/internal/planetscale/organization_sso.go
@@ -1,0 +1,213 @@
+package planetscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"time"
+)
+
+// OrganizationSSOService is an interface for communicating with the PlanetScale
+// organization SSO API endpoints.
+type OrganizationSSOService interface {
+	Get(context.Context, *GetOrganizationSSORequest) (*OrganizationSSO, error)
+	Enable(context.Context, *EnableOrganizationSSORequest) (*OrganizationSSO, error)
+	Disable(context.Context, *DisableOrganizationSSORequest) (*OrganizationSSO, error)
+	Configure(context.Context, *ConfigureOrganizationSSORequest) (*SSOPortal, error)
+	EnableDirectory(context.Context, *EnableOrganizationSSODirectoryRequest) (*SSOPortal, error)
+	DisableDirectory(context.Context, *DisableOrganizationSSODirectoryRequest) (*OrganizationSSO, error)
+	ListDomains(context.Context, *ListOrganizationSSODomainsRequest) ([]*OrganizationDomain, error)
+	VerifyDomain(context.Context, *VerifyOrganizationSSODomainRequest) (*SSOPortal, error)
+	DeleteDomain(context.Context, *DeleteOrganizationSSODomainRequest) error
+}
+
+// OrganizationSSO is the SSO status for an organization.
+type OrganizationSSO struct {
+	ID                    string                `json:"id"`
+	Type                  string                `json:"type"`
+	Enabled               bool                  `json:"enabled"`
+	Configured            bool                  `json:"configured"`
+	Directory             bool                  `json:"directory"`
+	HasVerifiedDomain     bool                  `json:"has_verified_domain"`
+	Domains               []*OrganizationDomain `json:"domains"`
+	DomainVerificationURL *string               `json:"domain_verification_url"`
+}
+
+// OrganizationDomain is an email domain registered for organization SSO.
+type OrganizationDomain struct {
+	ID            string     `json:"id"`
+	Type          string     `json:"type"`
+	Domain        string     `json:"domain"`
+	State         string     `json:"state"`
+	VerifiedAt    *time.Time `json:"verified_at"`
+	FailureReason *string    `json:"failure_reason"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+// SSOPortal is a one-time URL for verifying a domain or configuring SSO.
+type SSOPortal struct {
+	PortalURL string `json:"portal_url"`
+}
+
+type GetOrganizationSSORequest struct {
+	Organization string
+}
+
+type EnableOrganizationSSORequest struct {
+	Organization string
+}
+
+type DisableOrganizationSSORequest struct {
+	Organization string
+}
+
+type ConfigureOrganizationSSORequest struct {
+	Organization string
+}
+
+type EnableOrganizationSSODirectoryRequest struct {
+	Organization string
+}
+
+type DisableOrganizationSSODirectoryRequest struct {
+	Organization string
+}
+
+type ListOrganizationSSODomainsRequest struct {
+	Organization string
+}
+
+type VerifyOrganizationSSODomainRequest struct {
+	Organization string
+}
+
+type DeleteOrganizationSSODomainRequest struct {
+	Organization string
+	DomainID     string
+}
+
+type organizationSSOService struct {
+	client *Client
+}
+
+var _ OrganizationSSOService = &organizationSSOService{}
+
+func organizationSSOAPIPath(org string) string {
+	return path.Join(organizationsAPIPath, org, "sso")
+}
+
+func organizationSSOConfigureAPIPath(org string) string {
+	return path.Join(organizationSSOAPIPath(org), "configure")
+}
+
+func organizationSSODirectoryAPIPath(org string) string {
+	return path.Join(organizationSSOAPIPath(org), "directory")
+}
+
+func organizationSSODomainsAPIPath(org string) string {
+	return path.Join(organizationSSOAPIPath(org), "domains")
+}
+
+func organizationSSODomainAPIPath(org, domainID string) string {
+	return path.Join(organizationSSODomainsAPIPath(org), domainID)
+}
+
+func (s *organizationSSOService) Get(ctx context.Context, getReq *GetOrganizationSSORequest) (*OrganizationSSO, error) {
+	req, err := s.client.newRequest(http.MethodGet, organizationSSOAPIPath(getReq.Organization), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get organization sso: %w", err)
+	}
+
+	sso := &OrganizationSSO{}
+	if err := s.client.do(ctx, req, sso); err != nil {
+		return nil, err
+	}
+	return sso, nil
+}
+
+func (s *organizationSSOService) Enable(ctx context.Context, enableReq *EnableOrganizationSSORequest) (*OrganizationSSO, error) {
+	req, err := s.client.newRequest(http.MethodPost, organizationSSOAPIPath(enableReq.Organization), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for enable organization sso: %w", err)
+	}
+
+	sso := &OrganizationSSO{}
+	if err := s.client.do(ctx, req, sso); err != nil {
+		return nil, err
+	}
+	return sso, nil
+}
+
+func (s *organizationSSOService) Disable(ctx context.Context, disableReq *DisableOrganizationSSORequest) (*OrganizationSSO, error) {
+	req, err := s.client.newRequest(http.MethodDelete, organizationSSOAPIPath(disableReq.Organization), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for disable organization sso: %w", err)
+	}
+
+	sso := &OrganizationSSO{}
+	if err := s.client.do(ctx, req, sso); err != nil {
+		return nil, err
+	}
+	return sso, nil
+}
+
+func (s *organizationSSOService) Configure(ctx context.Context, configureReq *ConfigureOrganizationSSORequest) (*SSOPortal, error) {
+	return s.postPortal(ctx, organizationSSOConfigureAPIPath(configureReq.Organization), "configure organization sso")
+}
+
+func (s *organizationSSOService) EnableDirectory(ctx context.Context, enableReq *EnableOrganizationSSODirectoryRequest) (*SSOPortal, error) {
+	return s.postPortal(ctx, organizationSSODirectoryAPIPath(enableReq.Organization), "enable organization sso directory")
+}
+
+func (s *organizationSSOService) DisableDirectory(ctx context.Context, disableReq *DisableOrganizationSSODirectoryRequest) (*OrganizationSSO, error) {
+	req, err := s.client.newRequest(http.MethodDelete, organizationSSODirectoryAPIPath(disableReq.Organization), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for disable organization sso directory: %w", err)
+	}
+
+	sso := &OrganizationSSO{}
+	if err := s.client.do(ctx, req, sso); err != nil {
+		return nil, err
+	}
+	return sso, nil
+}
+
+func (s *organizationSSOService) ListDomains(ctx context.Context, listReq *ListOrganizationSSODomainsRequest) ([]*OrganizationDomain, error) {
+	req, err := s.client.newRequest(http.MethodGet, organizationSSODomainsAPIPath(listReq.Organization), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for list organization sso domains: %w", err)
+	}
+
+	var domains []*OrganizationDomain
+	if err := s.client.do(ctx, req, &domains); err != nil {
+		return nil, err
+	}
+	return domains, nil
+}
+
+func (s *organizationSSOService) VerifyDomain(ctx context.Context, verifyReq *VerifyOrganizationSSODomainRequest) (*SSOPortal, error) {
+	return s.postPortal(ctx, organizationSSODomainsAPIPath(verifyReq.Organization), "verify organization sso domain")
+}
+
+func (s *organizationSSOService) DeleteDomain(ctx context.Context, deleteReq *DeleteOrganizationSSODomainRequest) error {
+	req, err := s.client.newRequest(http.MethodDelete, organizationSSODomainAPIPath(deleteReq.Organization, deleteReq.DomainID), nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for delete organization sso domain: %w", err)
+	}
+	return s.client.do(ctx, req, nil)
+}
+
+func (s *organizationSSOService) postPortal(ctx context.Context, apiPath, action string) (*SSOPortal, error) {
+	req, err := s.client.newRequest(http.MethodPost, apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for %s: %w", action, err)
+	}
+
+	portal := &SSOPortal{}
+	if err := s.client.do(ctx, req, portal); err != nil {
+		return nil, err
+	}
+	return portal, nil
+}

--- a/internal/planetscale/organization_sso.go
+++ b/internal/planetscale/organization_sso.go
@@ -18,8 +18,9 @@ type OrganizationSSOService interface {
 	EnableDirectory(context.Context, *OrganizationSSORequest) (*SSOPortal, error)
 	DisableDirectory(context.Context, *OrganizationSSORequest) (*OrganizationSSO, error)
 	ListDomains(context.Context, *OrganizationSSORequest) ([]*OrganizationDomain, error)
+	GetDomain(context.Context, *OrganizationSSODomainRequest) (*OrganizationDomain, error)
 	VerifyDomain(context.Context, *OrganizationSSORequest) (*SSOPortal, error)
-	DeleteDomain(context.Context, *DeleteOrganizationSSODomainRequest) error
+	DeleteDomain(context.Context, *OrganizationSSODomainRequest) error
 }
 
 // OrganizationSSO is the SSO status for an organization.
@@ -55,7 +56,7 @@ type OrganizationSSORequest struct {
 	Organization string
 }
 
-type DeleteOrganizationSSODomainRequest struct {
+type OrganizationSSODomainRequest struct {
 	Organization string
 	DomainID     string
 }
@@ -107,11 +108,24 @@ func (s *organizationSSOService) ListDomains(ctx context.Context, listReq *Organ
 	return domains, nil
 }
 
+func (s *organizationSSOService) GetDomain(ctx context.Context, getReq *OrganizationSSODomainRequest) (*OrganizationDomain, error) {
+	req, err := s.client.newRequest(http.MethodGet, path.Join(organizationSSOAPIPath(getReq.Organization), "domains", getReq.DomainID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for get organization sso domain: %w", err)
+	}
+
+	domain := &OrganizationDomain{}
+	if err := s.client.do(ctx, req, domain); err != nil {
+		return nil, err
+	}
+	return domain, nil
+}
+
 func (s *organizationSSOService) VerifyDomain(ctx context.Context, verifyReq *OrganizationSSORequest) (*SSOPortal, error) {
 	return s.postPortal(ctx, path.Join(organizationSSOAPIPath(verifyReq.Organization), "domains"), "verify organization sso domain")
 }
 
-func (s *organizationSSOService) DeleteDomain(ctx context.Context, deleteReq *DeleteOrganizationSSODomainRequest) error {
+func (s *organizationSSOService) DeleteDomain(ctx context.Context, deleteReq *OrganizationSSODomainRequest) error {
 	req, err := s.client.newRequest(http.MethodDelete, path.Join(organizationSSOAPIPath(deleteReq.Organization), "domains", deleteReq.DomainID), nil)
 	if err != nil {
 		return fmt.Errorf("error creating request for delete organization sso domain: %w", err)

--- a/internal/planetscale/organization_sso.go
+++ b/internal/planetscale/organization_sso.go
@@ -11,14 +11,14 @@ import (
 // OrganizationSSOService is an interface for communicating with the PlanetScale
 // organization SSO API endpoints.
 type OrganizationSSOService interface {
-	Get(context.Context, *GetOrganizationSSORequest) (*OrganizationSSO, error)
-	Enable(context.Context, *EnableOrganizationSSORequest) (*OrganizationSSO, error)
-	Disable(context.Context, *DisableOrganizationSSORequest) (*OrganizationSSO, error)
-	Configure(context.Context, *ConfigureOrganizationSSORequest) (*SSOPortal, error)
-	EnableDirectory(context.Context, *EnableOrganizationSSODirectoryRequest) (*SSOPortal, error)
-	DisableDirectory(context.Context, *DisableOrganizationSSODirectoryRequest) (*OrganizationSSO, error)
-	ListDomains(context.Context, *ListOrganizationSSODomainsRequest) ([]*OrganizationDomain, error)
-	VerifyDomain(context.Context, *VerifyOrganizationSSODomainRequest) (*SSOPortal, error)
+	Get(context.Context, *OrganizationSSORequest) (*OrganizationSSO, error)
+	Enable(context.Context, *OrganizationSSORequest) (*OrganizationSSO, error)
+	Disable(context.Context, *OrganizationSSORequest) (*OrganizationSSO, error)
+	Configure(context.Context, *OrganizationSSORequest) (*SSOPortal, error)
+	EnableDirectory(context.Context, *OrganizationSSORequest) (*SSOPortal, error)
+	DisableDirectory(context.Context, *OrganizationSSORequest) (*OrganizationSSO, error)
+	ListDomains(context.Context, *OrganizationSSORequest) ([]*OrganizationDomain, error)
+	VerifyDomain(context.Context, *OrganizationSSORequest) (*SSOPortal, error)
 	DeleteDomain(context.Context, *DeleteOrganizationSSODomainRequest) error
 }
 
@@ -46,40 +46,12 @@ type OrganizationDomain struct {
 	UpdatedAt     time.Time  `json:"updated_at"`
 }
 
-// SSOPortal is a one-time URL for verifying a domain or configuring SSO.
+// SSOPortal is a URL for verifying a domain or configuring SSO.
 type SSOPortal struct {
 	PortalURL string `json:"portal_url"`
 }
 
-type GetOrganizationSSORequest struct {
-	Organization string
-}
-
-type EnableOrganizationSSORequest struct {
-	Organization string
-}
-
-type DisableOrganizationSSORequest struct {
-	Organization string
-}
-
-type ConfigureOrganizationSSORequest struct {
-	Organization string
-}
-
-type EnableOrganizationSSODirectoryRequest struct {
-	Organization string
-}
-
-type DisableOrganizationSSODirectoryRequest struct {
-	Organization string
-}
-
-type ListOrganizationSSODomainsRequest struct {
-	Organization string
-}
-
-type VerifyOrganizationSSODomainRequest struct {
+type OrganizationSSORequest struct {
 	Organization string
 }
 
@@ -98,84 +70,32 @@ func organizationSSOAPIPath(org string) string {
 	return path.Join(organizationsAPIPath, org, "sso")
 }
 
-func organizationSSOConfigureAPIPath(org string) string {
-	return path.Join(organizationSSOAPIPath(org), "configure")
+func (s *organizationSSOService) Get(ctx context.Context, getReq *OrganizationSSORequest) (*OrganizationSSO, error) {
+	return s.doSSO(ctx, http.MethodGet, organizationSSOAPIPath(getReq.Organization), "get organization sso")
 }
 
-func organizationSSODirectoryAPIPath(org string) string {
-	return path.Join(organizationSSOAPIPath(org), "directory")
+func (s *organizationSSOService) Enable(ctx context.Context, enableReq *OrganizationSSORequest) (*OrganizationSSO, error) {
+	return s.doSSO(ctx, http.MethodPost, organizationSSOAPIPath(enableReq.Organization), "enable organization sso")
 }
 
-func organizationSSODomainsAPIPath(org string) string {
-	return path.Join(organizationSSOAPIPath(org), "domains")
+func (s *organizationSSOService) Disable(ctx context.Context, disableReq *OrganizationSSORequest) (*OrganizationSSO, error) {
+	return s.doSSO(ctx, http.MethodDelete, organizationSSOAPIPath(disableReq.Organization), "disable organization sso")
 }
 
-func organizationSSODomainAPIPath(org, domainID string) string {
-	return path.Join(organizationSSODomainsAPIPath(org), domainID)
+func (s *organizationSSOService) Configure(ctx context.Context, configureReq *OrganizationSSORequest) (*SSOPortal, error) {
+	return s.postPortal(ctx, path.Join(organizationSSOAPIPath(configureReq.Organization), "configure"), "configure organization sso")
 }
 
-func (s *organizationSSOService) Get(ctx context.Context, getReq *GetOrganizationSSORequest) (*OrganizationSSO, error) {
-	req, err := s.client.newRequest(http.MethodGet, organizationSSOAPIPath(getReq.Organization), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request for get organization sso: %w", err)
-	}
-
-	sso := &OrganizationSSO{}
-	if err := s.client.do(ctx, req, sso); err != nil {
-		return nil, err
-	}
-	return sso, nil
+func (s *organizationSSOService) EnableDirectory(ctx context.Context, enableReq *OrganizationSSORequest) (*SSOPortal, error) {
+	return s.postPortal(ctx, path.Join(organizationSSOAPIPath(enableReq.Organization), "directory"), "enable organization sso directory")
 }
 
-func (s *organizationSSOService) Enable(ctx context.Context, enableReq *EnableOrganizationSSORequest) (*OrganizationSSO, error) {
-	req, err := s.client.newRequest(http.MethodPost, organizationSSOAPIPath(enableReq.Organization), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request for enable organization sso: %w", err)
-	}
-
-	sso := &OrganizationSSO{}
-	if err := s.client.do(ctx, req, sso); err != nil {
-		return nil, err
-	}
-	return sso, nil
+func (s *organizationSSOService) DisableDirectory(ctx context.Context, disableReq *OrganizationSSORequest) (*OrganizationSSO, error) {
+	return s.doSSO(ctx, http.MethodDelete, path.Join(organizationSSOAPIPath(disableReq.Organization), "directory"), "disable organization sso directory")
 }
 
-func (s *organizationSSOService) Disable(ctx context.Context, disableReq *DisableOrganizationSSORequest) (*OrganizationSSO, error) {
-	req, err := s.client.newRequest(http.MethodDelete, organizationSSOAPIPath(disableReq.Organization), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request for disable organization sso: %w", err)
-	}
-
-	sso := &OrganizationSSO{}
-	if err := s.client.do(ctx, req, sso); err != nil {
-		return nil, err
-	}
-	return sso, nil
-}
-
-func (s *organizationSSOService) Configure(ctx context.Context, configureReq *ConfigureOrganizationSSORequest) (*SSOPortal, error) {
-	return s.postPortal(ctx, organizationSSOConfigureAPIPath(configureReq.Organization), "configure organization sso")
-}
-
-func (s *organizationSSOService) EnableDirectory(ctx context.Context, enableReq *EnableOrganizationSSODirectoryRequest) (*SSOPortal, error) {
-	return s.postPortal(ctx, organizationSSODirectoryAPIPath(enableReq.Organization), "enable organization sso directory")
-}
-
-func (s *organizationSSOService) DisableDirectory(ctx context.Context, disableReq *DisableOrganizationSSODirectoryRequest) (*OrganizationSSO, error) {
-	req, err := s.client.newRequest(http.MethodDelete, organizationSSODirectoryAPIPath(disableReq.Organization), nil)
-	if err != nil {
-		return nil, fmt.Errorf("error creating request for disable organization sso directory: %w", err)
-	}
-
-	sso := &OrganizationSSO{}
-	if err := s.client.do(ctx, req, sso); err != nil {
-		return nil, err
-	}
-	return sso, nil
-}
-
-func (s *organizationSSOService) ListDomains(ctx context.Context, listReq *ListOrganizationSSODomainsRequest) ([]*OrganizationDomain, error) {
-	req, err := s.client.newRequest(http.MethodGet, organizationSSODomainsAPIPath(listReq.Organization), nil)
+func (s *organizationSSOService) ListDomains(ctx context.Context, listReq *OrganizationSSORequest) ([]*OrganizationDomain, error) {
+	req, err := s.client.newRequest(http.MethodGet, path.Join(organizationSSOAPIPath(listReq.Organization), "domains"), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request for list organization sso domains: %w", err)
 	}
@@ -187,16 +107,29 @@ func (s *organizationSSOService) ListDomains(ctx context.Context, listReq *ListO
 	return domains, nil
 }
 
-func (s *organizationSSOService) VerifyDomain(ctx context.Context, verifyReq *VerifyOrganizationSSODomainRequest) (*SSOPortal, error) {
-	return s.postPortal(ctx, organizationSSODomainsAPIPath(verifyReq.Organization), "verify organization sso domain")
+func (s *organizationSSOService) VerifyDomain(ctx context.Context, verifyReq *OrganizationSSORequest) (*SSOPortal, error) {
+	return s.postPortal(ctx, path.Join(organizationSSOAPIPath(verifyReq.Organization), "domains"), "verify organization sso domain")
 }
 
 func (s *organizationSSOService) DeleteDomain(ctx context.Context, deleteReq *DeleteOrganizationSSODomainRequest) error {
-	req, err := s.client.newRequest(http.MethodDelete, organizationSSODomainAPIPath(deleteReq.Organization, deleteReq.DomainID), nil)
+	req, err := s.client.newRequest(http.MethodDelete, path.Join(organizationSSOAPIPath(deleteReq.Organization), "domains", deleteReq.DomainID), nil)
 	if err != nil {
 		return fmt.Errorf("error creating request for delete organization sso domain: %w", err)
 	}
 	return s.client.do(ctx, req, nil)
+}
+
+func (s *organizationSSOService) doSSO(ctx context.Context, method, apiPath, action string) (*OrganizationSSO, error) {
+	req, err := s.client.newRequest(method, apiPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request for %s: %w", action, err)
+	}
+
+	sso := &OrganizationSSO{}
+	if err := s.client.do(ctx, req, sso); err != nil {
+		return nil, err
+	}
+	return sso, nil
 }
 
 func (s *organizationSSOService) postPortal(ctx context.Context, apiPath, action string) (*SSOPortal, error) {

--- a/internal/planetscale/organization_sso_test.go
+++ b/internal/planetscale/organization_sso_test.go
@@ -42,7 +42,7 @@ func TestOrganizationSSO_Get(t *testing.T) {
 	client, err := NewClient(WithBaseURL(ts.URL))
 	c.Assert(err, qt.IsNil)
 
-	sso, err := client.OrganizationSSO.Get(context.Background(), &GetOrganizationSSORequest{Organization: "my-org"})
+	sso, err := client.OrganizationSSO.Get(context.Background(), &OrganizationSSORequest{Organization: "my-org"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(sso.Enabled, qt.IsTrue)
 	c.Assert(sso.Configured, qt.IsFalse)
@@ -77,7 +77,7 @@ func TestOrganizationSSO_Enable(t *testing.T) {
 	client, err := NewClient(WithBaseURL(ts.URL))
 	c.Assert(err, qt.IsNil)
 
-	sso, err := client.OrganizationSSO.Enable(context.Background(), &EnableOrganizationSSORequest{Organization: "my-org"})
+	sso, err := client.OrganizationSSO.Enable(context.Background(), &OrganizationSSORequest{Organization: "my-org"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(sso.Enabled, qt.IsTrue)
 	c.Assert(sso.DomainVerificationURL, qt.Not(qt.IsNil))
@@ -98,7 +98,7 @@ func TestOrganizationSSO_Configure(t *testing.T) {
 	client, err := NewClient(WithBaseURL(ts.URL))
 	c.Assert(err, qt.IsNil)
 
-	portal, err := client.OrganizationSSO.Configure(context.Background(), &ConfigureOrganizationSSORequest{Organization: "my-org"})
+	portal, err := client.OrganizationSSO.Configure(context.Background(), &OrganizationSSORequest{Organization: "my-org"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(portal.PortalURL, qt.Equals, "https://portal.example/sso")
 }
@@ -126,11 +126,49 @@ func TestOrganizationSSO_ListDomains(t *testing.T) {
 	client, err := NewClient(WithBaseURL(ts.URL))
 	c.Assert(err, qt.IsNil)
 
-	domains, err := client.OrganizationSSO.ListDomains(context.Background(), &ListOrganizationSSODomainsRequest{Organization: "my-org"})
+	domains, err := client.OrganizationSSO.ListDomains(context.Background(), &OrganizationSSORequest{Organization: "my-org"})
 	c.Assert(err, qt.IsNil)
 	c.Assert(domains, qt.HasLen, 1)
 	c.Assert(domains[0].ID, qt.Equals, "dom_1")
 	c.Assert(domains[0].State, qt.Equals, "pending")
+}
+
+func TestOrganizationSSO_Disable(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"id":"org_1","type":"OrganizationSSO","enabled":false,"configured":false,"directory":false,"has_verified_domain":false,"domains":[],"domain_verification_url":null}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	sso, err := client.OrganizationSSO.Disable(context.Background(), &OrganizationSSORequest{Organization: "my-org"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(sso.Enabled, qt.IsFalse)
+}
+
+func TestOrganizationSSO_EnableDirectory(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso/directory")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"portal_url":"https://portal.example/dsync"}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	portal, err := client.OrganizationSSO.EnableDirectory(context.Background(), &OrganizationSSORequest{Organization: "my-org"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(portal.PortalURL, qt.Equals, "https://portal.example/dsync")
 }
 
 func TestOrganizationSSO_DeleteDomain(t *testing.T) {

--- a/internal/planetscale/organization_sso_test.go
+++ b/internal/planetscale/organization_sso_test.go
@@ -1,0 +1,153 @@
+package planetscale
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestOrganizationSSO_Get(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{
+			"id": "org_1",
+			"type": "OrganizationSSO",
+			"enabled": true,
+			"configured": false,
+			"directory": false,
+			"has_verified_domain": true,
+			"domain_verification_url": null,
+			"domains": [{
+				"id": "dom_1",
+				"type": "OrganizationDomain",
+				"domain": "example.com",
+				"state": "verified",
+				"verified_at": "2021-01-14T10:19:23.000Z",
+				"failure_reason": null,
+				"created_at": "2021-01-14T10:19:23.000Z",
+				"updated_at": "2021-01-14T10:19:23.000Z"
+			}]
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	sso, err := client.OrganizationSSO.Get(context.Background(), &GetOrganizationSSORequest{Organization: "my-org"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(sso.Enabled, qt.IsTrue)
+	c.Assert(sso.Configured, qt.IsFalse)
+	c.Assert(sso.HasVerifiedDomain, qt.IsTrue)
+	c.Assert(sso.DomainVerificationURL, qt.IsNil)
+	c.Assert(sso.Domains, qt.HasLen, 1)
+	c.Assert(sso.Domains[0].Domain, qt.Equals, "example.com")
+	c.Assert(sso.Domains[0].VerifiedAt, qt.Not(qt.IsNil))
+	c.Assert(*sso.Domains[0].VerifiedAt, qt.Equals, time.Date(2021, time.January, 14, 10, 19, 23, 0, time.UTC))
+}
+
+func TestOrganizationSSO_Enable(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{
+			"id": "org_1",
+			"type": "OrganizationSSO",
+			"enabled": true,
+			"configured": false,
+			"directory": false,
+			"has_verified_domain": false,
+			"domain_verification_url": "https://portal.example/verify",
+			"domains": []
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	sso, err := client.OrganizationSSO.Enable(context.Background(), &EnableOrganizationSSORequest{Organization: "my-org"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(sso.Enabled, qt.IsTrue)
+	c.Assert(sso.DomainVerificationURL, qt.Not(qt.IsNil))
+	c.Assert(*sso.DomainVerificationURL, qt.Equals, "https://portal.example/verify")
+}
+
+func TestOrganizationSSO_Configure(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodPost)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso/configure")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{"portal_url":"https://portal.example/sso"}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	portal, err := client.OrganizationSSO.Configure(context.Background(), &ConfigureOrganizationSSORequest{Organization: "my-org"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(portal.PortalURL, qt.Equals, "https://portal.example/sso")
+}
+
+func TestOrganizationSSO_ListDomains(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso/domains")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`[{
+			"id": "dom_1",
+			"type": "OrganizationDomain",
+			"domain": "example.com",
+			"state": "pending",
+			"verified_at": null,
+			"failure_reason": null,
+			"created_at": "2021-01-14T10:19:23.000Z",
+			"updated_at": "2021-01-14T10:19:23.000Z"
+		}]`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	domains, err := client.OrganizationSSO.ListDomains(context.Background(), &ListOrganizationSSODomainsRequest{Organization: "my-org"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(domains, qt.HasLen, 1)
+	c.Assert(domains[0].ID, qt.Equals, "dom_1")
+	c.Assert(domains[0].State, qt.Equals, "pending")
+}
+
+func TestOrganizationSSO_DeleteDomain(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodDelete)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso/domains/dom_1")
+		w.WriteHeader(204)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	err = client.OrganizationSSO.DeleteDomain(context.Background(), &DeleteOrganizationSSODomainRequest{
+		Organization: "my-org",
+		DomainID:     "dom_1",
+	})
+	c.Assert(err, qt.IsNil)
+}

--- a/internal/planetscale/organization_sso_test.go
+++ b/internal/planetscale/organization_sso_test.go
@@ -183,9 +183,42 @@ func TestOrganizationSSO_DeleteDomain(t *testing.T) {
 	client, err := NewClient(WithBaseURL(ts.URL))
 	c.Assert(err, qt.IsNil)
 
-	err = client.OrganizationSSO.DeleteDomain(context.Background(), &DeleteOrganizationSSODomainRequest{
+	err = client.OrganizationSSO.DeleteDomain(context.Background(), &OrganizationSSODomainRequest{
 		Organization: "my-org",
 		DomainID:     "dom_1",
 	})
 	c.Assert(err, qt.IsNil)
+}
+
+func TestOrganizationSSO_GetDomain(t *testing.T) {
+	c := qt.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Assert(r.Method, qt.Equals, http.MethodGet)
+		c.Assert(r.URL.Path, qt.Equals, "/v1/organizations/my-org/sso/domains/dom_1")
+		w.WriteHeader(200)
+		_, err := w.Write([]byte(`{
+			"id": "dom_1",
+			"type": "OrganizationDomain",
+			"domain": "example.com",
+			"state": "pending",
+			"verified_at": null,
+			"failure_reason": null,
+			"created_at": "2021-01-14T10:19:23.000Z",
+			"updated_at": "2021-01-14T10:19:23.000Z"
+		}`))
+		c.Assert(err, qt.IsNil)
+	}))
+
+	client, err := NewClient(WithBaseURL(ts.URL))
+	c.Assert(err, qt.IsNil)
+
+	domain, err := client.OrganizationSSO.GetDomain(context.Background(), &OrganizationSSODomainRequest{
+		Organization: "my-org",
+		DomainID:     "dom_1",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(domain.ID, qt.Equals, "dom_1")
+	c.Assert(domain.Domain, qt.Equals, "example.com")
+	c.Assert(domain.State, qt.Equals, "pending")
 }

--- a/internal/planetscale/organizations.go
+++ b/internal/planetscale/organizations.go
@@ -21,6 +21,7 @@ type UpdateOrganizationRequest struct {
 	Organization        string  `json:"-"`
 	BillingEmail        *string `json:"billing_email,omitempty"`
 	IDPManagedRoles     *bool   `json:"idp_managed_roles,omitempty"`
+	IDPSSOManagedRoles  *bool   `json:"idp_sso_managed_roles,omitempty"`
 	InvoiceBudgetAlerts *bool   `json:"invoice_budget_alerts,omitempty"`
 	InvoiceBudgetAmount *int64  `json:"invoice_budget_amount,omitempty"`
 }
@@ -32,6 +33,9 @@ func (r *UpdateOrganizationRequest) MarshalJSON() ([]byte, error) {
 	}
 	if r.IDPManagedRoles != nil {
 		body["idp_managed_roles"] = *r.IDPManagedRoles
+	}
+	if r.IDPSSOManagedRoles != nil {
+		body["idp_sso_managed_roles"] = *r.IDPSSOManagedRoles
 	}
 	if r.InvoiceBudgetAlerts != nil {
 		body["invoice_budget_alerts"] = *r.InvoiceBudgetAlerts
@@ -126,6 +130,7 @@ type Organization struct {
 	Name                         string              `json:"name"`
 	BillingEmail                 string              `json:"billing_email"`
 	IDPManagedRoles              bool                `json:"idp_managed_roles"`
+	IDPSSOManagedRoles           bool                `json:"idp_sso_managed_roles"`
 	InvoiceBudgetAlerts          bool                `json:"invoice_budget_alerts"`
 	InvoiceBudgetAmount          InvoiceBudgetAmount `json:"invoice_budget_amount"`
 	SuggestedInvoiceBudgetAmount InvoiceBudgetAmount `json:"suggested_invoice_budget_amount"`


### PR DESCRIPTION
## Summary
- Add `pscale org sso` to show, enable, configure, and disable organization SSO, including directory sync and email domain verification

## Test plan
- [x] `pscale org sso show --org <org> --format json`
- [x] enable, configure, directory enable, and domain verify return a setup URL
- [x] disable, directory disable, and domain delete require `--force` in JSON