### PR TITLE
Add ARM VTGate size mappings

### DIFF
--- a/internal/cmd/branch/vtgate.go
+++ b/internal/cmd/branch/vtgate.go
@@ -16,7 +16,7 @@ import (
 var knownVTGateSizes = []string{
 	"VTG_DEV", "VTG_5", "VTG_10", "VTG_20", "VTG_40",
 	"VTG_80", "VTG_320", "VTG_640", "VTG_1280", "VTG_2560",
-	"VTG_5_ARM", "VTG_10_ARM", "VTG_20_ARM", "VTG_40_ARM",
+	"VTG_DEV_ARM", "VTG_5_ARM", "VTG_10_ARM", "VTG_20_ARM", "VTG_40_ARM",
 	"VTG_80_ARM", "VTG_320_ARM", "VTG_640_ARM", "VTG_1280_ARM", "VTG_2560_ARM",
 }
 
@@ -32,6 +32,7 @@ var vtgateInternalToName = map[string]string{
 	"vg.c1.2xlarge":       "VTG_640",
 	"vg.c1.4xlarge":       "VTG_1280",
 	"vg.c1.8xlarge":       "VTG_2560",
+	"vg.g1.arm64.pico":    "VTG_DEV_ARM",
 	"vg.c1.arm64.nano":    "VTG_5_ARM",
 	"vg.c1.arm64.micro":   "VTG_10_ARM",
 	"vg.c1.arm64.small":   "VTG_20_ARM",

--- a/internal/cmd/branch/vtgate.go
+++ b/internal/cmd/branch/vtgate.go
@@ -16,20 +16,31 @@ import (
 var knownVTGateSizes = []string{
 	"VTG_DEV", "VTG_5", "VTG_10", "VTG_20", "VTG_40",
 	"VTG_80", "VTG_320", "VTG_640", "VTG_1280", "VTG_2560",
+	"VTG_5_ARM", "VTG_10_ARM", "VTG_20_ARM", "VTG_40_ARM",
+	"VTG_80_ARM", "VTG_320_ARM", "VTG_640_ARM", "VTG_1280_ARM", "VTG_2560_ARM",
 }
 
 // vtgateInternalToName maps API-internal VTGate sizes to public SKU names.
 var vtgateInternalToName = map[string]string{
-	"vg.g1.pico":    "VTG_DEV",
-	"vg.c1.nano":    "VTG_5",
-	"vg.c1.micro":   "VTG_10",
-	"vg.c1.small":   "VTG_20",
-	"vg.c1.medium":  "VTG_40",
-	"vg.c1.large":   "VTG_80",
-	"vg.c1.xlarge":  "VTG_320",
-	"vg.c1.2xlarge": "VTG_640",
-	"vg.c1.4xlarge": "VTG_1280",
-	"vg.c1.8xlarge": "VTG_2560",
+	"vg.g1.pico":          "VTG_DEV",
+	"vg.c1.nano":          "VTG_5",
+	"vg.c1.micro":         "VTG_10",
+	"vg.c1.small":         "VTG_20",
+	"vg.c1.medium":        "VTG_40",
+	"vg.c1.large":         "VTG_80",
+	"vg.c1.xlarge":        "VTG_320",
+	"vg.c1.2xlarge":       "VTG_640",
+	"vg.c1.4xlarge":       "VTG_1280",
+	"vg.c1.8xlarge":       "VTG_2560",
+	"vg.c1.arm64.nano":    "VTG_5_ARM",
+	"vg.c1.arm64.micro":   "VTG_10_ARM",
+	"vg.c1.arm64.small":   "VTG_20_ARM",
+	"vg.c1.arm64.medium":  "VTG_40_ARM",
+	"vg.c1.arm64.large":   "VTG_80_ARM",
+	"vg.c1.arm64.xlarge":  "VTG_320_ARM",
+	"vg.c1.arm64.2xlarge": "VTG_640_ARM",
+	"vg.c1.arm64.4xlarge": "VTG_1280_ARM",
+	"vg.c1.arm64.8xlarge": "VTG_2560_ARM",
 }
 
 type branchVTGateConfig struct {

--- a/internal/cmd/branch/vtgate_test.go
+++ b/internal/cmd/branch/vtgate_test.go
@@ -244,10 +244,12 @@ func TestBranch_VtgateShowCmd_PendingUsesPreviousAutoscaling(t *testing.T) {
 func TestPublicVTGateName(t *testing.T) {
 	c := qt.New(t)
 	c.Assert(publicVTGateName("vg.c1.micro"), qt.Equals, "VTG_10")
+	c.Assert(publicVTGateName("vg.g1.arm64.pico"), qt.Equals, "VTG_DEV_ARM")
 	c.Assert(publicVTGateName("vg.c1.arm64.micro"), qt.Equals, "VTG_10_ARM")
 	c.Assert(publicVTGateName("VTG_320"), qt.Equals, "VTG_320")
 	c.Assert(publicVTGateName("VTG-320"), qt.Equals, "VTG_320")
 	c.Assert(publicVTGateName(""), qt.Equals, "")
+	c.Assert(knownVTGateSizes, qt.Contains, "VTG_DEV_ARM")
 	c.Assert(knownVTGateSizes, qt.Contains, "VTG_10_ARM")
 }
 

--- a/internal/cmd/branch/vtgate_test.go
+++ b/internal/cmd/branch/vtgate_test.go
@@ -244,9 +244,11 @@ func TestBranch_VtgateShowCmd_PendingUsesPreviousAutoscaling(t *testing.T) {
 func TestPublicVTGateName(t *testing.T) {
 	c := qt.New(t)
 	c.Assert(publicVTGateName("vg.c1.micro"), qt.Equals, "VTG_10")
+	c.Assert(publicVTGateName("vg.c1.arm64.micro"), qt.Equals, "VTG_10_ARM")
 	c.Assert(publicVTGateName("VTG_320"), qt.Equals, "VTG_320")
 	c.Assert(publicVTGateName("VTG-320"), qt.Equals, "VTG_320")
 	c.Assert(publicVTGateName(""), qt.Equals, "")
+	c.Assert(knownVTGateSizes, qt.Contains, "VTG_10_ARM")
 }
 
 func TestBranch_VtgateResizeCmd_SizeOnly(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add ARM VTGate SKU names to branch VTGate resize completion and map ARM64 internal resource sizes back to their public SKU names in `pscale branch vtgate show`.

This includes `VTG_DEV_ARM` (`vg.g1.arm64.pico`) and preserves support for hyphenated input such as `VTG-320-ARM` through the existing normalization path.

## Testing

- [x] `go test ./internal/cmd/branch`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2f9af8b-2f54-4945-8790-6a2ccde70fd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2f9af8b-2f54-4945-8790-6a2ccde70fd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

