### PR TITLE
feat: add --db-name for Postgres in `pscale shell`

### DIFF
--- a/internal/cmd/shell/shell.go
+++ b/internal/cmd/shell/shell.go
@@ -27,6 +27,7 @@ import (
 type shellFlags struct {
 	localAddr  string
 	remoteAddr string
+	dbName     string
 	role       string
 	replica    bool
 }
@@ -35,9 +36,17 @@ func ShellCmd(ch *cmdutil.Helper, sigc chan os.Signal, signals ...os.Signal) *co
 	var flags shellFlags
 
 	cmd := &cobra.Command{
-		Use: "shell [database] [branch]",
+		Use: "shell [database] [branch] [db-name]",
 		// we only require database, because we deduct branch automatically
-		Args:  cmdutil.RequiredArgs("database"),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cmdutil.RequiredArgs("database")(cmd, args); err != nil {
+				return err
+			}
+			if len(args) > 3 {
+				return fmt.Errorf("too many arguments\n\n%s", cmd.UsageString())
+			}
+			return nil
+		},
 		Short: "Open a shell instance to a database and branch",
 		Example: `The shell subcommand opens a secure shell instance to your database.
 
@@ -53,7 +62,13 @@ If there are multiple branches for the given database, you'll be prompted to
 choose one. To open a shell instance to a specific branch, pass the branch as a
 second argument:
 
-  pscale shell mydatabase mybranch`,
+  pscale shell mydatabase mybranch
+
+For Postgres databases, you can optionally specify the logical database
+to connect to using --db-name (or as a third argument):
+
+  pscale shell production main --db-name my_db
+  pscale shell production main my_db`,
 		PersistentPreRunE: cmdutil.CheckAuthentication(ch.Config),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
@@ -111,8 +126,12 @@ second argument:
 			}
 
 			var branch string
-			if len(args) == 2 {
+			var dbNamePositional string
+			if len(args) >= 2 {
 				branch = args[1]
+			}
+			if len(args) == 3 {
+				dbNamePositional = args[2]
 			}
 
 			if branch == "" {
@@ -163,10 +182,23 @@ second argument:
 			}
 
 			if isPostgreSQL {
-				return startShellForPostgres(ctx, ch, client, database, branch, dbBranch, clientPath, role, flags, sigc, signals, runForeground)
-			} else {
-				return startShellForMySQL(ctx, ch, client, database, branch, dbBranch, clientPath, authMethod, role, flags, sigc, signals, runForeground)
+				if flags.dbName != "" && dbNamePositional != "" {
+					return errors.New("only one of --db-name or the positional db-name argument is supported")
+				}
+
+				dbName := flags.dbName
+				if dbName == "" {
+					dbName = dbNamePositional
+				}
+
+				return startShellForPostgres(ctx, ch, client, database, branch, dbBranch, clientPath, role, flags, dbName, sigc, signals, runForeground)
 			}
+
+			if flags.dbName != "" || dbNamePositional != "" {
+				return errors.New("--db-name / db-name positional argument is only supported for Postgres databases")
+			}
+
+			return startShellForMySQL(ctx, ch, client, database, branch, dbBranch, clientPath, authMethod, role, flags, sigc, signals, runForeground)
 		},
 	}
 
@@ -178,6 +210,8 @@ second argument:
 	cmd.PersistentFlags().StringVar(&flags.role, "role",
 		"", "Role defines the access level, allowed values are: reader, writer, readwriter, admin. Defaults to 'reader' for replica passwords, otherwise defaults to 'admin'.")
 	cmd.Flags().BoolVar(&flags.replica, "replica", false, "When enabled, the password will route all reads to the branch's primary replicas and all read-only regions.")
+	cmd.Flags().StringVar(&flags.dbName, "db-name", "",
+		"Postgres logical database name to connect to (default: postgres). Only supported for Postgres databases.")
 
 	cmd.MarkPersistentFlagRequired("org") // nolint:errcheck
 
@@ -304,7 +338,7 @@ func historyFilePath(org, db, branch string) string {
 	return historyFile
 }
 
-func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, role cmdutil.PasswordRole, flags shellFlags, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {
+func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, role cmdutil.PasswordRole, flags shellFlags, dbName string, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {
 	// Postgres connects directly, no local proxy needed
 	if flags.localAddr != "" {
 		return errors.New("--local-addr flag is not supported for Postgres databases")
@@ -358,13 +392,11 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 	historyFile := historyFilePath(ch.Config.Organization, database, branch)
 	styledBranch := formatBranch(database, dbBranch)
 
-	psqlArgs := []string{
-		"-h", remoteHost,
-		"-p", remotePort,
-		"-U", username,
-		"-d", "postgres",
-		"-v", fmt.Sprintf("PROMPT1=%s", styledBranch),
+	if dbName == "" {
+		dbName = "postgres"
 	}
+
+	psqlArgs := postgresPsqlArgs(remoteHost, remotePort, username, dbName, styledBranch)
 
 	psql := &postgresql{
 		psqlPath:     clientPath,
@@ -380,6 +412,20 @@ func startShellForPostgres(ctx context.Context, ch *cmdutil.Helper, client *ps.C
 		return cmdutil.HandleError(err)
 	}
 	return nil
+}
+
+func postgresPsqlArgs(remoteHost, remotePort, username, dbName, styledBranch string) []string {
+	if dbName == "" {
+		dbName = "postgres"
+	}
+
+	return []string{
+		"-h", remoteHost,
+		"-p", remotePort,
+		"-U", username,
+		"-d", dbName,
+		"-v", fmt.Sprintf("PROMPT1=%s", styledBranch),
+	}
 }
 
 func startShellForMySQL(ctx context.Context, ch *cmdutil.Helper, client *ps.Client, database, branch string, dbBranch *ps.DatabaseBranch, clientPath string, authMethod mysql.AuthMethodDescription, role cmdutil.PasswordRole, flags shellFlags, sigc chan os.Signal, signals []os.Signal, runForeground bool) error {

--- a/internal/cmd/shell/shell_test.go
+++ b/internal/cmd/shell/shell_test.go
@@ -1,0 +1,36 @@
+package shell
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPostgresPsqlArgs_DefaultDBName(t *testing.T) {
+	c := qt.New(t)
+
+	args := postgresPsqlArgs("db.example.com", "5432", "test-user", "", "prod/my-branch> ")
+
+	c.Assert(args, qt.DeepEquals, []string{
+		"-h", "db.example.com",
+		"-p", "5432",
+		"-U", "test-user",
+		"-d", "postgres",
+		"-v", "PROMPT1=prod/my-branch> ",
+	})
+}
+
+func TestPostgresPsqlArgs_CustomDBName(t *testing.T) {
+	c := qt.New(t)
+
+	args := postgresPsqlArgs("db.example.com", "5432", "test-user", "my_db", "prod/my-branch> ")
+
+	c.Assert(args, qt.DeepEquals, []string{
+		"-h", "db.example.com",
+		"-p", "5432",
+		"-U", "test-user",
+		"-d", "my_db",
+		"-v", "PROMPT1=prod/my-branch> ",
+	})
+}
+

--- a/internal/cmd/shell/shell_test.go
+++ b/internal/cmd/shell/shell_test.go
@@ -33,4 +33,3 @@ func TestPostgresPsqlArgs_CustomDBName(t *testing.T) {
 		"-v", "PROMPT1=prod/my-branch> ",
 	})
 }
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1395.

This change adds Postgres-only support for specifying the logical Postgres database at shell startup:

- New flag: `--db-name <name>`
- Positional alternative (Postgres only): `pscale shell <database> <branch> <db-name>`

`pscale` now launches `psql` with `-d <db-name>` instead of always using the hard-coded `postgres`.

MySQL behavior is unchanged; using `--db-name` with MySQL returns an error.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://planetscale.slack.com/archives/C0BU4KLDL4D/p1788450944881169?thread_ts=1788450944.881169&cid=C0BU4KLDL4D)

<div><a href="https://cursor.com/agents/bc-f22d74cf-14e3-5ad7-8c92-08935e55e7de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f22d74cf-14e3-5ad7-8c92-08935e55e7de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

