### PR TITLE
Increase live connections request timeout

### DIFF
--- a/internal/connections/client.go
+++ b/internal/connections/client.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	clientUserAgent = "pscale-cli"
-	defaultTimeout  = 5 * time.Second
+	defaultTimeout  = 10 * time.Second
 
 	// Retry defaults for list-only 503s returned while the server's
 	// connection snapshot cache is being populated. The floor is 50ms


### PR DESCRIPTION
## What changed

Increase the live-connections HTTP request timeout from 5 seconds to 10 seconds.

## Why

Connection listings can take longer than 5 seconds when network setup is slow. The longer timeout lets the server return a result or its own error instead of the CLI canceling first.

## Testing

- go test ./internal/connections ./internal/cmd/branch/connections
- Built the CLI and called the local live-connections endpoint